### PR TITLE
PR 20: Fix TUI — pop_screen ordering, destructive action confirmations

### DIFF
--- a/main.py
+++ b/main.py
@@ -100,19 +100,19 @@ def build_services(
 
 def _wire_scheduler(executor: ToolExecutor, agent: Agent) -> None:
     """Wire the scheduler callback to the agent after initialization."""
-    if executor._scheduler is not None:
+    if executor.scheduler is not None:
 
         async def on_schedule_fire(task_name: str, prompt: str) -> str:
             return await agent.chat(
                 f"[Scheduled task: {task_name}] {prompt}", conversation=[]
             )
 
-        executor._scheduler._on_fire = on_schedule_fire
+        executor.scheduler._on_fire = on_schedule_fire
 
 
 def _build_discord_bot(executor: ToolExecutor, agent: Agent):
     """Return a DiscordBot if DISCORD_BOT_TOKEN is configured, else None."""
-    sm = getattr(executor, "_secret_manager", None)
+    sm = executor.secret_manager
     if sm is None:
         return None
     from src.discord_bot.bot import DISCORD_TOKEN_SECRET, DiscordBot
@@ -193,13 +193,13 @@ async def _load_system_prompt(tool_context: ToolContext, executor: ToolExecutor)
 
     # collect available secret names for the system prompt
     secret_names: list[str] = []
-    if executor._secret_manager:
-        secret_names = executor._secret_manager.list_secret_names()
+    if executor.secret_manager:
+        secret_names = executor.secret_manager.list_secret_names()
 
     # build compact custom tools list for the system prompt
     custom_tools_list = ""
-    if executor._custom_tool_manager is not None:
-        approved = executor._custom_tool_manager.get_approved_tools()
+    if executor.custom_tool_manager is not None:
+        approved = executor.custom_tool_manager.get_approved_tools()
         if approved:
             lines = []
             for t in approved:
@@ -243,14 +243,14 @@ def main(
         async def _refresh_prompt() -> str:
             return await _load_system_prompt(executor._ctx, executor)
 
-        agent._system_prompt_provider = _refresh_prompt
-        agent._system_prompt = await _refresh_prompt()
+        agent.system_prompt_provider = _refresh_prompt
+        agent.system_prompt = await _refresh_prompt()
 
         discord_bot = _build_discord_bot(executor, agent)
 
         async with asyncio.TaskGroup() as tg:
-            if executor._scheduler:
-                tg.create_task(executor._scheduler.run())
+            if executor.scheduler:
+                tg.create_task(executor.scheduler.run())
             if discord_bot is not None:
                 tg.create_task(discord_bot.start())
 
@@ -281,8 +281,8 @@ def chat(
         async def _refresh_prompt() -> str:
             return await _load_system_prompt(executor._ctx, executor)
 
-        agent._system_prompt_provider = _refresh_prompt
-        agent._system_prompt = await _refresh_prompt()
+        agent.system_prompt_provider = _refresh_prompt
+        agent.system_prompt = await _refresh_prompt()
         logger.info("Services initialized. Starting interactive chat.")
         print("\nAgent ready. Type your message (Ctrl+C to exit).\n")
 

--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -485,6 +485,36 @@ class Agent:
         self._sub_llm_client = sub_llm_client
         self._compact_threshold_chars = compact_threshold_chars
 
+    # -- public read-only properties for TUI/Discord --
+
+    @property
+    def client(self) -> AgentClient:
+        """Return the underlying LLM client."""
+        return self._client
+
+    @property
+    def system_prompt(self) -> str | None:
+        """Return the current system prompt."""
+        return self._system_prompt
+
+    @system_prompt.setter
+    def system_prompt(self, value: str | None) -> None:
+        self._system_prompt = value
+
+    @property
+    def system_prompt_provider(self) -> Any:
+        return self._system_prompt_provider
+
+    @system_prompt_provider.setter
+    def system_prompt_provider(self, value: Any) -> None:
+        self._system_prompt_provider = value
+
+    async def refresh_system_prompt(self) -> str:
+        """Call the system prompt provider and update the cached prompt."""
+        if self._system_prompt_provider is not None:
+            self._system_prompt = await self._system_prompt_provider()
+        return self._system_prompt or ""
+
     # number of messages from the end to preserve full tool results
     TOOL_RESULT_PRESERVE_COUNT = 4
 

--- a/src/discord_bot/bot.py
+++ b/src/discord_bot/bot.py
@@ -288,7 +288,7 @@ class DiscordBot:
         self, message: discord.Message, thread: discord.Thread
     ) -> None:
         """Route an operator message into a session and run the agent."""
-        store = self._executor._ctx._store
+        store = self._executor.store
         if store is None or store.chat is None:
             await thread.send("⚠️ Local store not initialized.")
             return
@@ -356,7 +356,7 @@ class DiscordBot:
             from src.agent.conversation import maybe_generate_session_title
 
             title = await maybe_generate_session_title(
-                store, thread_id, self._executor._ctx._llm_client
+                store, thread_id, self._executor.llm_client
             )
             if title:
                 try:
@@ -368,7 +368,7 @@ class DiscordBot:
 
     async def _load_conversation(self, thread_id: str) -> list[dict[str, Any]]:
         """Load a session's full message history in agent.chat() format."""
-        store = self._executor._ctx._store
+        store = self._executor.store
         if store is None or store.chat is None:
             raise RuntimeError("Store or ChatStore is not initialized")
 

--- a/src/tools/custom.py
+++ b/src/tools/custom.py
@@ -78,7 +78,7 @@ class CustomToolManager:
 
         while True:
             if self._store.documents is None:
-            raise RuntimeError("DocumentStore is not initialized")
+                raise RuntimeError("DocumentStore is not initialized")
             resp = await self._store.documents.list(limit=100, cursor=cursor)
             documents = resp.get("documents", [])
 

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -31,6 +31,36 @@ class ToolExecutor:
         self._secret_manager: Any | None = None
         self._scheduler: Any | None = None
 
+    # -- public read-only properties for TUI/Discord/main.py --
+
+    @property
+    def store(self) -> Any:
+        return self._ctx._store
+
+    @property
+    def secret_manager(self) -> Any | None:
+        return self._secret_manager
+
+    @property
+    def custom_tool_manager(self) -> Any | None:
+        return self._custom_tool_manager
+
+    @property
+    def scheduler(self) -> Any | None:
+        return self._scheduler
+
+    @property
+    def http_client(self) -> Any:
+        return self._ctx._http_client
+
+    @property
+    def llm_client(self) -> Any:
+        return self._ctx._llm_client
+
+    @property
+    def exa_client(self) -> Any:
+        return self._ctx._exa_client
+
     async def initialize(self) -> None:
         from src.config import CONFIG
 

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -73,18 +73,16 @@ class VictrolaApp(App):
             async def _refresh_prompt() -> str:
                 return await _load_system_prompt(self.executor._ctx, self.executor)
 
-            self.agent._system_prompt_provider = _refresh_prompt
-            self.agent._system_prompt = await _refresh_prompt()
+            self.agent.system_prompt_provider = _refresh_prompt
+            self.agent.system_prompt = await _refresh_prompt()
             logger.info("System prompt loaded")
         except Exception:
             logger.exception("System prompt load failed")
 
         # wire scheduler callback and start in background
-        if self.executor._scheduler:
-            import asyncio
-
-            self.executor._scheduler._on_fire = self._on_schedule_fire
-            asyncio.create_task(self.executor._scheduler.run())
+        if self.executor.scheduler:
+            self.executor.scheduler._on_fire = self._on_schedule_fire
+            asyncio.create_task(self.executor.scheduler.run())
             logger.info("Scheduler started in background")
 
         # start Discord chat bot if DISCORD_BOT_TOKEN is configured

--- a/src/tui/screens/chat.py
+++ b/src/tui/screens/chat.py
@@ -171,7 +171,7 @@ class ChatScreen(Screen):
                 try:
                     from src.agent.conversation import maybe_generate_session_title
 
-                    store = self.app.executor._ctx._store  # type: ignore[attr-defined]
+                    store = self.app.executor.store  # type: ignore[attr-defined]
                     if store is not None:
                         await maybe_generate_session_title(
                             store, self.session_id, conv_manager._llm if conv_manager else None
@@ -210,7 +210,7 @@ class ChatScreen(Screen):
     async def _refresh_pending_banner(self) -> None:
         """Show a banner at the top of the chat log if any custom tools are pending review."""
         executor = self.app.executor  # type: ignore[attr-defined]
-        manager = getattr(executor, "_custom_tool_manager", None)
+        manager = executor.custom_tool_manager
         banner = self.query_one("#pending-banner", Static)
         if manager is None:
             banner.add_class("hidden")

--- a/src/tui/screens/confirm.py
+++ b/src/tui/screens/confirm.py
@@ -1,0 +1,35 @@
+"""Reusable confirmation dialog screen for destructive actions."""
+
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Center, Middle
+from textual.screen import ModalScreen
+from textual.widgets import Footer, Label
+
+
+class ConfirmScreen(ModalScreen[bool]):
+    """A modal confirmation dialog. Returns True (confirm) or False (cancel)."""
+
+    BINDINGS = [
+        Binding("y,enter", "confirm", "Yes"),
+        Binding("n,escape", "cancel", "No"),
+    ]
+
+    def __init__(self, message: str, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._message = message
+
+    def compose(self) -> ComposeResult:
+        with Center():
+            with Middle():
+                yield Label(self._message, id="confirm-message")
+                yield Label("[bold]Y[/bold] to confirm · [bold]N[/bold] to cancel", markup=True)
+        yield Footer()
+
+    def action_confirm(self) -> None:
+        self.dismiss(True)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)

--- a/src/tui/screens/schedules.py
+++ b/src/tui/screens/schedules.py
@@ -155,6 +155,18 @@ class ScheduleListScreen(Screen):
         if not scheduler or not name:
             return
 
+        from src.tui.screens.confirm import ConfirmScreen
+
+        def _on_confirm(confirmed: bool) -> None:
+            if confirmed:
+                self.run_worker(self._do_delete_schedule(name), exclusive=True)
+
+        self.app.push_screen(ConfirmScreen(f"Delete schedule '{name}'?"), _on_confirm)
+
+    async def _do_delete_schedule(self, name: str) -> None:
+        scheduler = self._get_scheduler()
+        if not scheduler:
+            return
         try:
             result = await scheduler.delete_task(name)
             self.notify(result)
@@ -245,9 +257,11 @@ class ScheduleInputScreen(Screen):
             self.notify(f"Invalid schedule: {e}", severity="error")
             return
 
-        self.app.pop_screen()
+        # Await _on_save BEFORE popping the screen so the save
+        # completes while the screen is still mounted.
         if self._on_save:
             await self._on_save(name, schedule, prompt)
+        self.app.pop_screen()
 
     def action_cancel(self) -> None:
         self.app.pop_screen()

--- a/src/tui/screens/secrets.py
+++ b/src/tui/screens/secrets.py
@@ -104,6 +104,19 @@ class SecretListScreen(Screen):
         if not name:
             return
 
+        # Confirm before deleting
+        from src.tui.screens.confirm import ConfirmScreen
+
+        def _on_confirm(confirmed: bool) -> None:
+            if confirmed:
+                self.run_worker(self._do_delete_secret(name), exclusive=True)
+
+        self.app.push_screen(ConfirmScreen(f"Delete secret '{name}'?"), _on_confirm)
+
+    async def _do_delete_secret(self, name: str) -> None:
+        manager = self._get_manager()
+        if manager is None:
+            return
         try:
             result = await manager.delete_secret(name)
             self.notify(result)
@@ -170,9 +183,16 @@ class SecretInputScreen(Screen):
                 self.notify("Value is required", severity="error")
                 return
 
-            self.app.pop_screen()
+            # Clear the input values before popping so the secret
+            # is not left in widget memory.
+            name_input.value = ""
+            value_input.value = ""
+
+            # Await _on_save BEFORE popping the screen so the save
+            # completes while the screen is still mounted.
             if self._on_save:
                 await self._on_save(name, value)
+            self.app.pop_screen()
 
     def action_cancel(self) -> None:
         self.app.pop_screen()

--- a/src/tui/screens/sessions.py
+++ b/src/tui/screens/sessions.py
@@ -154,6 +154,15 @@ class SessionListScreen(Screen):
         if not rkey:
             return
 
+        from src.tui.screens.confirm import ConfirmScreen
+
+        def _on_confirm(confirmed: bool) -> None:
+            if confirmed:
+                self.run_worker(self._do_delete_session(rkey), exclusive=True)
+
+        self.app.push_screen(ConfirmScreen(f"Delete session '{rkey}'?"), _on_confirm)
+
+    async def _do_delete_session(self, rkey: str) -> None:
         chat = self._chat_store()
         if chat is None:
             return

--- a/src/tui/screens/sessions.py
+++ b/src/tui/screens/sessions.py
@@ -85,7 +85,7 @@ class SessionListScreen(Screen):
 
     def _chat_store(self) -> Any:
         executor = self.app.executor  # type: ignore[attr-defined]
-        store = getattr(executor._ctx, "_store", None)
+        store = executor.store
         if store is None:
             return None
         return store.chat

--- a/src/tui/screens/system_prompt.py
+++ b/src/tui/screens/system_prompt.py
@@ -50,11 +50,11 @@ class SystemPromptScreen(Screen):
         # not whatever was cached at boot.
         text: str
         try:
-            provider = getattr(agent, "_system_prompt_provider", None)
+            provider = agent.system_prompt_provider
             if provider is not None:
                 text = await provider()
             else:
-                text = getattr(agent, "_system_prompt", None) or "(no prompt set)"
+                text = agent.system_prompt or "(no prompt set)"
         except Exception as e:
             logger.exception("Failed to fetch current system prompt")
             text = f"(error fetching prompt: {e})"

--- a/src/tui/screens/tool_detail.py
+++ b/src/tui/screens/tool_detail.py
@@ -169,6 +169,21 @@ class ToolDetailScreen(Screen):
         manager = self._manager()
         if manager is None:
             return
+
+        from src.tui.screens.confirm import ConfirmScreen
+
+        def _on_confirm(confirmed: bool) -> None:
+            if confirmed:
+                self.run_worker(self._do_revoke(), exclusive=True)
+
+        self.app.push_screen(
+            ConfirmScreen(f"Revoke approval for '{self._tool_name}'?"), _on_confirm
+        )
+
+    async def _do_revoke(self) -> None:
+        manager = self._manager()
+        if manager is None:
+            return
         try:
             result = await manager.revoke_tool(self._tool_name)
             self.notify(result)
@@ -178,6 +193,21 @@ class ToolDetailScreen(Screen):
             self.notify("Failed to revoke tool", severity="error")
 
     async def action_delete(self) -> None:
+        manager = self._manager()
+        if manager is None:
+            return
+
+        from src.tui.screens.confirm import ConfirmScreen
+
+        def _on_confirm(confirmed: bool) -> None:
+            if confirmed:
+                self.run_worker(self._do_delete(), exclusive=True)
+
+        self.app.push_screen(
+            ConfirmScreen(f"Delete tool '{self._tool_name}'?"), _on_confirm
+        )
+
+    async def _do_delete(self) -> None:
         manager = self._manager()
         if manager is None:
             return

--- a/src/tui/screens/tool_detail.py
+++ b/src/tui/screens/tool_detail.py
@@ -40,13 +40,13 @@ class ToolDetailScreen(Screen):
         executor = getattr(self.app, "executor", None)
         if executor is None:
             return None
-        return getattr(executor, "_custom_tool_manager", None)
+        return executor.custom_tool_manager
 
     def _secret_manager(self) -> Any:
         executor = getattr(self.app, "executor", None)
         if executor is None:
             return None
-        return getattr(executor, "_secret_manager", None)
+        return executor.secret_manager
 
     def compose(self) -> ComposeResult:
         yield Header(name=f"Tool: {self._tool_name}")

--- a/tests/test_pr19_public_api.py
+++ b/tests/test_pr19_public_api.py
@@ -1,0 +1,75 @@
+"""Tests for PR 19: Extract public API facade — remove private attribute access."""
+
+import pytest
+import subprocess
+
+
+def test_executor_has_public_properties():
+    """ToolExecutor should expose public properties."""
+    from src.tools.executor import ToolExecutor
+    from src.tools.registry import ToolRegistry, ToolContext
+
+    ctx = ToolContext()
+    executor = ToolExecutor(registry=ToolRegistry(), ctx=ctx)
+
+    assert hasattr(executor, "store")
+    assert hasattr(executor, "secret_manager")
+    assert hasattr(executor, "custom_tool_manager")
+    assert hasattr(executor, "scheduler")
+    assert hasattr(executor, "http_client")
+    assert hasattr(executor, "llm_client")
+    assert hasattr(executor, "exa_client")
+
+
+def test_agent_has_public_properties():
+    """Agent should expose public properties."""
+    from src.agent.agent import Agent
+
+    agent = Agent(model_api="anthropic", model_name="x", model_api_key="key")
+
+    assert hasattr(agent, "client")
+    assert hasattr(agent, "system_prompt")
+    assert hasattr(agent, "system_prompt_provider")
+    assert hasattr(agent, "refresh_system_prompt")
+
+
+def test_no_private_access_in_tui():
+    """No TUI screen should access underscore-prefixed executor attributes.
+    Note: agent._chat_lock and agent._conversation are removed by PR 1, not PR 19.
+    PR 19 handles executor/agent private attrs like _ctx, _secret_manager, etc."""
+    result = subprocess.run(
+        ["grep", "-rn", r"executor\._ctx\._\|executor\._secret_manager\|executor\._scheduler\b\|executor\._custom_tool_manager\|agent\._system_prompt\b\|agent\._system_prompt_provider\|agent\._client\b",
+         "src/tui/"],
+        capture_output=True,
+        text=True,
+    )
+    violations = [line for line in result.stdout.strip().split("\n") if line]
+    assert not violations, f"Found private attribute access in TUI:\n{result.stdout}"
+
+
+def test_no_private_access_in_discord():
+    """No Discord bot file should access underscore-prefixed executor/agent attributes."""
+    result = subprocess.run(
+        ["grep", "-rn", r"executor\._ctx\._\|executor\._secret_manager\|executor\._scheduler\b\|executor\._custom_tool_manager\|executor\._conversation\|executor\._chat_lock",
+         "src/discord_bot/"],
+        capture_output=True,
+        text=True,
+    )
+    violations = [line for line in result.stdout.strip().split("\n") if line]
+    assert not violations, f"Found private attribute access in Discord:\n{result.stdout}"
+
+
+def test_no_private_access_in_main_py():
+    """main.py should not access underscore-prefixed executor attributes."""
+    result = subprocess.run(
+        ["grep", "-n", r"executor\._scheduler\|executor\._secret_manager\|executor\._custom_tool_manager\|executor\._ctx",
+         "main.py"],
+        capture_output=True,
+        text=True,
+    )
+    # Filter out _load_system_prompt which takes executor._ctx as a param (still needed)
+    violations = [
+        line for line in result.stdout.strip().split("\n")
+        if line and "_load_system_prompt" not in line
+    ]
+    assert not violations, f"Found private attribute access in main.py:\n{result.stdout}"

--- a/tests/test_pr20_tui_fixes.py
+++ b/tests/test_pr20_tui_fixes.py
@@ -1,0 +1,91 @@
+"""Tests for PR 20: Fix TUI — pop_screen ordering and confirmations."""
+
+import pytest
+import inspect
+
+
+def test_confirm_screen_exists():
+    """ConfirmScreen should exist and be a ModalScreen."""
+    from src.tui.screens.confirm import ConfirmScreen
+    from textual.screen import ModalScreen
+
+    assert issubclass(ConfirmScreen, ModalScreen)
+
+
+def test_confirm_screen_takes_message():
+    """ConfirmScreen should accept a message parameter."""
+    from src.tui.screens.confirm import ConfirmScreen
+
+    screen = ConfirmScreen("Are you sure?")
+    assert screen._message == "Are you sure?"
+
+
+def test_confirm_screen_has_confirm_and_cancel_actions():
+    """ConfirmScreen should have confirm and cancel actions."""
+    from src.tui.screens.confirm import ConfirmScreen
+
+    screen = ConfirmScreen("test")
+    assert hasattr(screen, "action_confirm")
+    assert hasattr(screen, "action_cancel")
+
+
+def test_secret_input_clears_before_pop():
+    """SecretInputScreen.on_input_submitted should clear inputs and await save before pop."""
+    import ast
+
+    with open("src/tui/screens/secrets.py") as f:
+        tree = ast.parse(f.read())
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == "on_input_submitted":
+                source = ast.unparse(node)
+                # Check that pop_screen comes after _on_save
+                pop_idx = source.find("pop_screen")
+                save_idx = source.find("_on_save")
+                assert pop_idx > save_idx, "pop_screen should come after _on_save"
+                # Check that input values are cleared (empty string assignment)
+                assert ".value = ''" in source or '.value = ""' in source, \
+                    "Input values should be cleared"
+                return
+    assert False, "on_input_submitted method not found"
+
+
+def test_schedule_save_awaits_before_pop():
+    """ScheduleInputScreen.action_save should await _on_save before pop_screen."""
+    import ast
+
+    with open("src/tui/screens/schedules.py") as f:
+        tree = ast.parse(f.read())
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == "action_save":
+                source = ast.unparse(node)
+                pop_idx = source.find("pop_screen")
+                save_idx = source.find("_on_save")
+                assert pop_idx > save_idx, "pop_screen should come after _on_save"
+                return
+    assert False, "action_save method not found"
+
+
+def test_delete_actions_use_confirmation():
+    """Delete/revoke actions should push a ConfirmScreen."""
+    import subprocess
+
+    files_and_actions = [
+        ("src/tui/screens/secrets.py", "action_delete_secret"),
+        ("src/tui/screens/schedules.py", "action_delete_schedule"),
+        ("src/tui/screens/sessions.py", "action_delete_session"),
+        ("src/tui/screens/tool_detail.py", "action_revoke"),
+        ("src/tui/screens/tool_detail.py", "action_delete"),
+    ]
+
+    for filepath, action_name in files_and_actions:
+        result = subprocess.run(
+            ["grep", "-A15", action_name, filepath],
+            capture_output=True,
+            text=True,
+        )
+        assert "ConfirmScreen" in result.stdout, \
+            f"{action_name} in {filepath} should use ConfirmScreen"


### PR DESCRIPTION
## High #17, #18 — Pop screen before save + no destructive confirmations

`SecretInputScreen.on_input_submitted` popped the screen before awaiting `_on_save`. No confirmation prompts for destructive actions.

## Changes
- Fix pop_screen ordering in `SecretInputScreen.on_input_submitted`: await `_on_save` BEFORE `pop_screen`, clear input values after capturing
- Fix pop_screen ordering in `ScheduleInputScreen.action_save`: await `_on_save` BEFORE `pop_screen`
- Add reusable `ConfirmScreen` (`ModalScreen`) with Y/N confirm/cancel
- Add confirmation dialogs for: delete session, delete tool, revoke tool, delete secret, delete schedule
- Clear secret input values after capturing (no secret left in widget memory)

## Acceptance Criteria
- [x] AC.1: `SecretInputScreen.on_input_submitted` awaits `_on_save` before calling `pop_screen()`
- [x] AC.2: `ScheduleInputScreen.action_save` awaits `_on_save` before calling `pop_screen()`
- [x] AC.3: Delete session, delete tool, revoke tool, delete secret, and delete schedule all show a confirmation dialog
- [x] AC.4: The input value is cleared after capturing (no secret left in widget memory)
- [x] AC.5: A reusable `ConfirmScreen` exists

## Dependencies
PR 19 (both touch TUI screens; the public API facade must be in place first).