### PR TITLE
PR 3: Track and cancel TUI background tasks (scheduler + Discord)

### DIFF
--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Any
 
@@ -27,6 +28,8 @@ class VictrolaApp(App):
         self.agent = agent
         self.conversation_manager: Any = None
         self.executor = executor
+        self._scheduler_task: asyncio.Task | None = None
+        self._bot_task: asyncio.Task | None = None
 
     async def on_mount(self) -> None:
         """Initialize all async services then show session list."""
@@ -75,10 +78,15 @@ class VictrolaApp(App):
 
         # wire scheduler callback and start in background
         if self.executor._scheduler:
-            import asyncio
-
             self.executor._scheduler._on_fire = self._on_schedule_fire
-            asyncio.create_task(self.executor._scheduler.run())
+
+            async def _run_scheduler() -> None:
+                try:
+                    await self.executor._scheduler.run()
+                except Exception:
+                    logger.exception("Scheduler background task crashed")
+
+            self._scheduler_task = asyncio.create_task(_run_scheduler())
             logger.info("Scheduler started in background")
 
         # start Discord chat bot if DISCORD_BOT_TOKEN is configured
@@ -87,9 +95,13 @@ class VictrolaApp(App):
 
             bot = _build_discord_bot(self.executor, self.agent)
             if bot is not None:
-                import asyncio
+                async def _run_bot() -> None:
+                    try:
+                        await bot.start()
+                    except Exception:
+                        logger.exception("Discord bot background task crashed")
 
-                asyncio.create_task(bot.start())
+                self._bot_task = asyncio.create_task(_run_bot())
                 logger.info("Discord bot started in background")
         except Exception:
             logger.exception("Discord bot failed to start")
@@ -100,6 +112,19 @@ class VictrolaApp(App):
 
     async def on_unmount(self) -> None:
         """Clean up resources on shutdown."""
+        # Cancel background tasks
+        for task in (self._scheduler_task, self._bot_task):
+            if task is not None and not task.done():
+                task.cancel()
+        for task in (self._scheduler_task, self._bot_task):
+            if task is not None:
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    logger.exception("Background task raised on shutdown")
+        # Close agent resources
         try:
             await self.agent.aclose()
         except Exception:

--- a/tests/test_pr03_background_tasks.py
+++ b/tests/test_pr03_background_tasks.py
@@ -1,0 +1,59 @@
+"""Tests for PR 3: Track and cancel TUI background tasks."""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+
+def test_app_stores_task_refs():
+    """VictrolaApp should initialize _scheduler_task and _bot_task as None."""
+    from src.tui.app import VictrolaApp
+
+    app = VictrolaApp(agent=MagicMock(), executor=MagicMock())
+    assert hasattr(app, "_scheduler_task")
+    assert hasattr(app, "_bot_task")
+    assert app._scheduler_task is None
+    assert app._bot_task is None
+
+
+@pytest.mark.asyncio
+async def test_on_unmount_cancels_tasks():
+    """on_unmount should cancel and await both background tasks."""
+    from src.tui.app import VictrolaApp
+
+    app = VictrolaApp(agent=MagicMock(), executor=MagicMock())
+
+    async def _long_running():
+        await asyncio.sleep(100)
+
+    app._scheduler_task = asyncio.create_task(_long_running())
+    app._bot_task = asyncio.create_task(_long_running())
+
+    app.agent.aclose = AsyncMock()
+
+    await app.on_unmount()
+
+    assert app._scheduler_task.cancelled()
+    assert app._bot_task.cancelled()
+    app.agent.aclose.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_on_unmount_handles_completed_tasks():
+    """on_unmount should handle already-completed tasks gracefully."""
+    from src.tui.app import VictrolaApp
+
+    app = VictrolaApp(agent=MagicMock(), executor=MagicMock())
+
+    async def _quick():
+        pass
+
+    app._scheduler_task = asyncio.create_task(_quick())
+    app._bot_task = asyncio.create_task(_quick())
+
+    await asyncio.sleep(0.01)
+
+    app.agent.aclose = AsyncMock()
+    await app.on_unmount()
+
+    app.agent.aclose.assert_called_once()


### PR DESCRIPTION
## Critical #5 — Untracked background tasks

Scheduler and Discord bot tasks created via `asyncio.create_task()` in `VictrolaApp.on_mount` were never stored. They couldn't be cancelled on exit; exceptions inside them were never surfaced.

## Changes
- Store `self._scheduler_task` and `self._bot_task` references
- Wrap each task body in `try/except` with `logger.exception`
- Extend `on_unmount` to cancel and await both tasks before closing agent
- Remove duplicate `import asyncio` inside `on_mount` (now at module level)

## Acceptance Criteria
- [x] AC.1: `VictrolaApp` stores references to scheduler and Discord bot tasks
- [x] AC.2: `on_unmount` cancels and awaits both tasks
- [x] AC.3: If the scheduler or Discord bot raises at runtime, the exception is logged

## Dependencies
PR 2 (both touch `app.py` shutdown lifecycle; `on_unmount` calls both `agent.aclose()` and cancels tasks).