### PR TITLE
PR 9: Validate rkey in notes and custom tools

### DIFF
--- a/src/tools/custom.py
+++ b/src/tools/custom.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -11,6 +12,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 TOOL_RKEY_PREFIX = "customtool:"
+
+# Valid tool name pattern: alphanumeric with -_. (no path separators, no colons)
+_TOOL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9\-_.]{1,128}$")
 
 
 @dataclass
@@ -150,6 +154,12 @@ class CustomToolManager:
 
     async def create_tool(self, tool: CustomTool) -> str:
         """Create a new custom tool in the local store."""
+        if not _TOOL_NAME_PATTERN.match(tool.name):
+            return (
+                f"Error: tool name '{tool.name}' is invalid. "
+                "Allowed: alphanumeric, dash, underscore, dot (1-128 chars)"
+            )
+
         rkey = f"{TOOL_RKEY_PREFIX}{tool.name}"
         content = json.dumps(tool.to_dict())
         assert self._store.documents is not None

--- a/src/tools/definitions/notes.py
+++ b/src/tools/definitions/notes.py
@@ -1,9 +1,30 @@
 import logging
+import re
 from typing import Any
 
 from src.tools.registry import TOOL_REGISTRY, ToolContext, ToolParameter
 
 logger = logging.getLogger(__name__)
+
+# Valid rkey pattern: 1-512 chars, alphanumeric with -_.~:
+_RKEY_PATTERN = re.compile(r"^[A-Za-z0-9\-_.~:]{1,512}$")
+
+# Reserved prefix that collides with custom tool storage
+_RESERVED_RKEY_PREFIX = "customtool:"
+
+
+def _validate_rkey(rkey: str) -> str | None:
+    """Validate an rkey. Returns an error message string if invalid, None if valid."""
+    if not rkey:
+        return "Error: rkey is required"
+    if rkey.startswith(_RESERVED_RKEY_PREFIX):
+        return f"Error: rkey '{rkey}' uses reserved prefix 'customtool:' — choose a different name"
+    if not _RKEY_PATTERN.match(rkey):
+        return (
+            f"Error: rkey '{rkey}' contains invalid characters or is too long. "
+            "Allowed: alphanumeric, dash, underscore, dot, tilde, colon (1-512 chars)"
+        )
+    return None
 
 
 async def _get_note(ctx: ToolContext, rkey: str) -> dict[str, Any] | None:
