### PR TITLE
PR 10: Add Discord operator allowlist

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -36,6 +36,13 @@ class Config(BaseSettings):
     discord_sessions_channel: str = "victrola-sessions"
     """name of the text channel the Discord bot watches for chat sessions"""
 
+    discord_allowed_user_ids: str = ""
+    """comma-separated Discord user IDs allowed to drive the agent via Discord.
+    If empty, all users are allowed (with a startup warning)."""
+
+    discord_chat_timeout_seconds: int = 300
+    """timeout in seconds for agent.chat() calls from the Discord bot"""
+
     # exa web search
     exa_api_key: str = ""
     """api key for Exa web search"""

--- a/src/discord_bot/bot.py
+++ b/src/discord_bot/bot.py
@@ -208,6 +208,23 @@ class DiscordBot:
         self._agent = agent
         self._executor = executor
 
+        # Parse the allowlist of Discord user IDs
+        raw_ids = CONFIG.discord_allowed_user_ids.strip()
+        if raw_ids:
+            self._allowed_user_ids: set[int] | None = {
+                int(uid.strip()) for uid in raw_ids.split(",") if uid.strip()
+            }
+            logger.info(
+                "Discord allowlist active: %d user(s) permitted",
+                len(self._allowed_user_ids),
+            )
+        else:
+            self._allowed_user_ids = None
+            logger.warning(
+                "DISCORD_ALLOWED_USER_IDS is not set — all Discord users can "
+                "drive the agent. Set this in .env to restrict access."
+            )
+
         intents = discord.Intents.default()
         intents.message_content = True  # privileged; must also be enabled on Dev Portal
         self._client = discord.Client(intents=intents)
@@ -235,6 +252,16 @@ class DiscordBot:
         # Ignore self and other bots
         if message.author == self._client.user or message.author.bot:
             return
+
+        # Check allowlist if configured
+        if self._allowed_user_ids is not None:
+            if message.author.id not in self._allowed_user_ids:
+                logger.info(
+                    "Ignoring message from non-allowlisted user %s (id=%s)",
+                    message.author,
+                    message.author.id,
+                )
+                return
 
         thread = await self._resolve_thread(message)
         if thread is None:

--- a/src/tools/custom.py
+++ b/src/tools/custom.py
@@ -78,7 +78,7 @@ class CustomToolManager:
 
         while True:
             if self._store.documents is None:
-            raise RuntimeError("DocumentStore is not initialized")
+                raise RuntimeError("DocumentStore is not initialized")
             resp = await self._store.documents.list(limit=100, cursor=cursor)
             documents = resp.get("documents", [])
 

--- a/tests/test_pr10_discord_allowlist.py
+++ b/tests/test_pr10_discord_allowlist.py
@@ -1,0 +1,59 @@
+"""Tests for PR 10: Add Discord operator allowlist."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.config import CONFIG
+
+
+def test_config_has_discord_allowed_user_ids():
+    """Config should have discord_allowed_user_ids field defaulting to empty string."""
+    assert hasattr(CONFIG, "discord_allowed_user_ids")
+    assert CONFIG.discord_allowed_user_ids == ""
+
+
+def test_config_has_discord_chat_timeout():
+    """Config should have discord_chat_timeout_seconds field."""
+    assert hasattr(CONFIG, "discord_chat_timeout_seconds")
+    assert CONFIG.discord_chat_timeout_seconds == 300
+
+
+def test_bot_parses_allowlist():
+    """DiscordBot should parse comma-separated user IDs into a set."""
+    from src.discord_bot.bot import DiscordBot
+
+    with patch.object(CONFIG, "discord_allowed_user_ids", "123,456,789"):
+        bot = DiscordBot(
+            token="fake",
+            channel_name="test",
+            agent=MagicMock(),
+            executor=MagicMock(),
+        )
+    assert bot._allowed_user_ids == {123, 456, 789}
+
+
+def test_bot_allowlist_none_when_empty():
+    """DiscordBot should set _allowed_user_ids to None when config is empty."""
+    from src.discord_bot.bot import DiscordBot
+
+    with patch.object(CONFIG, "discord_allowed_user_ids", ""):
+        bot = DiscordBot(
+            token="fake",
+            channel_name="test",
+            agent=MagicMock(),
+            executor=MagicMock(),
+        )
+    assert bot._allowed_user_ids is None
+
+
+def test_bot_has_no_chat_lock():
+    """DiscordBot should not have _chat_lock attribute."""
+    from src.discord_bot.bot import DiscordBot
+
+    bot = DiscordBot(
+        token="fake",
+        channel_name="test",
+        agent=MagicMock(),
+        executor=MagicMock(),
+    )
+    assert not hasattr(bot, "_chat_lock")


### PR DESCRIPTION
## High #10 — Anyone with channel access can drive the agent

Anyone with channel access could drive the agent and invoke arbitrary tools.

## Changes
- Add `discord_allowed_user_ids` config field (comma-separated Discord user IDs)
- Add `discord_chat_timeout_seconds` config field (for PR 11)
- Parse allowlist in `DiscordBot.__init__`
- Check `message.author.id` against allowlist in `on_message`
- Non-allowlisted users are ignored and logged
- Empty allowlist warns at startup but allows all (backward compatible)
- Also removes `bot._chat_lock` (per PR 1's plan — bot no longer needs its own lock)

## Acceptance Criteria
- [x] AC.1: When `DISCORD_ALLOWED_USER_IDS` is set, only messages from those user IDs are processed
- [x] AC.2: Messages from non-allowlisted users are ignored and logged
- [x] AC.3: When `DISCORD_ALLOWED_USER_IDS` is empty (default), a warning is logged at startup and all messages are processed

## Dependencies
None (includes `_chat_lock` removal from PR 1's plan since this branches from main).