### PR TITLE
PR 13: Restrict update_task to an allowlist of fields

### DIFF
--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -118,23 +118,39 @@ class Scheduler:
         next_run = task.config.next_run(datetime.now(timezone.utc))
         return f"Schedule '{task.name}' created ({task.config}). Next run: {next_run.strftime('%Y-%m-%d %H:%M UTC')}."
 
+    ALLOWED_UPDATE_FIELDS = {"schedule", "prompt", "enabled", "last_run"}
+
     async def update_task(self, name: str, **fields: Any) -> str:
         """Update an existing scheduled task."""
         task = self._tasks.get(name)
         if task is None:
             return f"Schedule '{name}' not found."
 
+        skipped = []
         for key, value in fields.items():
+            if key not in self.ALLOWED_UPDATE_FIELDS:
+                skipped.append(key)
+                continue
             if value is not None:
                 setattr(task, key, value)
 
+        if skipped:
+            logger.warning(
+                "update_task('%s') ignored unknown field(s): %s",
+                name,
+                ", ".join(skipped),
+            )
+
         # re-validate and clear cache if schedule changed
-        if "schedule" in fields:
+        if "schedule" in fields and "schedule" in self.ALLOWED_UPDATE_FIELDS:
             task._config = None
             _ = task.config
 
         self._save()
-        return f"Schedule '{name}' updated."
+        msg = f"Schedule '{name}' updated."
+        if skipped:
+            msg += f" Ignored unknown field(s): {', '.join(skipped)}."
+        return msg
 
     async def delete_task(self, name: str) -> str:
         """Delete a scheduled task."""

--- a/tests/test_pr13_scheduler_allowlist.py
+++ b/tests/test_pr13_scheduler_allowlist.py
@@ -1,0 +1,74 @@
+"""Tests for PR 13: Restrict update_task to an allowlist of fields."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from src.scheduler.scheduler import Scheduler, ScheduledTask
+
+
+@pytest.fixture
+def scheduler_with_task(tmp_path):
+    """Create a scheduler with a test task."""
+    s = Scheduler(path=tmp_path / "schedules.json")
+    task = ScheduledTask(name="test", schedule="interval:1h", prompt="hello")
+    s._tasks["test"] = task
+    return s, task
+
+
+@pytest.mark.asyncio
+async def test_update_task_accepts_allowed_fields(scheduler_with_task):
+    """update_task should accept schedule, prompt, enabled, last_run."""
+    s, task = scheduler_with_task
+
+    result = await s.update_task("test", prompt="new prompt", enabled=False)
+
+    assert task.prompt == "new prompt"
+    assert task.enabled is False
+    assert "updated" in result
+
+
+@pytest.mark.asyncio
+async def test_update_task_rejects_unknown_fields(scheduler_with_task):
+    """update_task should not modify internal attributes via unknown fields."""
+    s, task = scheduler_with_task
+
+    result = await s.update_task("test", _config="malicious")
+
+    assert task._config != "malicious"
+    assert "ignored" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_update_task_skips_none_values(scheduler_with_task):
+    """update_task should skip fields with None values."""
+    s, task = scheduler_with_task
+    original_prompt = task.prompt
+
+    await s.update_task("test", prompt=None)
+
+    assert task.prompt == original_prompt
+
+
+@pytest.mark.asyncio
+async def test_update_task_not_found(tmp_path):
+    """update_task should return not found for unknown task."""
+    s = Scheduler(path=tmp_path / "schedules.json")
+
+    result = await s.update_task("nonexistent", prompt="test")
+
+    assert "not found" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_update_task_does_not_clobber_internal_attrs(scheduler_with_task):
+    """update_task should not allow clobbering internal attributes."""
+    s, task = scheduler_with_task
+
+    await s.update_task(
+        "test",
+        _config="evil",
+        _tasks="evil",
+    )
+
+    assert task._config != "evil"
+    assert not hasattr(task, "_tasks")


### PR DESCRIPTION
## High #13 — update_task accepts arbitrary fields via setattr

`update_task` accepted arbitrary `**fields` and called `setattr` with no allowlist. Could clobber internal attributes like `_config`.

## Changes
- Add `ALLOWED_UPDATE_FIELDS = {schedule, prompt, enabled, last_run}`
- Filter fields to only allowlisted keys
- Log and skip unknown keys
- Return a message noting which fields were ignored

## Acceptance Criteria
- [x] AC.1: `update_task` only accepts keys in `{schedule, prompt, enabled, last_run}`
- [x] AC.2: Unknown keys are logged and ignored
- [x] AC.3: Calling `update_task(name='_config', value=malicious)` does not modify `_config`

## Dependencies
None.