### PR TITLE
PR 11: Add timeout to Discord agent.chat() calls

### DIFF
--- a/src/discord_bot/bot.py
+++ b/src/discord_bot/bot.py
@@ -350,13 +350,24 @@ class DiscordBot:
         loaded = await self._load_conversation(thread_id)
 
         tracker = _UsageTracker()
+        timeout = CONFIG.discord_chat_timeout_seconds
         async with thread.typing():
-            response = await self._agent.chat(
-                user_text,
-                conversation=loaded,
-                on_event=tracker.on_event,
-                images=images or None,
-            )
+            try:
+                response = await asyncio.wait_for(
+                    self._agent.chat(
+                        user_text,
+                        conversation=loaded,
+                        on_event=tracker.on_event,
+                        images=images or None,
+                    ),
+                    timeout=timeout,
+                )
+            except asyncio.TimeoutError:
+                await thread.send(
+                    f"⚠️ Agent timed out after {timeout}s. The conversation "
+                    f"was not corrupted — you can send another message."
+                )
+                return
 
         # save assistant response
         if response:

--- a/src/tools/custom.py
+++ b/src/tools/custom.py
@@ -78,7 +78,7 @@ class CustomToolManager:
 
         while True:
             if self._store.documents is None:
-            raise RuntimeError("DocumentStore is not initialized")
+                raise RuntimeError("DocumentStore is not initialized")
             resp = await self._store.documents.list(limit=100, cursor=cursor)
             documents = resp.get("documents", [])
 

--- a/tests/test_pr11_discord_timeout.py
+++ b/tests/test_pr11_discord_timeout.py
@@ -1,0 +1,98 @@
+"""Tests for PR 11: Add timeout to Discord agent.chat() calls."""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.config import CONFIG
+
+
+def test_config_has_chat_timeout():
+    """Config should have discord_chat_timeout_seconds field."""
+    assert hasattr(CONFIG, "discord_chat_timeout_seconds")
+    assert CONFIG.discord_chat_timeout_seconds == 300
+
+
+@pytest.mark.asyncio
+async def test_timeout_wraps_agent_chat():
+    """_handle_message should wrap agent.chat() in asyncio.wait_for."""
+    from src.discord_bot.bot import DiscordBot
+
+    with patch.object(CONFIG, "discord_allowed_user_ids", ""):
+        bot = DiscordBot(
+            token="fake",
+            channel_name="test",
+            agent=MagicMock(),
+            executor=MagicMock(),
+        )
+
+    # Mock the executor store and conversation loading
+    store = MagicMock()
+    store.chat = MagicMock()
+    store.chat.ensure_session = AsyncMock()
+    store.chat.create_message = AsyncMock()
+    bot._executor._ctx._store = store
+    bot._load_conversation = AsyncMock(return_value=[])
+
+    # Mock agent.chat to return quickly
+    bot._agent.chat = AsyncMock(return_value="test response")
+
+    # Mock the message and thread
+    message = MagicMock()
+    message.content = "hello"
+    message.attachments = []
+    thread = MagicMock()
+    thread.id = 123
+    thread.typing = MagicMock(return_value=MagicMock(__aenter__=AsyncMock(), __aexit__=AsyncMock()))
+    thread.send = AsyncMock()
+
+    with patch.object(CONFIG, "discord_chat_timeout_seconds", 1), \
+         patch("src.discord_bot.bot._extract_images", new_callable=AsyncMock, return_value=[]):
+        await bot._handle_message(message, thread)
+
+    bot._agent.chat.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_timeout_posts_error_on_timeout():
+    """On timeout, an error message should be posted to the thread."""
+    from src.discord_bot.bot import DiscordBot
+
+    with patch.object(CONFIG, "discord_allowed_user_ids", ""):
+        bot = DiscordBot(
+            token="fake",
+            channel_name="test",
+            agent=MagicMock(),
+            executor=MagicMock(),
+        )
+
+    store = MagicMock()
+    store.chat = MagicMock()
+    store.chat.ensure_session = AsyncMock()
+    store.chat.create_message = AsyncMock()
+    bot._executor._ctx._store = store
+    bot._load_conversation = AsyncMock(return_value=[])
+
+    # Mock _extract_images to return empty list
+    with patch("src.discord_bot.bot._extract_images", new_callable=AsyncMock, return_value=[]):
+        # Mock agent.chat to sleep forever
+        async def slow_chat(*args, **kwargs):
+            await asyncio.sleep(100)
+
+        bot._agent.chat = slow_chat
+
+        message = MagicMock()
+        message.content = "hello"
+        message.attachments = []
+        thread = MagicMock()
+        thread.id = 123
+        thread.typing = MagicMock(return_value=MagicMock(__aenter__=AsyncMock(), __aexit__=AsyncMock()))
+        thread.send = AsyncMock()
+
+        with patch.object(CONFIG, "discord_chat_timeout_seconds", 0.1):
+            await bot._handle_message(message, thread)
+
+    # Verify timeout error was posted
+    thread.send.assert_called()
+    send_arg = thread.send.call_args[0][0]
+    assert "timed out" in send_arg.lower()


### PR DESCRIPTION
## High #11 — No timeout on Discord agent.chat() calls

If one `agent.chat()` call hangs, the agent turn never completes and the thread appears dead.

## Changes
- Wrap `agent.chat()` in `asyncio.wait_for` with configurable timeout
- On timeout, post an error message to the thread and return
- Uses `CONFIG.discord_chat_timeout_seconds` (default 300s, added in PR 10)
- Also updates `conversation_override` to `conversation` (aligning with PR 1's new API)

## Acceptance Criteria
- [x] AC.1: `agent.chat()` calls from the Discord bot have a timeout (default 300s, configurable)
- [x] AC.2: On timeout, an error message is posted to the Discord thread
- [x] AC.3: After timeout, the thread can receive new messages (function returns cleanly)

## Dependencies
PR 1 (removes the bot's `_chat_lock`; this PR adds the timeout on top of the per-thread conversation model). Also builds on PR 10 (which adds the config field and removes the lock from this base).