### PR TITLE
PR 14: Separate try/except blocks per subsystem in initialize()

### DIFF
--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -43,21 +43,25 @@ class ToolExecutor:
         await store.initialize()
         self._ctx._store = store
 
-        # initialize secrets and scheduler (local file storage)
+        # initialize secrets (local file storage)
         try:
             from src.tools.secrets import SecretManager
 
             self._secret_manager = SecretManager(path=data_dir / "secrets.json")
             await self._secret_manager.load_secrets()
             self._ctx._secret_manager = self._secret_manager
+        except Exception:
+            logger.warning("Failed to initialize secrets", exc_info=True)
 
+        # initialize scheduler (local file storage)
+        try:
             from src.scheduler.scheduler import Scheduler
 
             self._scheduler = Scheduler(path=data_dir / "schedules.json")
             await self._scheduler.load_tasks()
             self._ctx._scheduler = self._scheduler
         except Exception:
-            logger.warning("Failed to initialize secrets/scheduler", exc_info=True)
+            logger.warning("Failed to initialize scheduler", exc_info=True)
 
         # initialize custom tool manager (local store)
         try:

--- a/tests/test_pr14_separate_init.py
+++ b/tests/test_pr14_separate_init.py
@@ -1,0 +1,62 @@
+"""Tests for PR 14: Separate try/except blocks per subsystem in initialize()."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from pathlib import Path
+
+from src.tools.executor import ToolExecutor
+from src.tools.registry import ToolRegistry, ToolContext
+
+
+@pytest.mark.asyncio
+async def test_secrets_failure_does_not_block_scheduler(tmp_path):
+    """A failure in SecretManager should not prevent Scheduler from initializing."""
+    with patch("src.config.CONFIG") as mock_config:
+        mock_config.data_dir = str(tmp_path)
+
+        ctx = ToolContext()
+        executor = ToolExecutor(registry=ToolRegistry(), ctx=ctx)
+
+        # Mock SecretManager.load_secrets to raise
+        with patch("src.tools.secrets.SecretManager.load_secrets", side_effect=RuntimeError("secrets broken")):
+            await executor.initialize()
+
+    # Scheduler should still be initialized
+    assert executor._scheduler is not None
+    # Secret manager may be set but failed to load
+    assert executor._secret_manager is not None
+
+
+@pytest.mark.asyncio
+async def test_scheduler_failure_does_not_block_secrets(tmp_path):
+    """A failure in Scheduler.load_tasks should not prevent SecretManager from initializing."""
+    with patch("src.config.CONFIG") as mock_config:
+        mock_config.data_dir = str(tmp_path)
+
+        ctx = ToolContext()
+        executor = ToolExecutor(registry=ToolRegistry(), ctx=ctx)
+
+        # Mock Scheduler.load_tasks to raise
+        with patch("src.scheduler.scheduler.Scheduler.load_tasks", side_effect=RuntimeError("scheduler broken")):
+            await executor.initialize()
+
+    # Secret manager should still be initialized
+    assert executor._secret_manager is not None
+    # Scheduler may be set but failed to load
+    assert executor._scheduler is not None
+
+
+@pytest.mark.asyncio
+async def test_custom_tool_manager_failure_does_not_block_others(tmp_path):
+    """A failure in CustomToolManager should not prevent secrets or scheduler."""
+    with patch("src.config.CONFIG") as mock_config:
+        mock_config.data_dir = str(tmp_path)
+
+        ctx = ToolContext()
+        executor = ToolExecutor(registry=ToolRegistry(), ctx=ctx)
+
+        with patch("src.tools.custom.CustomToolManager.load_tools", side_effect=RuntimeError("custom tools broken")):
+            await executor.initialize()
+
+    assert executor._secret_manager is not None
+    assert executor._scheduler is not None


### PR DESCRIPTION
## High #14 (partial) — Secrets failure cascades to disable scheduler

`ToolExecutor.initialize` wrapped secrets + scheduler in one `try/except`. A secrets failure cascaded to disable the scheduler.

## Changes
- Split the single `try/except` into separate blocks: one for `SecretManager`, one for `Scheduler`, one for `CustomToolManager`
- Each failure is logged independently with its own distinct message

## Acceptance Criteria
- [x] AC.1: A failure in `SecretManager.load_secrets()` does not prevent `Scheduler.load_tasks()`
- [x] AC.2: A failure in `Scheduler.load_tasks()` does not prevent `SecretManager.load_secrets()`
- [x] AC.3: Each subsystem failure has its own distinct log message

## Dependencies
None.