### PR TITLE
PR 16: Fix StoreNotFound misuse for conflicts

### DIFF
--- a/src/store/store.py
+++ b/src/store/store.py
@@ -26,6 +26,11 @@ class StoreNotFound(Exception):
     """
 
 
+class StoreConflict(Exception):
+    """Raised when a create call collides with an existing row
+    (duplicate primary key / IntegrityError)."""
+
+
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -126,7 +131,7 @@ class DocumentStore:
             await self._db.commit()
         except aiosqlite.IntegrityError as e:
             await self._db.rollback()
-            raise StoreNotFound(f"agent_document '{rkey}' already exists") from e
+            raise StoreConflict(f"agent_document '{rkey}' already exists") from e
         except Exception:
             await self._db.rollback()
             raise
@@ -243,7 +248,7 @@ class RecordStore:
             await self._db.commit()
         except aiosqlite.IntegrityError as e:
             await self._db.rollback()
-            raise StoreNotFound(
+            raise StoreConflict(
                 f"private_record '{collection}/{rkey}' already exists"
             ) from e
         except Exception:

--- a/src/tools/custom.py
+++ b/src/tools/custom.py
@@ -172,8 +172,8 @@ class CustomToolManager:
         try:
             await self._store.documents.create(rkey, content)
         except Exception as e:
-            msg = str(e).lower()
-            if "already exists" in msg or "conflict" in msg:
+            from src.store.store import StoreConflict
+            if isinstance(e, StoreConflict):
                 await self._store.documents.update(rkey, content)
             else:
                 raise

--- a/src/tools/custom.py
+++ b/src/tools/custom.py
@@ -78,7 +78,7 @@ class CustomToolManager:
 
         while True:
             if self._store.documents is None:
-            raise RuntimeError("DocumentStore is not initialized")
+                raise RuntimeError("DocumentStore is not initialized")
             resp = await self._store.documents.list(limit=100, cursor=cursor)
             documents = resp.get("documents", [])
 

--- a/tests/test_pr15_sqlite_transactions.py
+++ b/tests/test_pr15_sqlite_transactions.py
@@ -4,7 +4,7 @@ import asyncio
 import pytest
 from pathlib import Path
 
-from src.store.store import Store, StoreNotFound
+from src.store.store import Store, StoreNotFound, StoreConflict
 
 
 @pytest.fixture
@@ -29,9 +29,9 @@ async def test_document_create_uses_transaction(store):
 
 @pytest.mark.asyncio
 async def test_document_create_duplicate_raises(store):
-    """Duplicate create should raise StoreNotFound (or StoreConflict in PR 16)."""
+    """Duplicate create should raise StoreConflict (StoreNotFound on pre-PR16)."""
     await store.documents.create("dup_key", "first")
-    with pytest.raises(StoreNotFound):
+    with pytest.raises((StoreNotFound, StoreConflict)):
         await store.documents.create("dup_key", "second")
 
 

--- a/tests/test_pr16_store_conflict.py
+++ b/tests/test_pr16_store_conflict.py
@@ -1,0 +1,72 @@
+"""Tests for PR 16: Fix StoreNotFound misuse for conflicts."""
+
+import pytest
+from pathlib import Path
+
+from src.store.store import Store, StoreConflict, StoreNotFound
+
+
+@pytest.fixture
+async def store(tmp_path):
+    s = Store(path=tmp_path / "test.db")
+    await s.initialize()
+    yield s
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_store_conflict_exists():
+    """StoreConflict exception class should exist."""
+    assert issubclass(StoreConflict, Exception)
+
+
+@pytest.mark.asyncio
+async def test_document_create_duplicate_raises_conflict(store):
+    """DocumentStore.create should raise StoreConflict on duplicate, not StoreNotFound."""
+    await store.documents.create("dup_key", "first")
+    with pytest.raises(StoreConflict):
+        await store.documents.create("dup_key", "second")
+
+
+@pytest.mark.asyncio
+async def test_record_create_duplicate_raises_conflict(store):
+    """RecordStore.create should raise StoreConflict on duplicate."""
+    await store.records.create("col", "key", {"v": 1})
+    with pytest.raises(StoreConflict):
+        await store.records.create("col", "key", {"v": 2})
+
+
+@pytest.mark.asyncio
+async def test_store_not_found_still_raised_for_missing(store):
+    """StoreNotFound should still be raised for actual not-found conditions."""
+    with pytest.raises(StoreNotFound):
+        await store.documents.get("nonexistent_key")
+
+
+@pytest.mark.asyncio
+async def test_custom_tool_create_catches_conflict(tmp_path):
+    """CustomToolManager.create_tool should catch StoreConflict explicitly."""
+    from src.tools.custom import CustomTool, CustomToolManager
+    from unittest.mock import MagicMock
+
+    store = Store(path=tmp_path / "test.db")
+    await store.initialize()
+    executor = MagicMock()
+    manager = CustomToolManager(store=store, executor=executor, secret_manager=None)
+
+    tool = CustomTool(
+        name="test_tool",
+        description="test",
+        parameters={},
+        code="output('hi')",
+    )
+
+    # First create should succeed
+    result = await manager.create_tool(tool)
+    assert "created" in result.lower()
+
+    # Second create with same name should not raise — should fall back to update
+    result2 = await manager.create_tool(tool)
+    assert "created" in result2.lower()
+
+    await store.close()


### PR DESCRIPTION
## High #14 (related) — StoreNotFound raised for conflict conditions

`StoreNotFound` was raised for 'already exists' conflicts, which is semantically wrong and forces callers to substring-match error messages.

## Changes
- Add `StoreConflict(Exception)` exception class
- Change `DocumentStore.create` to raise `StoreConflict` on `IntegrityError`
- Change `RecordStore.create` to raise `StoreConflict` on `IntegrityError`
- Update `CustomToolManager.create_tool` to catch `StoreConflict` explicitly (no more substring matching)
- `StoreNotFound` is now only raised for actual 'not found' conditions

## Acceptance Criteria
- [x] AC.1: `StoreConflict` exception class exists
- [x] AC.2: `DocumentStore.create` and `RecordStore.create` raise `StoreConflict` on duplicate PK
- [x] AC.3: `CustomToolManager.create_tool` catches `StoreConflict` explicitly (no substring matching)
- [x] AC.4: `StoreNotFound` is only raised for actual 'not found' conditions

## Dependencies
PR 9 (both touch `custom.py` `create_tool`; merge PR 9 first).