### PR TITLE
PR 17: Fix Deno process output handling — cap stderr, handle EOF as error

### DIFF
--- a/src/tools/custom.py
+++ b/src/tools/custom.py
@@ -78,7 +78,7 @@ class CustomToolManager:
 
         while True:
             if self._store.documents is None:
-            raise RuntimeError("DocumentStore is not initialized")
+                raise RuntimeError("DocumentStore is not initialized")
             resp = await self._store.documents.list(limit=100, cursor=cursor)
             documents = resp.get("documents", [])
 

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -271,17 +271,20 @@ const params = {params_json};
         if process.stderr is None:
             raise RuntimeError("Process stderr is not available")
 
+        # Maximum stderr bytes to capture (prevents memory exhaustion)
+        MAX_STDERR_SIZE = 64 * 1024
+
         outputs: list[Any] = []
         debug_messages: list[str] = []
         error: str | None = None
         tool_call_count = 0
         total_output_bytes = 0
-        deadline = asyncio.get_event_loop().time() + MAX_EXECUTION_TIME
+        deadline = asyncio.get_running_loop().time() + MAX_EXECUTION_TIME
 
         try:
             while True:
                 # calculate remaining time against the total execution deadline
-                remaining = deadline - asyncio.get_event_loop().time()
+                remaining = deadline - asyncio.get_running_loop().time()
                 if remaining <= 0:
                     self._kill_process(process)
                     error = f"execution timed out after {MAX_EXECUTION_TIME:.0f} seconds (total)"
@@ -295,6 +298,11 @@ const params = {params_json};
 
                 # if there are no more lines we're finished...
                 if not line:
+                    # Empty stdout before any tool call. If the process
+                    # exited with an error, treat it as a crash.
+                    # Otherwise it's a clean exit (empty output).
+                    if process.returncode is not None and process.returncode != 0 and tool_call_count == 0:
+                        error = f"deno process exited early with code {process.returncode}"
                     break
 
                 line_str = line.decode().strip()
@@ -363,7 +371,26 @@ const params = {params_json};
 
         await process.wait()
 
-        stderr_content = await process.stderr.read()
+        # Read stderr with a size cap to prevent memory exhaustion
+        stderr_chunks: list[bytes] = []
+        stderr_total = 0
+        while True:
+            chunk = await process.stderr.read(MAX_STDERR_SIZE)
+            if not chunk:
+                break
+            stderr_total += len(chunk)
+            if stderr_total <= MAX_STDERR_SIZE:
+                stderr_chunks.append(chunk)
+            else:
+                # Truncate — keep what fits and add a marker
+                excess = stderr_total - MAX_STDERR_SIZE
+                keep = len(chunk) - excess
+                if keep > 0:
+                    stderr_chunks.append(chunk[:keep])
+                stderr_chunks.append(b"\n... (stderr truncated)")
+                break
+        stderr_content = b"".join(stderr_chunks)
+
         if stderr_content:
             stderr_str = stderr_content.decode().strip()
             if stderr_str:
@@ -371,6 +398,11 @@ const params = {params_json};
                     error += f"\n\nStderr:\n{stderr_str}"
                 else:
                     error = stderr_str
+
+        # After wait(), returncode is guaranteed to be an int.
+        # Treat any non-zero exit as an error, even if error is already set.
+        if process.returncode != 0 and error is None:
+            error = f"deno process exited with code {process.returncode}"
 
         success = process.returncode == 0 and error is None
 

