### PR TITLE
PR 6: Add LLM API call retry with exponential backoff

### DIFF
--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -16,6 +16,47 @@ from src.tools.executor import ToolExecutor
 
 logger = logging.getLogger(__name__)
 
+# Retry configuration for transient LLM API failures
+MAX_RETRIES = 3
+BASE_DELAY = 1.0  # seconds
+DELAY_FACTOR = 2.0
+MAX_DELAY = 30.0  # seconds
+
+
+def _is_retryable_status(status_code: int) -> bool:
+    """Return True for HTTP status codes that should trigger a retry."""
+    return status_code == 429 or status_code >= 500
+
+
+async def _retry_with_backoff(
+    coro_factory: Callable[[], Awaitable[Any]],
+    *,
+    is_retryable_exc: Callable[[Exception], bool],
+    max_retries: int = MAX_RETRIES,
+    base_delay: float = BASE_DELAY,
+) -> Any:
+    """Call coro_factory() with exponential backoff on retryable errors.
+
+    After exhausting retries, the original exception propagates.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(max_retries + 1):
+        try:
+            return await coro_factory()
+        except Exception as exc:
+            last_exc = exc
+            if attempt >= max_retries or not is_retryable_exc(exc):
+                raise
+            delay = min(base_delay * (DELAY_FACTOR ** attempt), MAX_DELAY)
+            logger.warning(
+                "LLM API call failed (attempt %d/%d), retrying in %.1fs: %s",
+                attempt + 1, max_retries + 1, delay, exc,
+            )
+            await asyncio.sleep(delay)
+    # Should not reach here, but satisfy the type checker
+    if last_exc:
+        raise last_exc
+
 
 @dataclass
 class AgentTextBlock:
@@ -54,6 +95,33 @@ class AgentClient(ABC):
         pass
 
 
+def _is_anthropic_retryable(exc: Exception) -> bool:
+    """Check if an Anthropic API exception should be retried."""
+    # Retry on overloaded errors and API status errors with retryable codes
+    from anthropic import APIStatusError, APIConnectionError, APITimeoutError
+
+    if isinstance(exc, (APIConnectionError, APITimeoutError)):
+        return True
+    if isinstance(exc, APIStatusError):
+        status = getattr(exc, "status_code", None)
+        if status is not None and _is_retryable_status(status):
+            return True
+    return False
+
+
+def _is_httpx_retryable(exc: Exception) -> bool:
+    """Check if an httpx exception should be retried."""
+    if isinstance(exc, (httpx.TransportError, httpx.TimeoutException)):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = getattr(exc, "response", None)
+        if status is not None:
+            code = getattr(status, "status_code", None)
+            if code is not None and _is_retryable_status(code):
+                return True
+    return False
+
+
 class AnthropicClient(AgentClient):
     def __init__(
         self, api_key: str, model_name: str = "claude-sonnet-4-5-20250929"
@@ -86,8 +154,14 @@ class AnthropicClient(AgentClient):
             tools[-1]["cache_control"] = {"type": "ephemeral"}
             kwargs["tools"] = tools
 
-        async with self._client.messages.stream(**kwargs) as stream:  # type: ignore
-            msg = await stream.get_final_message()
+        async def _do_stream():
+            async with self._client.messages.stream(**kwargs) as stream:  # type: ignore
+                return await stream.get_final_message()
+
+        msg = await _retry_with_backoff(
+            _do_stream,
+            is_retryable_exc=_is_anthropic_retryable,
+        )
 
         content: list[AgentTextBlock | AgentToolUseBlock] = []
         for block in msg.content:
@@ -182,18 +256,24 @@ class OpenAICompatibleClient(AgentClient):
         if tools:
             payload["tools"] = self._convert_tools(tools)
 
-        resp = await self._http.post(
-            f"{self._endpoint}/chat/completions",
-            headers={
-                "Authorization": f"Bearer {self._api_key}",
-                "Content-Type": "application/json",
-            },
-            json=payload,
+        async def _do_post():
+            resp = await self._http.post(
+                f"{self._endpoint}/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+            )
+            if not resp.is_success:
+                logger.error("API error %d: %s", resp.status_code, resp.text[:1000])
+                resp.raise_for_status()
+            return resp.json()
+
+        data = await _retry_with_backoff(
+            _do_post,
+            is_retryable_exc=_is_httpx_retryable,
         )
-        if not resp.is_success:
-            logger.error("API error %d: %s", resp.status_code, resp.text[:1000])
-            resp.raise_for_status()
-        data = resp.json()
 
         return self._parse_response(data)
 

--- a/src/tools/custom.py
+++ b/src/tools/custom.py
@@ -78,7 +78,7 @@ class CustomToolManager:
 
         while True:
             if self._store.documents is None:
-            raise RuntimeError("DocumentStore is not initialized")
+                raise RuntimeError("DocumentStore is not initialized")
             resp = await self._store.documents.list(limit=100, cursor=cursor)
             documents = resp.get("documents", [])
 

--- a/tests/test_pr06_llm_retry.py
+++ b/tests/test_pr06_llm_retry.py
@@ -1,0 +1,163 @@
+"""Tests for PR 6: Add LLM API call retry with exponential backoff."""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+from anthropic import APIStatusError, APIConnectionError, APITimeoutError
+
+from src.agent.agent import (
+    _retry_with_backoff,
+    _is_retryable_status,
+    _is_anthropic_retryable,
+    _is_httpx_retryable,
+    AnthropicClient,
+    OpenAICompatibleClient,
+)
+
+
+# --- _is_retryable_status tests ---
+
+def test_is_retryable_429():
+    assert _is_retryable_status(429) is True
+
+def test_is_retryable_500():
+    assert _is_retryable_status(500) is True
+
+def test_is_retryable_503():
+    assert _is_retryable_status(503) is True
+
+def test_not_retryable_400():
+    assert _is_retryable_status(400) is False
+
+def test_not_retryable_404():
+    assert _is_retryable_status(404) is False
+
+def test_not_retryable_200():
+    assert _is_retryable_status(200) is False
+
+
+# --- _retry_with_backoff tests ---
+
+@pytest.mark.asyncio
+async def test_retry_succeeds_after_failures():
+    """Should retry and succeed when transient failures occur."""
+    call_count = 0
+
+    async def coro_factory():
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise ConnectionError("transient")
+        return "success"
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        result = await _retry_with_backoff(
+            coro_factory,
+            is_retryable_exc=lambda e: isinstance(e, ConnectionError),
+            base_delay=0.01,
+        )
+    assert result == "success"
+    assert call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_propagates_after_max_retries():
+    """Should propagate the exception after max retries."""
+    call_count = 0
+
+    async def coro_factory():
+        nonlocal call_count
+        call_count += 1
+        raise ConnectionError("persistent")
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        with pytest.raises(ConnectionError, match="persistent"):
+            await _retry_with_backoff(
+                coro_factory,
+                is_retryable_exc=lambda e: isinstance(e, ConnectionError),
+                max_retries=3,
+                base_delay=0.01,
+            )
+    assert call_count == 4  # initial + 3 retries
+
+
+@pytest.mark.asyncio
+async def test_no_retry_on_non_retryable():
+    """Should not retry non-retryable exceptions."""
+    call_count = 0
+
+    async def coro_factory():
+        nonlocal call_count
+        call_count += 1
+        raise ValueError("not retryable")
+
+    with pytest.raises(ValueError):
+        await _retry_with_backoff(
+            coro_factory,
+            is_retryable_exc=lambda e: isinstance(e, ConnectionError),
+            base_delay=0.01,
+        )
+    assert call_count == 1
+
+
+# --- Anthropic client retry tests ---
+
+@pytest.mark.asyncio
+async def test_anthropic_retries_on_overloaded():
+    """AnthropicClient.complete should retry on overloaded errors."""
+    client = AnthropicClient(api_key="fake", model_name="test")
+
+    call_count = 0
+    original_msg = MagicMock()
+    original_msg.content = []
+    original_msg.usage = MagicMock(input_tokens=1, output_tokens=1)
+    original_msg.stop_reason = "end_turn"
+
+    async def fake_stream():
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            # Simulate a 529 Overloaded error
+            raise APIStatusError(
+                message="Overloaded",
+                response=MagicMock(status_code=529),
+                body=None,
+            )
+        return original_msg
+
+    with patch.object(client, "_client") as mock_client:
+        mock_stream = MagicMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.get_final_message = fake_stream
+        mock_client.messages.stream = MagicMock(return_value=mock_stream)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await client.complete(messages=[], system="test")
+
+    assert call_count == 3
+    assert result.stop_reason == "end_turn"
+
+
+# --- httpx retryable tests ---
+
+def test_httpx_transport_error_retryable():
+    exc = httpx.TransportError("connection lost")
+    assert _is_httpx_retryable(exc) is True
+
+def test_httpx_timeout_retryable():
+    exc = httpx.TimeoutException("timed out")
+    assert _is_httpx_retryable(exc) is True
+
+def test_httpx_429_retryable():
+    response = MagicMock()
+    response.status_code = 429
+    exc = httpx.HTTPStatusError("rate limited", request=MagicMock(), response=response)
+    assert _is_httpx_retryable(exc) is True
+
+def test_httpx_400_not_retryable():
+    response = MagicMock()
+    response.status_code = 400
+    exc = httpx.HTTPStatusError("bad request", request=MagicMock(), response=response)
+    assert _is_httpx_retryable(exc) is False


### PR DESCRIPTION
## High #6 — No retry on transient LLM API failures

A single transient failure (429, 5xx, connection error) killed the whole turn.

## Changes
- Add `_retry_with_backoff` helper (max 3 retries, base 1s delay, factor 2, max 30s)
- Add `_is_retryable_status` helper (429, 5xx)
- Wrap `AnthropicClient.complete` stream call with retry
- Wrap `OpenAICompatibleClient.complete` httpx.post call with retry
- Retry on `APIConnectionError`, `APITimeoutError`, `APIStatusError`(429/5xx)
- Retry on `httpx.TransportError`, `TimeoutException`, `HTTPStatusError`(429/5xx)

## Acceptance Criteria
- [x] AC.1: `AnthropicClient.complete` retries on 429/5xx/`APIStatusError` up to 3 times with exponential backoff
- [x] AC.2: `OpenAICompatibleClient.complete` retries on HTTP 429/5xx/`httpx.TransportError` up to 3 times
- [x] AC.3: After exhausting retries, the original exception propagates
- [x] AC.4: Non-retryable errors (4xx except 429) do not retry

## Dependencies
None.