### PR TITLE
PR 1: Per-session conversation state (remove shared _conversation + lock)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from collections.abc import Callable
-from typing import Literal
+from typing import Any, Literal
 
 import click
 import httpx
@@ -97,7 +97,9 @@ def _wire_scheduler(executor: ToolExecutor, agent: Agent) -> None:
     if executor._scheduler is not None:
 
         async def on_schedule_fire(task_name: str, prompt: str) -> str:
-            return await agent.chat(f"[Scheduled task: {task_name}] {prompt}")
+            return await agent.chat(
+                f"[Scheduled task: {task_name}] {prompt}", conversation=[]
+            )
 
         executor._scheduler._on_fire = on_schedule_fire
 
@@ -278,6 +280,7 @@ def chat(
         logger.info("Services initialized. Starting interactive chat.")
         print("\nAgent ready. Type your message (Ctrl+C to exit).\n")
 
+        conversation: list[dict[str, Any]] = []
         while True:
             try:
                 user_input = input("You: ")
@@ -288,7 +291,7 @@ def chat(
                 continue
 
             logger.info("User: %s", user_input)
-            response = await agent.chat(user_input)
+            response = await agent.chat(user_input, conversation=conversation)
             print(f"\nAgent: {response}\n")
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,12 @@ dependencies = [
     "pydantic-settings>=2.12.0",
     "textual>=1.0.0",
 ]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.24.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -475,17 +475,11 @@ class Agent:
                 )
 
         self._tool_executor = tool_executor
-        self._conversation: list[dict[str, Any]] = []
         self._max_iterations = max_iterations
         self._system_prompt = system_prompt
         self._system_prompt_provider = system_prompt_provider
         self._sub_llm_client = sub_llm_client
         self._compact_threshold_chars = compact_threshold_chars
-        # Serializes all chat() calls across surfaces (TUI, Discord, scheduler
-        # fires). `_conversation` is shared mutable state; without this lock,
-        # a Discord message arriving during a TUI chat's LLM await could
-        # swap it out mid-call.
-        self._chat_lock = asyncio.Lock()
 
     # number of messages from the end to preserve full tool results
     TOOL_RESULT_PRESERVE_COUNT = 4
@@ -507,7 +501,7 @@ class Agent:
         else:
             return {"error": f"Unknown tool: {tool_use.name}"}
 
-    def _repair_conversation(self) -> None:
+    def _repair_conversation(self, conversation: list[dict[str, Any]]) -> None:
         """Fix broken tool_use/tool_result pairs in conversation history.
 
         If a previous chat() call crashed mid-tool-execution, or concurrent
@@ -516,8 +510,8 @@ class Agent:
         The Anthropic API rejects these. This method patches them up.
         """
         i = 0
-        while i < len(self._conversation):
-            msg = self._conversation[i]
+        while i < len(conversation):
+            msg = conversation[i]
             if msg["role"] != "assistant":
                 i += 1
                 continue
@@ -537,7 +531,7 @@ class Agent:
 
             # collect tool_result ids from next message (if it exists and is a user message)
             existing_result_ids: set[str] = set()
-            next_msg = self._conversation[i + 1] if i + 1 < len(self._conversation) else None
+            next_msg = conversation[i + 1] if i + 1 < len(conversation) else None
             if next_msg and next_msg["role"] == "user":
                 next_content = next_msg.get("content", [])
                 if isinstance(next_content, list):
@@ -565,23 +559,23 @@ class Agent:
                     i += 2
                 else:
                     # insert a new tool_result message
-                    self._conversation.insert(i + 1, {"role": "user", "content": patch})
+                    conversation.insert(i + 1, {"role": "user", "content": patch})
                     i += 2
             else:
                 i += 1
 
-    def _trim_old_tool_results(self) -> None:
+    def _trim_old_tool_results(self, conversation: list[dict[str, Any]]) -> None:
         """Replace verbose tool_result content with a short summary for older messages.
 
         Keeps the last TOOL_RESULT_PRESERVE_COUNT messages intact so the LLM
         has recent context, but shrinks older tool results to save tokens.
         """
-        cutoff = len(self._conversation) - self.TOOL_RESULT_PRESERVE_COUNT
+        cutoff = len(conversation) - self.TOOL_RESULT_PRESERVE_COUNT
         if cutoff <= 0:
             return
 
         for i in range(cutoff):
-            msg = self._conversation[i]
+            msg = conversation[i]
             if msg["role"] != "user":
                 continue
             content = msg["content"]
@@ -606,38 +600,38 @@ class Agent:
                 })
                 changed = True
             if changed:
-                self._conversation[i] = {**msg, "content": new_content}
+                conversation[i] = {**msg, "content": new_content}
 
     @staticmethod
     def _accumulate_usage(total: dict[str, int], usage: dict[str, int]) -> None:
         for k, v in usage.items():
             total[k] = total.get(k, 0) + v
 
-    async def _maybe_compact(self) -> None:
+    async def _maybe_compact(self, conversation: list[dict[str, Any]]) -> None:
         """Summarize older conversation messages when the char budget is exceeded.
 
         Keeps the most recent ~25% of the budget as raw messages; replaces
         everything older with a single summary turn produced by the sub-agent.
         No-ops if no sub-agent LLM is wired in.
         """
-        if self._sub_llm_client is None or not self._conversation:
+        if self._sub_llm_client is None or not conversation:
             return
 
-        total = sum(len(str(m.get("content", ""))) for m in self._conversation)
+        total = sum(len(str(m.get("content", ""))) for m in conversation)
         if total <= self._compact_threshold_chars:
             return
 
         keep_chars = self._compact_threshold_chars // 4
         cumulative = 0
-        split_idx = len(self._conversation)
-        for i in range(len(self._conversation) - 1, -1, -1):
-            cumulative += len(str(self._conversation[i].get("content", "")))
+        split_idx = len(conversation)
+        for i in range(len(conversation) - 1, -1, -1):
+            cumulative += len(str(conversation[i].get("content", "")))
             if cumulative >= keep_chars:
                 split_idx = i
                 break
 
-        older = self._conversation[:split_idx]
-        recent = self._conversation[split_idx:]
+        older = conversation[:split_idx]
+        recent = conversation[split_idx:]
         if not older:
             return
 
@@ -692,7 +686,9 @@ class Agent:
             len(summary),
             len(recent),
         )