--- a/tests/test_pr17_deno_output.py
+++ b/tests/test_pr17_deno_output.py
@@ -1,0 +1,102 @@
+"""Tests for PR 17: Fix Deno process output handling."""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.tools.executor import ToolExecutor
+from src.tools.registry import ToolRegistry, ToolContext
+
+
+def test_no_deprecated_get_event_loop():
+    """No asyncio.get_event_loop() calls should remain in executor.py."""
+    import subprocess
+    result = subprocess.run(
+        ["grep", "-n", "get_event_loop", "src/tools/executor.py"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0, f"Found get_event_loop:\n{result.stdout}"
+
+
+@pytest.mark.asyncio
+async def test_nonzero_exit_code_treated_as_error():
+    """A process that exits with code != 0 and empty stdout should be an error."""
+    process = MagicMock()
+    process.stdin = MagicMock()
+    process.stdout = MagicMock()
+    process.stderr = MagicMock()
+    process.returncode = 1
+    process.pid = 12345
+
+    # Simulate: empty stdout on first readline, then process exits
+    process.stdout.readline = AsyncMock(return_value=b"")
+    process.wait = AsyncMock()
+    process.stderr.read = AsyncMock(return_value=b"some error text")
+
+    executor = ToolExecutor(registry=ToolRegistry(), ctx=ToolContext())
+
+    result = await executor._process_deno_output(process)
+
+    assert result["success"] is False
+    assert "error" in result
+    # Should mention the exit code
+    assert "code 1" in result["error"] or "some error text" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_zero_exit_code_with_empty_stdout_is_clean():
+    """A process that exits with code 0 and empty stdout is a clean exit."""
+    process = MagicMock()
+    process.stdin = MagicMock()
+    process.stdout = MagicMock()
+    process.stderr = MagicMock()
+    process.returncode = 0
+    process.pid = 12345
+
+    process.stdout.readline = AsyncMock(return_value=b"")
+    process.wait = AsyncMock()
+    process.stderr.read = AsyncMock(return_value=b"")
+
+    executor = ToolExecutor(registry=ToolRegistry(), ctx=ToolContext())
+
+    result = await executor._process_deno_output(process)
+
+    assert result["success"] is True
+    assert "error" not in result
+
+
+@pytest.mark.asyncio
+async def test_stderr_capped():
+    """Stderr output should be capped at MAX_STDERR_SIZE."""
+    process = MagicMock()
+    process.stdin = MagicMock()
+    process.stdout = MagicMock()
+    process.stderr = MagicMock()
+    process.returncode = 1  # Non-zero so stderr becomes the error
+    process.pid = 12345
+
+    process.stdout.readline = AsyncMock(return_value=b"")
+    process.wait = AsyncMock()
+
+    # Generate 100KB of stderr across multiple reads
+    chunk1 = b"x" * 65536  # exactly MAX_STDERR_SIZE
+    chunk2 = b"y" * 40000  # exceeds the cap
+    reads = [chunk1, chunk2, b""]
+    read_idx = 0
+    async def mock_read(size):
+        nonlocal read_idx
+        if read_idx >= len(reads):
+            return b""
+        r = reads[read_idx]
+        read_idx += 1
+        return r
+    process.stderr.read = mock_read
+
+    executor = ToolExecutor(registry=ToolRegistry(), ctx=ToolContext())
+
+    result = await executor._process_deno_output(process)
+
+    # The stderr should be truncated
+    assert "error" in result
+    assert "truncated" in result["error"]


### PR DESCRIPTION
## High #15/#20 — Uncapped stderr and masked crashes

`stderr.read()` had no size cap; `b""` on readline was treated as clean exit, masking crashes.

## Changes
- Add `MAX_STDERR_SIZE` (64KB) constant and cap stderr reads with truncation marker
- After `await process.wait()`, treat `returncode != 0` as error even if `error` is `None`
- Empty stdout on first readline before tool calls: error only when `returncode != 0`; `returncode == 0` is a clean exit (preserving current behavior)
- Replace deprecated `asyncio.get_event_loop()` with `asyncio.get_running_loop()`

## Acceptance Criteria
- [x] AC.1: Stderr output is capped at `MAX_STDERR_SIZE` bytes with a truncation marker
- [x] AC.2: After `await process.wait()`, a `returncode != 0` is always treated as an error
- [x] AC.3: Empty stdout on first read is an error ONLY when `returncode != 0`; clean exit when `returncode == 0`
- [x] AC.4: No deprecated `asyncio.get_event_loop()` calls

## Dependencies
None.