### PR TITLE
PR 8: Validate sub-agent key/provider consistency at startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import click
 import httpx
 
 from src.agent.agent import Agent
+from src.agent.config_utils import resolve_sub_agent_key as _resolve_sub_agent_key
 from src.agent.prompt import build_system_prompt
 from src.config import CONFIG
 from src.tools.executor import ToolExecutor
@@ -59,7 +60,12 @@ def build_services(
 
     from src.agent.llm import SubAgentLLM
 
-    sub_api_key = CONFIG.sub_model_api_key or CONFIG.model_api_key
+    sub_api_key = _resolve_sub_agent_key(
+        model_api=CONFIG.model_api,
+        model_api_key=CONFIG.model_api_key,
+        sub_model_api=CONFIG.sub_model_api,
+        sub_model_api_key=CONFIG.sub_model_api_key,
+    )
     llm_client = None
     if sub_api_key:
         llm_client = SubAgentLLM(

--- a/src/agent/config_utils.py
+++ b/src/agent/config_utils.py
@@ -1,0 +1,33 @@
+"""Shared configuration helpers for sub-agent key resolution."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_sub_agent_key(
+    model_api: str,
+    model_api_key: str | None,
+    sub_model_api: str,
+    sub_model_api_key: str | None,
+) -> str | None:
+    """Resolve the sub-agent API key with provider-consistency validation.
+
+    - If providers match and sub_model_api_key is empty, fall back to model_api_key.
+    - If providers differ and sub_model_api_key is empty, log a warning and
+      return None (graceful degradation — no sub-agent wired).
+    - If sub_model_api_key is set, return it as-is.
+    """
+    if sub_model_api_key:
+        return sub_model_api_key
+    if sub_model_api == model_api:
+        # Same provider — safe to reuse the main key
+        return model_api_key
+    # Different provider, no sub key — don't silently send the wrong key
+    logger.warning(
+        "Sub-agent provider (%s) differs from main provider (%s) but no "
+        "sub_model_api_key is set. Sub-agent LLM will not be wired.",
+        sub_model_api,
+        model_api,
+    )
+    return None

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -41,8 +41,14 @@ class VictrolaApp(App):
             from src.agent.conversation import ConversationManager
             from src.agent.llm import SubAgentLLM
             from src.config import CONFIG
+            from src.agent.config_utils import resolve_sub_agent_key as _resolve_sub_agent_key
 
-            sub_api_key = CONFIG.sub_model_api_key or CONFIG.model_api_key
+            sub_api_key = _resolve_sub_agent_key(
+                model_api=CONFIG.model_api,
+                model_api_key=CONFIG.model_api_key,
+                sub_model_api=CONFIG.sub_model_api,
+                sub_model_api_key=CONFIG.sub_model_api_key,
+            )
             llm_client = None
             if sub_api_key:
                 llm_client = SubAgentLLM(

--- a/tests/test_pr08_sub_agent_key.py
+++ b/tests/test_pr08_sub_agent_key.py
@@ -1,0 +1,74 @@
+"""Tests for PR 8: Validate sub-agent key/provider consistency."""
+
+import pytest
+import logging
+from src.agent.config_utils import resolve_sub_agent_key as _resolve_sub_agent_key
+
+
+def test_same_provider_falls_back_to_main_key():
+    """When providers match and sub key is empty, fall back to main key."""
+    result = _resolve_sub_agent_key(
+        model_api="anthropic",
+        model_api_key="main-key",
+        sub_model_api="anthropic",
+        sub_model_api_key=None,
+    )
+    assert result == "main-key"
+
+
+def test_same_provider_falls_back_on_empty_string():
+    """Empty string sub key should also fall back to main key."""
+    result = _resolve_sub_agent_key(
+        model_api="anthropic",
+        model_api_key="main-key",
+        sub_model_api="anthropic",
+        sub_model_api_key="",
+    )
+    assert result == "main-key"
+
+
+def test_different_provider_no_sub_key_returns_none(caplog):
+    """When providers differ and sub key is empty, return None with a warning."""
+    with caplog.at_level(logging.WARNING):
+        result = _resolve_sub_agent_key(
+            model_api="anthropic",
+            model_api_key="main-key",
+            sub_model_api="openai",
+            sub_model_api_key=None,
+        )
+    assert result is None
+    assert any("differs from main provider" in r.message for r in caplog.records)
+
+
+def test_different_provider_with_sub_key_returns_it():
+    """When sub key is set, return it regardless of provider mismatch."""
+    result = _resolve_sub_agent_key(
+        model_api="anthropic",
+        model_api_key="main-key",
+        sub_model_api="openai",
+        sub_model_api_key="sub-key",
+    )
+    assert result == "sub-key"
+
+
+def test_same_provider_with_sub_key_returns_it():
+    """When sub key is set and providers match, return the sub key."""
+    result = _resolve_sub_agent_key(
+        model_api="anthropic",
+        model_api_key="main-key",
+        sub_model_api="anthropic",
+        sub_model_api_key="sub-key",
+    )
+    assert result == "sub-key"
+
+
+def test_different_provider_empty_string_returns_none(caplog):
+    """Empty string sub key with different provider should return None."""
+    with caplog.at_level(logging.WARNING):
+        result = _resolve_sub_agent_key(
+            model_api="anthropic",
+            model_api_key="main-key",
+            sub_model_api="openapi",
+            sub_model_api_key="",
+        )
+    assert result is None


### PR DESCRIPTION
## High #8 — Wrong API key silently sent to different provider

`sub_api_key = CONFIG.sub_model_api_key or CONFIG.model_api_key` silently sends the main model's key to a different provider if misconfigured.

## Changes
- Extract `resolve_sub_agent_key()` into `src/agent/config_utils.py` (shared module, avoids importing `main.py` in tests)
- If providers differ and sub key is empty: log warning and return `None` (graceful degradation — no sub-agent wired)
- If providers match and sub key is empty: fall back to `model_api_key` (backward compatible)
- Update `build_services` in `main.py` to use the helper
- Update `app.py` `on_mount` to use the helper (removes duplicated logic)

## Acceptance Criteria
- [x] AC.1: When `sub_model_api` differs from `model_api` and `sub_model_api_key` is empty, the sub-agent LLM is not wired and a warning is logged
- [x] AC.2: When providers match and only `sub_model_api_key` is empty, the fallback to `model_api_key` still works
- [x] AC.3: No API key is sent to a provider that doesn't match it

## Dependencies
None.