-        self._conversation = [
+        # Use slice assignment so the caller's list is mutated in place
+        # (a plain `conversation = ...` would only rebind the local).
+        conversation[:] = [
             {
                 "role": "user",
                 "content": (
@@ -704,53 +700,39 @@ class Agent:
     async def chat(
         self,
         user_message: str,
+        conversation: list[dict[str, Any]],
         on_event: Callable[[AgentEvent], Awaitable[None]] | None = None,
-        conversation_override: list[dict[str, Any]] | None = None,
         images: list[dict[str, str]] | None = None,
     ) -> str:
         """Send a message and get a response, handling tool calls.
 
-        When `conversation_override` is provided, the agent uses that as its
-        conversation history for this turn and restores the previous history
-        afterward. This is how the Discord bot and scheduler isolate per-session
-        context without the caller having to swap `_conversation` manually
-        (which would race against other callers between the swap and the
-        LLM await).
+        `conversation` is a list owned by the caller and mutated in place —
+        each surface (TUI, Discord, scheduler) maintains its own conversation
+        list and passes it here. The agent does not hold shared conversation
+        state.
 
         When `images` is provided, the current user turn is sent as a multi-
         block message with images first, then text. Each image dict should be
         `{"media_type": "image/png", "data": "<base64>"}`. Images are ephemeral
         — they only affect this turn; nothing is persisted to the conversation
         store for them.
-
-        All chat() calls are serialized via `_chat_lock` so `_conversation`
-        is never mutated by another caller mid-flight.
         """
 
         async def _emit(event: AgentEvent) -> None:
             if on_event is not None:
                 await on_event(event)
 
-        async with self._chat_lock:
-            saved_conv: list[dict[str, Any]] | None = None
-            if conversation_override is not None:
-                saved_conv = self._conversation
-                self._conversation = list(conversation_override)
-            try:
-                return await self._chat_impl(user_message, _emit, images=images)
-            finally:
-                if saved_conv is not None:
-                    self._conversation = saved_conv
+        return await self._chat_impl(user_message, conversation, _emit, images=images)
 
     async def _chat_impl(
         self,
         user_message: str,
+        conversation: list[dict[str, Any]],
         _emit: Callable[[AgentEvent], Awaitable[None]],
         images: list[dict[str, str]] | None = None,
     ) -> str:
-        """Inner chat loop; caller holds `_chat_lock` and has already set
-        `_conversation` to the target history (possibly swapped from another
-        session). Do not call directly — go through `chat()`."""
+        """Inner chat loop. `conversation` is the caller-owned list that
+        will be mutated in place. Do not call directly — go through `chat()`."""
         # refresh the system prompt before each operator turn so that newly
         # added secrets, approved custom tools, self-note edits, and skills
         # show up without restarting the harness.
@@ -765,7 +747,7 @@ class Agent:
 
         # compact the conversation if it's gotten huge
         try:
-            await self._maybe_compact()
+            await self._maybe_compact(conversation)
         except Exception:
             logger.exception("compaction failed; continuing with raw conversation")
 
@@ -787,21 +769,21 @@ class Agent:
                     }
                 )
             content_blocks.append({"type": "text", "text": timestamped})
-            self._conversation.append({"role": "user", "content": content_blocks})
+            conversation.append({"role": "user", "content": content_blocks})
         else:
-            self._conversation.append({"role": "user", "content": timestamped})
+            conversation.append({"role": "user", "content": timestamped})
 
         total_usage: dict[str, int] = {}
         iteration = 0
         while iteration < self._max_iterations:
             iteration += 1
 
-            self._repair_conversation()
-            self._trim_old_tool_results()
+            self._repair_conversation(conversation)
+            self._trim_old_tool_results(conversation)
 
             await _emit(AgentEvent(kind="llm_start"))
             resp = await self._client.complete(
-                messages=self._conversation,
+                messages=conversation,
                 system=self._system_prompt,
                 tools=self._get_tools(),
             )
@@ -835,7 +817,7 @@ class Agent:
             }
             if resp.reasoning_content:
                 assistant_msg["reasoning_content"] = resp.reasoning_content
-            self._conversation.append(assistant_msg)
+            conversation.append(assistant_msg)
 
             # find any tool calls that we need to handle
             if resp.stop_reason == "tool_use":
@@ -875,7 +857,7 @@ class Agent:
                             }
                         )
 
-                self._conversation.append({"role": "user", "content": tool_results})
+                conversation.append({"role": "user", "content": tool_results})
             else:
                 # once there are no more tool calls, we proceed to the text response
                 if total_usage:
@@ -886,17 +868,17 @@ class Agent:
         logger.warning(
             "Hit max iterations (%d), forcing final response", self._max_iterations
         )
-        self._conversation.append(
+        conversation.append(
             {
                 "role": "user",
                 "content": "[System: Max tool calls reached. Provide final response now.]",
             }
         )
-        self._repair_conversation()
-        self._trim_old_tool_results()
+        self._repair_conversation(conversation)
+        self._trim_old_tool_results(conversation)
         await _emit(AgentEvent(kind="llm_start"))
         resp = await self._client.complete(
-            messages=self._conversation,
+            messages=conversation,
             system=self._system_prompt,
             tools=None,  # no tools for final call
         )

--- a/src/discord_bot/bot.py
+++ b/src/discord_bot/bot.py
@@ -207,8 +207,6 @@ class DiscordBot:
         self._channel_name = channel_name
         self._agent = agent
         self._executor = executor
-        # serialize all agent.chat() calls — agent._conversation is shared state
-        self._chat_lock = asyncio.Lock()
 
         intents = discord.Intents.default()
         intents.message_content = True  # privileged; must also be enabled on Dev Portal
@@ -242,15 +240,14 @@ class DiscordBot:
         if thread is None:
             return  # not in our sessions channel
 
-        async with self._chat_lock:
+        try:
+            await self._handle_message(message, thread)
+        except Exception as e:
+            logger.exception("Discord message handling failed")
             try:
-                await self._handle_message(message, thread)
-            except Exception as e:
-                logger.exception("Discord message handling failed")
-                try:
-                    await thread.send(f"⚠️ Error: `{type(e).__name__}`: {e}")
-                except Exception:
-                    pass
+                await thread.send(f"⚠️ Error: `{type(e).__name__}`: {e}")
+            except Exception:
+                pass
 
     async def _resolve_thread(
         self, message: discord.Message
@@ -320,17 +317,17 @@ class DiscordBot:
             ),
         )
 