@@ -73,6 +94,10 @@ async def note_upsert(
     if not content:
         return "Error: content is required"
 
+    rkey_error = _validate_rkey(rkey)
+    if rkey_error:
+        return rkey_error
+
     docs = ctx.store.documents
     assert docs is not None
 
@@ -133,6 +158,10 @@ async def note_get(ctx: ToolContext, rkeys: list[str]) -> str:
 
     parts: list[str] = []
     for rkey in rkeys:
+        rkey_error = _validate_rkey(rkey)
+        if rkey_error:
+            parts.append(f"Note '{rkey}': {rkey_error}")
+            continue
         doc = await _get_note(ctx, rkey)
         if doc is not None:
             parts.append(f"Note '{doc.get('rkey', rkey)}':\n\n{doc.get('content', '')}")

--- a/tests/test_pr09_rkey_validation.py
+++ b/tests/test_pr09_rkey_validation.py
@@ -1,0 +1,143 @@
+"""Tests for PR 9: Validate rkey in notes and custom tools."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.tools.definitions.notes import _validate_rkey, note_upsert
+from src.tools.custom import CustomTool, CustomToolManager
+
+
+# --- _validate_rkey tests ---
+
+def test_validate_rkey_valid():
+    assert _validate_rkey("self") is None
+    assert _validate_rkey("operator") is None
+    assert _validate_rkey("skill:my-skill") is None
+    assert _validate_rkey("task_1.0") is None
+    assert _validate_rkey("note~with~tilde") is None
+
+
+def test_validate_rkey_rejects_path_traversal():
+    result = _validate_rkey("../../etc/passwd")
+    assert result is not None
+    assert "invalid" in result.lower()
+
+
+def test_validate_rkey_rejects_customtool_prefix():
+    result = _validate_rkey("customtool:evil")
+    assert result is not None
+    assert "customtool" in result.lower()
+    assert "reserved" in result.lower()
+
+
+def test_validate_rkey_rejects_empty():
+    result = _validate_rkey("")
+    assert result is not None
+    assert "required" in result.lower()
+
+
+def test_validate_rkey_rejects_slashes():
+    result = _validate_rkey("foo/bar")
+    assert result is not None
+    assert "invalid" in result.lower()
+
+
+def test_validate_rkey_rejects_newlines():
+    result = _validate_rkey("foo\nbar")
+    assert result is not None
+    assert "invalid" in result.lower()
+
+
+def test_validate_rkey_rejects_too_long():
+    result = _validate_rkey("a" * 513)
+    assert result is not None
+    assert "invalid" in result.lower()
+
+
+# --- note_upsert integration test ---
+
+@pytest.mark.asyncio
+async def test_note_upsert_rejects_invalid_rkey():
+    """note_upsert should reject path-traversal rkeys without calling the store."""
+    ctx = MagicMock()
+    ctx.store.documents = MagicMock()
+    ctx.store.documents.get = AsyncMock()
+
+    result = await note_upsert(ctx, rkey="../../etc/passwd", content="test")
+
+    assert "Error" in result
+    assert "invalid" in result.lower()
+    ctx.store.documents.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_note_upsert_rejects_customtool_prefix():
+    """note_upsert should reject customtool: prefix."""
+    ctx = MagicMock()
+    ctx.store.documents = MagicMock()
+    ctx.store.documents.get = AsyncMock()
+
+    result = await note_upsert(ctx, rkey="customtool:evil", content="test")
+
+    assert "Error" in result
+    assert "reserved" in result.lower()
+
+
+# --- CustomToolManager.create_tool tests ---
+
+@pytest.mark.asyncio
+async def test_create_tool_rejects_invalid_name():
+    """create_tool should reject names with path separators."""
+    store = MagicMock()
+    executor = MagicMock()
+    manager = CustomToolManager(store=store, executor=executor, secret_manager=None)
+
+    tool = CustomTool(
+        name="../../evil",
+        description="bad",
+        parameters={},
+        code="output('hi')",
+    )
+
+    result = await manager.create_tool(tool)
+    assert "Error" in result
+    assert "invalid" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_create_tool_rejects_name_with_colon():
+    """create_tool should reject names with colons (would collide with rkey prefix)."""
+    store = MagicMock()
+    executor = MagicMock()
+    manager = CustomToolManager(store=store, executor=executor, secret_manager=None)
+
+    tool = CustomTool(
+        name="customtool:fake",
+        description="bad",
+        parameters={},
+        code="output('hi')",
+    )
+
+    result = await manager.create_tool(tool)
+    assert "Error" in result
+    assert "invalid" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_create_tool_accepts_valid_name():
+    """create_tool should accept valid names."""
+    store = MagicMock()
+    store.documents = MagicMock()
+    store.documents.create = AsyncMock()
+    executor = MagicMock()
+    manager = CustomToolManager(store=store, executor=executor, secret_manager=None)
+
+    tool = CustomTool(
+        name="my_tool.v2",
+        description="good",
+        parameters={},
+        code="output('hi')",
+    )
+
+    result = await manager.create_tool(tool)
+    assert "created" in result.lower()


### PR DESCRIPTION
## High #9 — Unvalidated rkey allows path traversal and prefix collision

`rkey` in `note_upsert` was not validated. A malicious agent could use path separators, newlines, or the `customtool:` prefix (colliding with custom tool storage).

## Changes
- Add `_validate_rkey()` in `notes.py`: checks `^[A-Za-z0-9\-_.~:]{1,512}$` and rejects `customtool:` prefix
- Call validation in `note_upsert` and `note_get` before store operations
- Add tool name validation in `CustomToolManager.create_tool` using `^[A-Za-z0-9\-_.]{1,128}$` (rejects path separators, colons)

## Acceptance Criteria
- [x] AC.1: `note_upsert` rejects rkeys that don't match `^[A-Za-z0-9\-_.~:]{1,512}$`
- [x] AC.2: `note_upsert` rejects rkeys starting with `customtool:`
- [x] AC.3: `CustomToolManager.create_tool` rejects tool names containing path separators or non-alphanumeric characters (except `-_.`)
- [x] AC.4: Error messages are clear and actionable

## Dependencies
None.