### PR TITLE
PR 4: Gate custom tool network access behind requires_net flag

### DIFF
--- a/src/tools/custom.py
+++ b/src/tools/custom.py
@@ -22,6 +22,7 @@ class CustomTool:
     approved: bool = False
     response_schema: dict[str, Any] | None = None
     secrets: list[str] = field(default_factory=list)
+    requires_net: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
@@ -30,6 +31,7 @@ class CustomTool:
             "parameters": self.parameters,
             "code": self.code,
             "approved": self.approved,
+            "requiresNet": self.requires_net,
         }
         if self.response_schema:
             d["responseSchema"] = self.response_schema
@@ -47,6 +49,7 @@ class CustomTool:
             approved=data.get("approved", False),
             response_schema=data.get("responseSchema", data.get("response_schema")),
             secrets=data.get("secrets", []),
+            requires_net=data.get("requiresNet", data.get("requires_net", False)),
         )
 
 
@@ -132,7 +135,7 @@ class CustomToolManager:
             code=tool.code,
             params=params,
             env=env,
-            allow_net=True,
+            allow_net=tool.requires_net,
         )
 
     def _build_env(self, tool: CustomTool) -> dict[str, str]:

--- a/src/tools/definitions/custom_tools.py
+++ b/src/tools/definitions/custom_tools.py
@@ -69,6 +69,12 @@ Use `list_available_secrets` to see what secrets the operator has configured. Re
             description="Optional list of environment variable names to inject into the Deno process.",
             required=False,
         ),
+        ToolParameter(
+            name="requires_net",
+            type="boolean",
+            description="Set to true if the tool needs network access (fetch, HTTP). Defaults to false — tools run without network access unless explicitly requested.",
+            required=False,
+        ),
     ],
 )
 async def create_custom_tool(
@@ -79,6 +85,7 @@ async def create_custom_tool(
     code: str,
     response_schema: dict[str, Any] | None = None,
     secrets: list[str] | None = None,
+    requires_net: bool = False,
 ) -> str:
     manager = ctx.custom_tool_manager
     if manager is None:
@@ -94,6 +101,7 @@ async def create_custom_tool(
         approved=False,
         response_schema=response_schema,
         secrets=secrets or [],
+        requires_net=requires_net,
     )
     return await manager.create_tool(tool)
 

--- a/src/tui/screens/tool_detail.py
+++ b/src/tui/screens/tool_detail.py
@@ -73,6 +73,8 @@ class ToolDetailScreen(Screen):
         status = "approved" if tool.approved else "pending review"
         await body.mount(Static(f"[b]Status:[/b] {status}", markup=True))
         await body.mount(Static(f"[b]Description:[/b] {tool.description}", markup=True))
+        net_label = "yes — tool can make network calls" if tool.requires_net else "no (sandboxed)"
+        await body.mount(Static(f"[b]Requires network:[/b] {net_label}", markup=True))
 
         # parameters
         await body.mount(Static("[b]Parameters:[/b]", markup=True))

--- a/tests/test_pr04_requires_net.py
+++ b/tests/test_pr04_requires_net.py
@@ -1,0 +1,108 @@
+"""Tests for PR 4: Gate custom tool network access behind requires_net flag."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.tools.custom import CustomTool, CustomToolManager
+
+
+def test_custom_tool_defaults_requires_net_false():
+    """CustomTool should default requires_net to False."""
+    tool = CustomTool(
+        name="test",
+        description="test tool",
+        parameters={},
+        code="output('hello')",
+    )
+    assert tool.requires_net is False
+
+
+def test_custom_tool_requires_net_true():
+    """CustomTool should accept requires_net=True."""
+    tool = CustomTool(
+        name="test",
+        description="test tool",
+        parameters={},
+        code="output('hello')",
+        requires_net=True,
+    )
+    assert tool.requires_net is True
+
+
+def test_to_dict_includes_requires_net():
+    """to_dict should include requiresNet."""
+    tool = CustomTool(
+        name="test",
+        description="test tool",
+        parameters={},
+        code="output('hello')",
+        requires_net=True,
+    )
+    d = tool.to_dict()
+    assert d["requiresNet"] is True
+
+
+def test_from_dict_reads_requires_net():
+    """from_dict should read requiresNet."""
+    data = {
+        "name": "test",
+        "description": "test tool",
+        "parameters": {},
+        "code": "output('hello')",
+        "approved": False,
+        "requiresNet": True,
+    }
+    tool = CustomTool.from_dict(data)
+    assert tool.requires_net is True
+
+
+def test_from_dict_defaults_requires_net_false():
+    """from_dict should default requires_net to False when missing."""
+    data = {
+        "name": "test",
+        "description": "test tool",
+        "parameters": {},
+        "code": "output('hello')",
+        "approved": False,
+    }
+    tool = CustomTool.from_dict(data)
+    assert tool.requires_net is False
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_passes_requires_net_to_executor():
+    """execute_tool should pass allow_net=tool.requires_net to execute_custom_tool_code."""
+    store = MagicMock()
+    executor = MagicMock()
+    executor.execute_custom_tool_code = AsyncMock(return_value={"success": True})
+
+    manager = CustomToolManager(store=store, executor=executor, secret_manager=None)
+
+    # Tool with requires_net=False
+    tool_false = CustomTool(
+        name="no_net",
+        description="no net",
+        parameters={},
+        code="output('hello')",
+        approved=True,
+        requires_net=False,
+    )
+    manager._tools["no_net"] = tool_false
+    await manager.execute_tool("no_net", {})
+    call_args = executor.execute_custom_tool_code.call_args
+    assert call_args.kwargs["allow_net"] is False
+
+    # Tool with requires_net=True
+    executor.execute_custom_tool_code.reset_mock()
+    tool_true = CustomTool(
+        name="with_net",
+        description="with net",
+        parameters={},
+        code="output('hello')",
+        approved=True,
+        requires_net=True,
+    )
+    manager._tools["with_net"] = tool_true
+    await manager.execute_tool("with_net", {})
+    call_args = executor.execute_custom_tool_code.call_args
+    assert call_args.kwargs["allow_net"] is True


### PR DESCRIPTION
## Critical #3 — Custom tool network access hardcoded to True

`CustomToolManager.execute_tool` hardcoded `allow_net=True` for all custom tools, defeating the Deno sandbox.

## Changes
- Add `requires_net: bool = False` field to `CustomTool` dataclass
- Update `to_dict()` to include `requiresNet`
- Update `from_dict()` to read `requiresNet` (defaults to False)
- Change `execute_tool` from `allow_net=True` to `allow_net=tool.requires_net`
- Add `requires_net` parameter to `create_custom_tool` tool definition
- Display `requires_net` flag in TUI tool detail screen

## Acceptance Criteria
- [x] AC.1: `CustomTool` has a `requires_net` field defaulting to `False`
- [x] AC.2: `execute_tool` passes `allow_net=tool.requires_net` to `execute_custom_tool_code`
- [x] AC.3: A custom tool created without `requires_net=True` cannot make network calls
- [x] AC.4: The TUI tool detail screen shows whether network access is requested

## Dependencies
None. Existing approved tools without `requires_net` default to `False` (safer default — tools need re-approval for network access).