-        # load the full session conversation for agent context. agent.chat()
-        # swaps + restores `_conversation` atomically under its own lock, so
-        # we don't need manual snapshot/restore logic here.
+        # load the full session conversation for agent context. The agent
+        # no longer holds shared conversation state — each call mutates
+        # the passed list in place.
         loaded = await self._load_conversation(thread_id)
 
         tracker = _UsageTracker()
         async with thread.typing():
             response = await self._agent.chat(
                 user_text,
+                conversation=loaded,
                 on_event=tracker.on_event,
-                conversation_override=loaded,
                 images=images or None,
             )
 

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -123,11 +123,10 @@ class VictrolaApp(App):
             except Exception:
                 logger.exception("Failed to save scheduled prompt to session")
 
-        # run the scheduled prompt in an isolated conversation. agent.chat()
-        # swaps + restores _conversation internally under its lock, so no
-        # manual snapshot is needed.
+        # run the scheduled prompt in an isolated conversation owned by this
+        # fire — the agent no longer holds shared conversation state.
         try:
-            response = await self.agent.chat(tagged_prompt, conversation_override=[])
+            response = await self.agent.chat(tagged_prompt, conversation=[])
             logger.info(
                 "Schedule '%s' completed: %s",
                 task_name,

--- a/src/tui/screens/chat.py
+++ b/src/tui/screens/chat.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from typing import Any
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -29,6 +30,7 @@ class ChatScreen(Screen):
         self.session_id = session_id
         self._current_tool_widget: ToolActivity | None = None
         self._llm_start_time: float | None = None
+        self._conversation: list[dict[str, Any]] = []
 
     def compose(self) -> ComposeResult:
         yield Header(name="Victrola Chat")
@@ -43,17 +45,12 @@ class ChatScreen(Screen):
 
     async def on_mount(self) -> None:
         conv_manager = self.app.conversation_manager  # type: ignore[attr-defined]
-        agent = self.app.agent  # type: ignore[attr-defined]
 
         if conv_manager:
             try:
                 messages = await conv_manager.load_session(self.session_id)
                 if messages:
-                    # Acquire agent's chat lock before touching _conversation so
-                    # we don't clobber a concurrent Discord/scheduler chat()'s
-                    # in-flight override.
-                    async with agent._chat_lock:
-                        agent._conversation = messages
+                    self._conversation = messages
                     chat_log = self.query_one("#chat-log", VerticalScroll)
                     for msg in messages:
                         role = msg.get("role", "user")
@@ -69,9 +66,6 @@ class ChatScreen(Screen):
                     chat_log.scroll_end(animate=False)
             except Exception:
                 logger.exception("Failed to load session history")
-        else:
-            async with agent._chat_lock:
-                agent._conversation = []
 
         self.query_one("#chat-input", Input).focus()
         await self._refresh_pending_banner()
@@ -152,7 +146,11 @@ class ChatScreen(Screen):
         input_widget = self.query_one("#chat-input", Input)
 
         try:
-            response = await agent.chat(user_text, on_event=self._on_agent_event)
+            response = await agent.chat(
+                user_text,
+                conversation=self._conversation,
+                on_event=self._on_agent_event,
+            )
             status_bar.hide()
 
             if response:
@@ -201,11 +199,7 @@ class ChatScreen(Screen):
             input_widget.focus()
 
     async def action_go_back(self) -> None:
-        agent = self.app.agent  # type: ignore[attr-defined]
-        # Lock so we don't clear _conversation while another surface's
-        # chat() is mid-flight using it.
-        async with agent._chat_lock:
-            agent._conversation = []
+        self._conversation = []
         self.app.pop_screen()
 
     def action_manage_tools(self) -> None:

--- a/test_images.py
+++ b/test_images.py
@@ -30,7 +30,8 @@ async def main():
         b64 = base64.b64encode(b'fake-png-bytes').decode('ascii')
 
         # 1. multi-block user message with image first, text last
-        await agent.chat('what is this?', images=[{'media_type': 'image/png', 'data': b64}])
+        conv1: list = []
+        await agent.chat('what is this?', conversation=conv1, images=[{'media_type': 'image/png', 'data': b64}])
         user_msg = captured[-1][-1]
         assert isinstance(user_msg['content'], list)
         assert user_msg['content'][0]['type'] == 'image'
@@ -39,7 +40,8 @@ async def main():
         print('pass 1: multi-block built (image first, text last)')
 
         # 2. plain string when no images
-        await agent.chat('just text')
+        conv2: list = []
+        await agent.chat('just text', conversation=conv2)
         assert isinstance(captured[-1][-1]['content'], str)
         print('pass 2: plain string when no images')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,89 @@
+"""Shared test fixtures for Victrola."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.store.store import Store
+from src.tools.registry import ToolContext, ToolRegistry
+from src.tools.executor import ToolExecutor
+
+
+@pytest.fixture
+async def temp_store(tmp_path: Path) -> Store:
+    """Create a Store against a temp SQLite DB, initialize, yield, close."""
+    store = Store(path=tmp_path / "test.db")
+    await store.initialize()
+    yield store
+    await store.close()
+
+
+@pytest.fixture
+def mock_agent_client():
+    """A no-op AgentClient stub that returns canned responses."""
+    from src.agent.agent import AgentClient, AgentResponse, AgentTextBlock
+
+    class _StubClient(AgentClient):
+        def __init__(self) -> None:
+            self.calls: list = []
+            self._responses: list[AgentResponse] = []
+
+        def set_response(self, text: str) -> None:
+            self._responses.append(
+                AgentResponse(
+                    content=[AgentTextBlock(text=text)],
+                    stop_reason="end_turn",
+                    usage={"input_tokens": 10, "output_tokens": 5},
+                )
+            )
+
+        async def complete(self, messages, system=None, tools=None):
+            self.calls.append({"messages": messages, "system": system, "tools": tools})
+            if self._responses:
+                return self._responses.pop(0)
+            return AgentResponse(
+                content=[AgentTextBlock(text="stub response")],
+                stop_reason="end_turn",
+                usage={"input_tokens": 10, "output_tokens": 5},
+            )
+
+    return _StubClient()
+
+
+@pytest.fixture
+async def isolated_executor(tmp_path: Path) -> ToolExecutor:
+    """A ToolExecutor with a temp store and mock context."""
+    store = Store(path=tmp_path / "test.db")
+    await store.initialize()
+
+    ctx = ToolContext(store=store)
+    registry = ToolRegistry()
+    executor = ToolExecutor(registry=registry, ctx=ctx)
+    executor._tool_definition = None
+
+    yield executor
+
+    await store.close()
+
+
+@pytest.fixture
+async def isolated_custom_tool_manager(tmp_path: Path):
+    """A CustomToolManager backed by a temp store."""
+    from src.tools.custom import CustomToolManager
+
+    store = Store(path=tmp_path / "test.db")
+    await store.initialize()
+
+    ctx = ToolContext(store=store)
+    registry = ToolRegistry()
+    executor = ToolExecutor(registry=registry, ctx=ctx)
+
+    manager = CustomToolManager(store=store, executor=executor, secret_manager=None)
+
+    yield manager
+
+    await store.close()

--- a/tests/test_pr01_conversation_state.py
+++ b/tests/test_pr01_conversation_state.py
@@ -1,0 +1,81 @@
+"""Tests for PR 1: Per-session conversation state."""
+
+import pytest
+
+from src.agent.agent import Agent, AgentResponse, AgentTextBlock
+from unittest.mock import MagicMock
+
+
+@pytest.mark.asyncio
+async def test_conversations_are_independent():
+    """Two conversation lists passed to chat() must remain independent."""
+    agent = Agent(model_api="anthropic", model_name="x", model_api_key="key")
+
+    # Stub the client to return a simple text response
+    async def fake_complete(**kwargs):
+        return AgentResponse(
+            content=[AgentTextBlock(text="response")],
+            stop_reason="end_turn",
+            usage={"input_tokens": 1, "output_tokens": 1},
+        )
+
+    agent._client = MagicMock()
+    agent._client.complete = fake_complete
+
+    conv1: list = []
+    conv2: list = []
+
+    await agent.chat("hello from conv1", conversation=conv1)
+    await agent.chat("hello from conv2", conversation=conv2)
+
+    # Each conversation should have exactly 2 messages (user + assistant)
+    assert len(conv1) == 2
+    assert len(conv2) == 2
+
+    # Verify they didn't cross-contaminate
+    user_msg_1 = conv1[0]["content"]
+    user_msg_2 = conv2[0]["content"]
+    assert "conv1" in user_msg_1
+    assert "conv2" in user_msg_2
+    assert "conv2" not in user_msg_1
+    assert "conv1" not in user_msg_2
+
+
+@pytest.mark.asyncio
+async def test_conversation_mutated_in_place():
+    """chat() must mutate the caller's list in place (not rebind)."""
+    agent = Agent(model_api="anthropic", model_name="x", model_api_key="key")
+
+    async def fake_complete(**kwargs):
+        return AgentResponse(
+            content=[AgentTextBlock(text="ok")],
+            stop_reason="end_turn",
+            usage={"input_tokens": 1, "output_tokens": 1},
+        )
+
+    agent._client = MagicMock()
+    agent._client.complete = fake_complete
+
+    conv: list = []
+    original_id = id(conv)
+    await agent.chat("test", conversation=conv)
+
+    # The same list object must have been mutated (not replaced)
+    assert id(conv) == original_id
+    assert len(conv) == 2  # user + assistant
+
+
+def test_agent_has_no_conversation_attr():
+    """Agent must not store _conversation or _chat_lock."""
+    agent = Agent(model_api="anthropic", model_name="x", model_api_key="key")
+    assert not hasattr(agent, "_conversation")
+    assert not hasattr(agent, "_chat_lock")
+
+
+def test_chat_requires_conversation_param():
+    """chat() must require a conversation parameter."""
+    import inspect
+    sig = inspect.signature(Agent.chat)
+    assert "conversation" in sig.parameters
+    # conversation should NOT have a default (it's required)
+    assert sig.parameters["conversation"].default is inspect.Parameter.empty


### PR DESCRIPTION
## Critical #1 — Shared conversation state across all surfaces

The Agent held a single `_conversation` list shared across TUI, Discord, and scheduler. The `_chat_lock` serialized all callers; a slow TUI turn blocked Discord/scheduler. The scheduler's `on_schedule_fire` called `agent.chat()` with no `conversation_override`, contaminating the wrong session.

## Changes
- Remove `_conversation` and `_chat_lock` from `Agent.__init__`
- Make `Agent.chat()` require a `conversation: list[dict]` parameter (mutated in place)
- Thread `conversation` through `_chat_impl`, `_repair_conversation`, `_trim_old_tool_results`, `_maybe_compact`
- Use slice assignment in `_maybe_compact` to mutate caller's list in place
- Remove Discord bot's `_chat_lock`; each thread loads its own conversation
- Update all call sites: main.py, TUI app.py, TUI chat.py, Discord bot, test_images.py
- Add pytest+pytest-asyncio dev deps, conftest.py, and tests

## Acceptance Criteria
- [x] AC.1: Agent class has no `_conversation` attribute and no `_chat_lock`
- [x] AC.2: `agent.chat()` accepts a required `conversation` parameter and mutates it in place
- [x] AC.3: `DiscordBot` has no `_chat_lock` attribute; each thread loads its own conversation
- [x] AC.4: Both scheduler-fire paths pass `conversation=[]`
- [x] AC.5: All `agent.chat(` call sites pass an explicit `conversation=` argument

## Dependencies
None — this is the foundational structural change.