### PR TITLE
PR 12: Fix scheduler — advance last_run after callback success

### DIFF
--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -24,6 +24,7 @@ class ScheduledTask:
 
     # computed at runtime, not persisted
     _config: ScheduleConfig | None = field(default=None, repr=False, compare=False)
+    _retry_count: int = field(default=0, repr=False, compare=False)
 
     @property
     def config(self) -> ScheduleConfig:
@@ -184,9 +185,9 @@ class Scheduler:
             if last.tzinfo is None:
                 last = last.replace(tzinfo=timezone.utc)
         else:
-            # never run, no last_run — initialize it to now and skip this tick
-            task.last_run = now.isoformat()
-            return False
+            # never run — last_run is initialized in create_task, but if
+            # we encounter a task without it, treat it as due now
+            return True
 
         next_run = task.config.next_run(last)
         return now >= next_run
@@ -194,10 +195,6 @@ class Scheduler:
     async def _fire(self, task: ScheduledTask, now: datetime) -> None:
         """Execute a scheduled task."""
         logger.info("Firing schedule '%s': %s", task.name, task.prompt[:100])
-
-        # update last_run immediately to prevent double-firing
-        task.last_run = now.isoformat()
-        self._save()
 
         if self._on_fire:
             try:
@@ -207,7 +204,30 @@ class Scheduler:
                     task.name,
                     (response[:200] if response else "(empty)"),
                 )
+                # Success — advance last_run and reset retry count
+                task.last_run = now.isoformat()
+                task._retry_count = 0
+                self._save()
             except Exception:
-                logger.exception("Schedule '%s' callback failed", task.name)
+                task._retry_count += 1
+                if task._retry_count >= 3:
+                    logger.warning(
+                        "Schedule '%s' failed %d consecutive times — "
+                        "advancing last_run to prevent infinite retries",
+                        task.name,
+                        task._retry_count,
+                    )
+                    task.last_run = now.isoformat()
+                    task._retry_count = 0
+                    self._save()
+                else:
+                    logger.exception(
+                        "Schedule '%s' callback failed (attempt %d/3) — "
+                        "will retry on next tick",
+                        task.name,
+                        task._retry_count,
+                    )
         else:
             logger.info("Schedule '%s' fired (no callback wired)", task.name)
+            task.last_run = now.isoformat()
+            self._save()

--- a/tests/test_pr12_scheduler_retry.py
+++ b/tests/test_pr12_scheduler_retry.py
@@ -1,0 +1,91 @@
+"""Tests for PR 12: Fix scheduler — advance last_run after callback success."""
+
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+from src.scheduler.scheduler import Scheduler, ScheduledTask
+
+
+@pytest.fixture
+def scheduler(tmp_path):
+    """Create a scheduler with a temp path."""
+    s = Scheduler(path=tmp_path / "schedules.json")
+    s._on_fire = AsyncMock(return_value="ok")
+    return s
+
+
+@pytest.mark.asyncio
+async def test_last_run_advanced_on_success(scheduler):
+    """last_run should be advanced after callback succeeds."""
+    now = datetime.now(timezone.utc)
+    task = ScheduledTask(name="test", schedule="interval:1h", prompt="hello")
+    task.last_run = (now - timedelta(hours=2)).isoformat()
+
+    await scheduler._fire(task, now)
+
+    assert task.last_run == now.isoformat()
+    assert task._retry_count == 0
+
+
+@pytest.mark.asyncio
+async def test_last_run_not_advanced_on_failure(scheduler):
+    """last_run should NOT be advanced when callback fails."""
+    now = datetime.now(timezone.utc)
+    original_last_run = (now - timedelta(hours=2)).isoformat()
+    task = ScheduledTask(name="test", schedule="interval:1h", prompt="hello")
+    task.last_run = original_last_run
+
+    scheduler._on_fire = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await scheduler._fire(task, now)
+
+    assert task.last_run == original_last_run  # unchanged
+    assert task._retry_count == 1
+
+
+@pytest.mark.asyncio
+async def test_last_run_advanced_after_3_failures(scheduler):
+    """After 3 consecutive failures, last_run should be advanced."""
+    now = datetime.now(timezone.utc)
+    original_last_run = (now - timedelta(hours=2)).isoformat()
+    task = ScheduledTask(name="test", schedule="interval:1h", prompt="hello")
+    task.last_run = original_last_run
+
+    scheduler._on_fire = AsyncMock(side_effect=RuntimeError("boom"))
+
+    # Fire 3 times — each should fail without advancing
+    for i in range(3):
+        await scheduler._fire(task, now)
+
+    # After 3 failures, last_run should be advanced
+    assert task.last_run == now.isoformat()
+    assert task._retry_count == 0  # reset after advancing
+
+
+@pytest.mark.asyncio
+async def test_retry_count_resets_on_success(scheduler):
+    """Retry count should reset to 0 after a success."""
+    now = datetime.now(timezone.utc)
+    task = ScheduledTask(name="test", schedule="interval:1h", prompt="hello")
+    task.last_run = (now - timedelta(hours=2)).isoformat()
+    task._retry_count = 2  # had some failures
+
+    await scheduler._fire(task, now)
+
+    assert task._retry_count == 0
+    assert task.last_run == now.isoformat()
+
+
+def test_is_due_no_write_side_effect():
+    """_is_due should not modify task.last_run when it's None."""
+    scheduler = Scheduler(path=MagicMock())
+    task = ScheduledTask(name="test", schedule="interval:1h", prompt="hello")
+    task.last_run = None  # never run
+
+    now = datetime.now(timezone.utc)
+    result = scheduler._is_due(task, now)
+
+    # Should return True (due now) without writing to last_run
+    assert result is True
+    assert task.last_run is None  # unchanged


### PR DESCRIPTION
## High #12 — last_run advanced before callback; failed runs never retried

`last_run` was advanced before the callback ran. If the callback failed, the missed run was never retried.

## Changes
- Move `last_run` advancement to after callback success
- Add `_retry_count` field to `ScheduledTask` (in-memory, not persisted)
- On failure: increment `_retry_count`, do not advance `last_run` (retries next tick)
- After 3 consecutive failures: advance `last_run` to prevent infinite retries and log a warning
- Remove write side-effect from `_is_due` (never-run tasks return `True` instead of initializing `last_run` — `create_task` already sets it)

## Acceptance Criteria
- [x] AC.1: `last_run` is only advanced after the callback succeeds
- [x] AC.2: If the callback raises, `last_run` is not advanced and the task retries on the next tick
- [x] AC.3: After 3 consecutive failures, `last_run` is advanced to prevent infinite retries, and a warning is logged
- [x] AC.4: `_is_due` no longer has a write side effect

## Dependencies
None.