### PR TITLE
PR 5: Fix secret name→env-var mapping (stop .upper())

### DIFF
--- a/src/tools/custom.py
+++ b/src/tools/custom.py
@@ -147,7 +147,7 @@ class CustomToolManager:
             for secret_name in tool.secrets:
                 val = self._secret_manager.get_secret(secret_name)
                 if val:
-                    env[secret_name.upper()] = val
+                    env[secret_name] = val
 
         return env
 

--- a/src/tools/definitions/custom_tools.py
+++ b/src/tools/definitions/custom_tools.py
@@ -66,7 +66,7 @@ Use `list_available_secrets` to see what secrets the operator has configured. Re
         ToolParameter(
             name="secrets",
             type="array",
-            description="Optional list of environment variable names to inject into the Deno process.",
+            description="Optional list of secret names to inject as environment variables into the Deno process. Secrets are injected under their exact configured name (e.g. a secret named 'my_api_key' is accessed via Deno.env.get('my_api_key')).",
             required=False,
         ),
         ToolParameter(

--- a/tests/test_pr05_secret_env_mapping.py
+++ b/tests/test_pr05_secret_env_mapping.py
@@ -1,0 +1,97 @@
+"""Tests for PR 5: Fix secret name→env-var mapping (stop .upper())."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from src.tools.custom import CustomTool, CustomToolManager
+
+
+def test_build_env_uses_exact_secret_name():
+    """_build_env should inject secrets using their exact configured name (no .upper())."""
+    store = MagicMock()
+    executor = MagicMock()
+    secret_manager = MagicMock()
+    secret_manager.get_secret = MagicMock(return_value="secret_value")
+
+    manager = CustomToolManager(store=store, executor=executor, secret_manager=secret_manager)
+
+    tool = CustomTool(
+        name="test_tool",
+        description="test",
+        parameters={},
+        code="output('hello')",
+        approved=True,
+        secrets=["my_api_key"],
+    )
+
+    env = manager._build_env(tool)
+    assert "my_api_key" in env
+    assert env["my_api_key"] == "secret_value"
+    # Should NOT have the uppercased version
+    assert "MY_API_KEY" not in env
+
+
+def test_build_env_preserves_case():
+    """_build_env should preserve the original case of secret names."""
+    store = MagicMock()
+    executor = MagicMock()
+    secret_manager = MagicMock()
+    secret_manager.get_secret = MagicMock(return_value="val123")
+
+    manager = CustomToolManager(store=store, executor=executor, secret_manager=secret_manager)
+
+    tool = CustomTool(
+        name="test_tool",
+        description="test",
+        parameters={},
+        code="output('hello')",
+        approved=True,
+        secrets=["MixedCase_Name"],
+    )
+
+    env = manager._build_env(tool)
+    assert "MixedCase_Name" in env
+    assert env["MixedCase_Name"] == "val123"
+
+
+def test_build_env_no_secrets():
+    """_build_env should return empty dict when tool has no secrets."""
+    store = MagicMock()
+    executor = MagicMock()
+
+    manager = CustomToolManager(store=store, executor=executor, secret_manager=None)
+
+    tool = CustomTool(
+        name="test_tool",
+        description="test",
+        parameters={},
+        code="output('hello')",
+        approved=True,
+        secrets=[],
+    )
+
+    env = manager._build_env(tool)
+    assert env == {}
+
+
+def test_build_env_skips_missing_secrets():
+    """_build_env should skip secrets that are not set (None/empty)."""
+    store = MagicMock()
+    executor = MagicMock()
+    secret_manager = MagicMock()
+    secret_manager.get_secret = MagicMock(return_value=None)
+
+    manager = CustomToolManager(store=store, executor=executor, secret_manager=secret_manager)
+
+    tool = CustomTool(
+        name="test_tool",
+        description="test",
+        parameters={},
+        code="output('hello')",
+        approved=True,
+        secrets=["missing_secret"],
+    )
+
+    env = manager._build_env(tool)
+    assert "missing_secret" not in env
+    assert env == {}


### PR DESCRIPTION
## Critical #4 — Secrets injected with .upper(), unreachable by configured name

`_build_env` did `env[secret_name.upper()] = val`, but docs and tool descriptions tell authors to use the original name. Secrets were silently unreachable.

## Changes
- Change `_build_env` from `env[secret_name.upper()]` to `env[secret_name]`
- Update `secrets` parameter description to document exact-name convention

## Acceptance Criteria
- [x] AC.1: `_build_env` injects secrets using their exact configured name (no `.upper()`)
- [x] AC.2: A custom tool that calls `Deno.env.get("my_api_key")` for a secret named `my_api_key` receives the value
- [x] AC.3: Tool documentation and `_build_env` agree on the name convention

## Dependencies
PR 4 (both touch `CustomTool` and `custom_tools.py`; merge PR 4 first).