### PR TITLE
PR 7: Replace assert with explicit validation throughout

### DIFF
--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -454,20 +454,24 @@ class Agent:
     ) -> None:
         match model_api:
             case "anthropic":
-                assert model_api_key
+                if not model_api_key:
+                    raise ValueError("model_api_key is required for anthropic")
                 self._client: AgentClient = AnthropicClient(
                     api_key=model_api_key, model_name=model_name
                 )
             case "openai":
-                assert model_api_key
+                if not model_api_key:
+                    raise ValueError("model_api_key is required for openai")
                 self._client = OpenAICompatibleClient(
                     api_key=model_api_key,
                     model_name=model_name,
                     endpoint="https://api.openai.com/v1",
                 )
             case "openapi":
-                assert model_api_key
-                assert model_endpoint, "model_endpoint is required for openapi"
+                if not model_api_key:
+                    raise ValueError("model_api_key is required for openapi")
+                if not model_endpoint:
+                    raise ValueError("model_endpoint is required for openapi")
                 self._client = OpenAICompatibleClient(
                     api_key=model_api_key,
                     model_name=model_name,

--- a/src/agent/conversation.py
+++ b/src/agent/conversation.py
@@ -37,7 +37,8 @@ class ConversationManager:
 
         payload = json.dumps({"role": role, "content": content}, default=str)
 
-        assert self._store.chat is not None
+        if self._store.chat is None:
+            raise RuntimeError("ChatStore is not initialized")
         await self._store.chat.create_message(
             session_id=session_id,
             sender=role,
@@ -49,7 +50,8 @@ class ConversationManager:
         messages: list[dict[str, Any]] = []
         cursor: str | None = None
 
-        assert self._store.chat is not None
+        if self._store.chat is None:
+            raise RuntimeError("ChatStore is not initialized")
         while True:
             data = await self._store.chat.list_messages(
                 session_id=session_id,
@@ -96,7 +98,8 @@ async def maybe_generate_session_title(
     """
     if llm_client is None:
         return None
-    assert store.chat is not None
+    if store.chat is None:
+        raise RuntimeError("ChatStore is not initialized")
 
     session = await store.chat.get_session(session_id)
     if session is None or session.get("title"):
@@ -150,7 +153,8 @@ async def maybe_generate_session_title(
         title = title[:TITLE_MAX_LEN].rstrip() + "..."
 
     try:
-        assert store.chat is not None
+        if store.chat is None:
+            raise RuntimeError("ChatStore is not initialized")
         await store.chat.set_title(session_id, title)
     except Exception:
         logger.exception("failed to persist title for session %s", session_id)

--- a/src/discord_bot/bot.py
+++ b/src/discord_bot/bot.py
@@ -372,7 +372,8 @@ class DiscordBot:
     async def _load_conversation(self, thread_id: str) -> list[dict[str, Any]]:
         """Load a session's full message history in agent.chat() format."""
         store = self._executor._ctx._store
-        assert store is not None and store.chat is not None
+        if store is None or store.chat is None:
+            raise RuntimeError("Store or ChatStore is not initialized")
 
         messages: list[dict[str, Any]] = []
         cursor: str | None = None

--- a/src/scheduler/schedule.py
+++ b/src/scheduler/schedule.py
@@ -86,7 +86,8 @@ class ScheduleConfig:
 
         match self.type:
             case "interval" | "hourly":
-                assert self.interval is not None
+                if self.interval is None:
+                    raise RuntimeError("interval is not set for interval/hourly schedule")
                 return from_time + self.interval
 
             case "daily":

--- a/src/store/store.py
+++ b/src/store/store.py
@@ -63,7 +63,8 @@ class Store:
             self._db = None
 
     async def _create_schema(self) -> None:
-        assert self._db is not None
+        if self._db is None:
+            raise RuntimeError("Database connection not initialized")
         await self._db.executescript(
             """
             CREATE TABLE IF NOT EXISTS agent_documents (
@@ -346,7 +347,8 @@ class ChatStore:
         )
         await self._db.commit()
         existing = await self.get_session(rkey)
-        assert existing is not None
+        if existing is None:
+            raise RuntimeError("ensure_session failed: session not found after create")
         return existing
 
     async def list_sessions(

--- a/src/tools/custom.py
+++ b/src/tools/custom.py
@@ -70,7 +70,8 @@ class CustomToolManager:
         cursor: str | None = None
 
         while True:
-            assert self._store.documents is not None
+            if self._store.documents is None:
+            raise RuntimeError("DocumentStore is not initialized")
             resp = await self._store.documents.list(limit=100, cursor=cursor)
             documents = resp.get("documents", [])
 
@@ -152,7 +153,8 @@ class CustomToolManager:
         """Create a new custom tool in the local store."""
         rkey = f"{TOOL_RKEY_PREFIX}{tool.name}"
         content = json.dumps(tool.to_dict())
-        assert self._store.documents is not None
+        if self._store.documents is None:
+            raise RuntimeError("DocumentStore is not initialized")
 
         try:
             await self._store.documents.create(rkey, content)
@@ -185,7 +187,8 @@ class CustomToolManager:
 
         rkey = f"{TOOL_RKEY_PREFIX}{name}"
         content = json.dumps(tool.to_dict())
-        assert self._store.documents is not None
+        if self._store.documents is None:
+            raise RuntimeError("DocumentStore is not initialized")
         await self._store.documents.update(rkey, content)
         return f"Custom tool '{name}' updated." + (
             " Approval reset." if resets_approval else ""
@@ -198,7 +201,8 @@ class CustomToolManager:
             return f"Custom tool '{name}' not found."
 
         rkey = f"{TOOL_RKEY_PREFIX}{name}"
-        assert self._store.documents is not None
+        if self._store.documents is None:
+            raise RuntimeError("DocumentStore is not initialized")
         try:
             await self._store.documents.delete(rkey)
         except Exception:
@@ -216,7 +220,8 @@ class CustomToolManager:
         tool.approved = True
         rkey = f"{TOOL_RKEY_PREFIX}{name}"
         content = json.dumps(tool.to_dict())
-        assert self._store.documents is not None
+        if self._store.documents is None:
+            raise RuntimeError("DocumentStore is not initialized")
         await self._store.documents.update(rkey, content)
         return f"Custom tool '{name}' approved."
 
@@ -229,6 +234,7 @@ class CustomToolManager:
         tool.approved = False
         rkey = f"{TOOL_RKEY_PREFIX}{name}"
         content = json.dumps(tool.to_dict())
-        assert self._store.documents is not None
+        if self._store.documents is None:
+            raise RuntimeError("DocumentStore is not initialized")
         await self._store.documents.update(rkey, content)
         return f"Custom tool '{name}' approval revoked."

--- a/src/tools/definitions/notes.py
+++ b/src/tools/definitions/notes.py
@@ -8,7 +8,8 @@ logger = logging.getLogger(__name__)
 
 async def _get_note(ctx: ToolContext, rkey: str) -> dict[str, Any] | None:
     """Fetch a note by rkey, returning None if not found."""
-    assert ctx.store.documents is not None
+    if ctx.store.documents is None:
+        raise RuntimeError("DocumentStore is not initialized")
     try:
         return await ctx.store.documents.get(rkey)
     except Exception as e:
@@ -74,7 +75,8 @@ async def note_upsert(
         return "Error: content is required"
 
     docs = ctx.store.documents
-    assert docs is not None
+    if docs is None:
+        raise RuntimeError("DocumentStore is not initialized")
 
     existed = False
     existing_content = ""
@@ -169,7 +171,8 @@ async def note_list(
     if limit > 100:
         limit = 100
 
-    assert ctx.store.documents is not None
+    if ctx.store.documents is None:
+        raise RuntimeError("DocumentStore is not initialized")
     resp = await ctx.store.documents.list(limit=limit, cursor=cursor)
 
     documents = resp.get("documents", [])

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -260,9 +260,12 @@ const params = {params_json};
     ) -> dict[str, Any]:
         """Shared logic for processing deno subprocess output."""
 
-        assert process.stdin is not None
-        assert process.stdout is not None
-        assert process.stderr is not None
+        if process.stdin is None:
+            raise RuntimeError("Process stdin is not available")
+        if process.stdout is None:
+            raise RuntimeError("Process stdout is not available")
+        if process.stderr is None:
+            raise RuntimeError("Process stderr is not available")
 
         outputs: list[Any] = []
         debug_messages: list[str] = []

--- a/tests/test_pr07_assert_replacement.py
+++ b/tests/test_pr07_assert_replacement.py
@@ -1,0 +1,45 @@
+"""Tests for PR 7: Replace assert with explicit validation."""
+
+import pytest
+
+from src.agent.agent import Agent
+
+
+def test_agent_raises_on_empty_api_key():
+    """Agent with empty model_api_key should raise ValueError."""
+    with pytest.raises(ValueError, match="model_api_key"):
+        Agent(model_api="anthropic", model_name="x", model_api_key="")
+
+
+def test_agent_raises_on_none_api_key():
+    """Agent with None model_api_key should raise ValueError."""
+    with pytest.raises(ValueError, match="model_api_key"):
+        Agent(model_api="anthropic", model_name="x", model_api_key=None)
+
+
+def test_agent_openapi_raises_without_endpoint():
+    """Agent with openapi but no endpoint should raise ValueError."""
+    with pytest.raises(ValueError, match="model_endpoint"):
+        Agent(model_api="openapi", model_name="x", model_api_key="key")
+
+
+def test_no_asserts_in_target_files():
+    """No assert statements should remain in the target files."""
+    import subprocess
+    files = [
+        "src/agent/agent.py",
+        "src/agent/conversation.py",
+        "src/store/store.py",
+        "src/tools/custom.py",
+        "src/tools/definitions/notes.py",
+        "src/tools/executor.py",
+        "src/discord_bot/bot.py",
+        "src/scheduler/schedule.py",
+    ]
+    for f in files:
+        result = subprocess.run(
+            ["grep", "-n", "^[[:space:]]*assert ", f],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0, f"Found assert in {f}:\n{result.stdout}"


### PR DESCRIPTION
## High #7 — assert used for control flow; vanishes under python -O

All `assert` statements used for runtime validation have been replaced with `if not <condition>: raise RuntimeError/ValueError` with descriptive messages.

## Files changed
- `agent.py` — model_api_key, model_endpoint validation (ValueError)
- `conversation.py` — ChatStore initialization checks (RuntimeError)
- `store.py` — _db and ensure_session checks (RuntimeError)
- `custom.py` — DocumentStore initialization checks (RuntimeError)
- `notes.py` — DocumentStore initialization checks (RuntimeError)
- `executor.py` — process stdin/stdout/stderr checks (RuntimeError)
- `bot.py` — Store/ChatStore initialization check (RuntimeError)
- `schedule.py` — interval check (RuntimeError)

## Acceptance Criteria
- [x] AC.1: No `assert` statements for runtime validation remain in the target files
- [x] AC.2: Each former assert site now raises RuntimeError or ValueError with a descriptive message
- [x] AC.3: Running `python -O` does not cause silent failures

## Dependencies
Soft deps on PR 1, PR 2 (both modify `agent.py`). Can merge in any order but may conflict if merged simultaneously.