### PR TITLE
Add conditional scheduling (triggers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Deno runs with the bare minimum of permissions: no filesystem writes, no network
 | Namespace | Tool | What it does |
 |-----------|------|---|
 | `memory` | `add`, `update`, `delete`, `search`, `get`, `list_skills`, `get_skill` | Entry-based memory with hybrid search. `self` holds the agent's personality; `operator` holds facts about you; `skill:*` holds reusable procedures; `episodic` and `factual` are RAG-retrieved per turn. |
-| `scheduler` | `list_schedules`, `get_schedule` | View scheduled tasks. Creation is via the web interface. |
+| `scheduler` | `list_schedules`, `get_schedule` | View scheduled tasks. Creation is via the web interface or `scheduler.create_schedule`. |
 | `notify` | `discord` | Send a message to Discord via webhook (requires `DISCORD_WEBHOOK_URL` secret). |
 | `summarize` | `summarize` | Summarize text using the sub-agent model. |
 | `web` | search tools via [Exa](https://exa.ai) (requires `EXA_API_KEY`). |
@@ -66,6 +66,26 @@ The agent can propose new tools by calling `custom_tools.create_custom_tool` dur
 
 If a tool references a secret that isn't configured yet, the approval flow walks you through setting each missing secret before completing approval.
 
+## Scheduling and Triggers
+
+Scheduled tasks fire a prompt on a recurring schedule (hourly, daily, weekly, cron). When a schedule fires, the agent runs the prompt in a fresh conversation with full tool access. Tasks are stored in SQLite (`store.db`).
+
+### Triggers (conditional schedules)
+
+A scheduled task can optionally have a **condition script** — TypeScript that runs on schedule *before* waking the agent. This avoids spending tokens on recurring checks that usually find nothing to act on.
+
+- The condition script calls `output({ wake: true })` to wake the agent, or `output({ wake: false })` to skip this cycle.
+- Condition code runs in the same Deno sandbox as custom tools, with optional network access and secrets.
+- Condition code requires **operator approval** before it will fire (same gate as custom tools). Until approved, the task skips silently.
+- If a condition script fails 3 consecutive times, the task is auto-disabled.
+- The operator can test condition code via the web interface before approving.
+
+Tasks without a condition script behave exactly as before — they always wake the agent on schedule.
+
+### One-time migration
+
+On startup, existing `schedules.json` entries are migrated to SQLite and the file is renamed to `schedules.json.migrated`. This is idempotent — re-running with a stale JSON file does not error or duplicate.
+
 ## Memory
 
 The agent has an entry-based memory system with hybrid search and RAG recall. All memory lives in SQLite (`memory_entries` table).
@@ -95,9 +115,9 @@ Embeddings are generated via a local Ollama instance using `nomic-embed-text` (7
 ## Storage
 
 Everything persistent lives under `./data/`:
-- `store.db` — SQLite: memory entries (+ FTS5 index + embeddings), chat sessions + messages, custom tool definitions, namespaced records
+- `store.db` — SQLite: memory entries (+ FTS5 index + embeddings), chat sessions + messages, custom tool definitions, scheduled tasks, namespaced records
 - `secrets.json` — named secrets (injected as env vars into custom tool Deno processes)
-- `schedules.json` — scheduled prompts
+- `schedules.json.migrated` — renamed after one-time migration to SQLite (kept as backup)
 
 Nothing leaves this directory unless you wire a tool to send it somewhere.
 

--- a/main.py
+++ b/main.py
@@ -116,6 +116,22 @@ def _wire_scheduler(executor: ToolExecutor, agent: Agent) -> None:
 
         executor.scheduler._on_fire = on_schedule_fire
 
+        async def run_condition(
+            code: str, requires_net: bool, secrets: list[str]
+        ) -> dict[str, Any]:
+            env: dict[str, str] = {}
+            sm = executor.secret_manager
+            if sm:
+                for name in secrets:
+                    val = sm.get_secret(name)
+                    if val:
+                        env[name.upper()] = val
+            return await executor.execute_condition_code(
+                code=code, env=env, allow_net=requires_net
+            )
+
+        executor.scheduler._condition_runner = run_condition
+
 
 def _build_discord_bot(executor: ToolExecutor, agent: Agent):
     """Return a DiscordBot if DISCORD_BOT_TOKEN is configured, else None."""

--- a/src/agent/prompt.py
+++ b/src/agent/prompt.py
@@ -79,6 +79,22 @@ Err toward writing too often rather than too rarely. Memory loss is much more ex
 ## Error handling
 
 When a tool call fails, read the error carefully before retrying. Adjust your approach based on the error message. If you emitted something other than an `execute_code` call and got an error, the fix is to wrap your intended operation in `execute_code` TypeScript.
+
+## Scheduled Tasks and Triggers
+
+Scheduled tasks fire a prompt on a recurring schedule (daily summaries, periodic checks, etc.). When a schedule fires, you run the prompt in a fresh conversation with no prior history — so the prompt must be self-contained.
+
+### Triggers (conditional schedules)
+
+A scheduled task can optionally have a **condition script** — TypeScript that runs on schedule *before* waking you. This lets you skip unnecessary wake-ups when there's nothing to act on.
+
+- Call `output({ wake: true })` to wake yourself with the task's prompt.
+- Call `output({ wake: false })` to skip this cycle (no LLM call, no tokens spent).
+- Condition code runs in a Deno sandbox with access to `output()` and `debug()` only — no backend tools. Optional network access and secrets can be declared.
+- Condition code requires **operator approval** before it will fire (same gate as custom tools). Until approved, the task skips silently.
+- Use `execute_code` to dry-run your condition script for TypeScript errors before creating a trigger. Note: condition scripts do NOT have access to the `tools` namespace — only `output()` and `debug()`.
+
+**When to use a trigger:** recurring checks that usually find nothing — "check if there are new PRs", "see if a build is still failing", "remind me about X if it's overdue". The condition script runs cheaply; you only get woken when there's something to do.
 """
 
 

--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -1,17 +1,29 @@
 import asyncio
 import json
 import logging
+import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from src.scheduler.schedule import ScheduleConfig, parse_schedule
+
+if TYPE_CHECKING:
+    from src.store.store import DocumentStore
 
 logger = logging.getLogger(__name__)
 
 CHECK_INTERVAL_SECONDS = 30
+
+SCHEDULE_RKEY_PREFIX = "schedule:"
+
+# Valid schedule name pattern: alphanumeric with -_ (no path separators, no colons)
+_SCHEDULE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9\-_.]{1,128}$")
+
+# Condition code runner: (code, requires_net, secrets) -> execution result dict
+ConditionRunner = Callable[[str, bool, list[str]], Awaitable[dict[str, Any]]]
 
 
 @dataclass
@@ -21,10 +33,15 @@ class ScheduledTask:
     prompt: str  # what to tell the agent
     enabled: bool = True
     last_run: str | None = None  # ISO 8601
+    condition_code: str | None = None  # TypeScript; absent = always wake
+    requires_net: bool = False  # does condition code need network
+    secrets: list[str] = field(default_factory=list)  # secret names for condition env
+    approved: bool = False  # approval gate (only relevant if condition_code present)
 
     # computed at runtime, not persisted
     _config: ScheduleConfig | None = field(default=None, repr=False, compare=False)
     _retry_count: int = field(default=0, repr=False, compare=False)
+    _condition_retry_count: int = field(default=0, repr=False, compare=False)
 
     @property
     def config(self) -> ScheduleConfig:
@@ -41,6 +58,11 @@ class ScheduledTask:
         }
         if self.last_run:
             d["last_run"] = self.last_run
+        if self.condition_code is not None:
+            d["condition_code"] = self.condition_code
+            d["requires_net"] = self.requires_net
+            d["secrets"] = self.secrets
+            d["approved"] = self.approved
         return d
 
     @classmethod
@@ -51,50 +73,145 @@ class ScheduledTask:
             prompt=data.get("prompt", ""),
             enabled=data.get("enabled", True),
             last_run=data.get("last_run"),
+            condition_code=data.get("condition_code"),
+            requires_net=data.get("requires_net", False),
+            secrets=data.get("secrets", []),
+            approved=data.get("approved", False),
         )
 
 
 class Scheduler:
     """Background scheduler that fires agent prompts on a schedule.
 
-    Schedules are stored locally as a JSON file.
-    When a task fires, it calls the `on_fire` callback with (task_name, prompt).
+    Schedules are stored in the DocumentStore (SQLite, rkey prefix ``schedule:``).
+    When a task fires, it calls the ``on_fire`` callback with (task_name, prompt).
+
+    Tasks with ``condition_code`` run the condition script first — the agent is
+    only woken when the script returns ``{ wake: true }``.
     """
 
     def __init__(
         self,
-        path: Path,
+        store: "DocumentStore",
         on_fire: Callable[[str, str], Awaitable[str]] | None = None,
+        condition_runner: ConditionRunner | None = None,
+        legacy_path: Path | None = None,
     ) -> None:
-        self._path = path
+        self._store = store
         self._on_fire = on_fire
+        self._condition_runner = condition_runner
+        self._legacy_path = legacy_path
         self._tasks: dict[str, ScheduledTask] = {}
         self._running = False
 
-    def _save(self) -> None:
-        """Persist all tasks to disk."""
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        data = [task.to_dict() for task in self._tasks.values()]
-        self._path.write_text(json.dumps(data, indent=2) + "\n")
+    async def _save_task(self, task: ScheduledTask) -> None:
+        """Upsert a single task to the document store."""
+        rkey = f"{SCHEDULE_RKEY_PREFIX}{task.name}"
+        content = json.dumps(task.to_dict())
+        try:
+            await self._store.create(rkey, content)
+        except Exception as e:
+            from src.store.store import StoreConflict
 
-    async def load_tasks(self) -> None:
-        """Load all scheduled tasks from the local JSON file."""
-        self._tasks.clear()
-        if not self._path.exists():
+            if isinstance(e, StoreConflict):
+                await self._store.update(rkey, content)
+            else:
+                raise
+
+    async def _delete_task(self, name: str) -> None:
+        """Remove a task document from the store."""
+        rkey = f"{SCHEDULE_RKEY_PREFIX}{name}"
+        try:
+            await self._store.delete(rkey)
+        except Exception:
+            logger.exception("Failed to delete schedule doc %s", rkey)
+
+    async def _migrate_legacy(self) -> None:
+        """One-time migration from schedules.json to DocumentStore.
+
+        Idempotent: if the JSON file was already renamed (.migrated), this
+        is a no-op. If a partial migration left some tasks already in the
+        store, they are skipped (upsert semantics handle duplicates).
+        """
+        if self._legacy_path is None or not self._legacy_path.exists():
             return
 
         try:
-            data = json.loads(self._path.read_text())
-            if isinstance(data, list):
-                for entry in data:
-                    try:
-                        task = ScheduledTask.from_dict(entry)
-                        _ = task.config  # validate the schedule expression
-                        self._tasks[task.name] = task
-                    except (KeyError, ValueError) as e:
-                        logger.warning("Failed to parse schedule entry: %s", e)
+            data = json.loads(self._legacy_path.read_text())
         except (json.JSONDecodeError, OSError) as e:
-            logger.warning("Failed to load schedules from %s: %s", self._path, e)
+            logger.warning("Failed to read legacy schedules.json: %s", e)
+            return
+
+        if not isinstance(data, list):
+            logger.warning("Legacy schedules.json is not a list — skipping migration")
+            return
+
+        migrated = 0
+        for entry in data:
+            try:
+                task = ScheduledTask.from_dict(entry)
+                _ = task.config  # validate schedule expression
+
+                # Create-only: skip if a task with this name already exists
+                # in the store (from a prior partial migration). Never
+                # overwrite newer SQLite data with stale legacy JSON.
+                if self._tasks.get(task.name) is not None:
+                    continue
+
+                rkey = f"{SCHEDULE_RKEY_PREFIX}{task.name}"
+                content = json.dumps(task.to_dict())
+                try:
+                    await self._store.create(rkey, content)
+                except Exception as e:
+                    from src.store.store import StoreConflict
+
+                    if isinstance(e, StoreConflict):
+                        continue  # already exists in store — skip
+                    raise
+
+                self._tasks[task.name] = task
+                migrated += 1
+            except Exception as e:
+                logger.warning("Failed to migrate schedule entry: %s", e)
+
+        logger.info("Migrated %d schedule(s) from legacy JSON", migrated)
+
+        # Rename the legacy file so we don't re-import
+        try:
+            self._legacy_path.rename(self._legacy_path.with_suffix(".json.migrated"))
+        except OSError as e:
+            logger.warning("Failed to rename legacy schedules.json: %s", e)
+
+    async def load_tasks(self) -> None:
+        """Load all scheduled tasks from the DocumentStore."""
+        self._tasks.clear()
+
+        # First, migrate from legacy JSON if needed
+        await self._migrate_legacy()
+
+        cursor: str | None = None
+        while True:
+            resp = await self._store.list(limit=100, cursor=cursor)
+            documents = resp.get("documents", [])
+
+            for doc in documents:
+                rkey = doc.get("rkey", "")
+                if not rkey.startswith(SCHEDULE_RKEY_PREFIX):
+                    continue
+                content = doc.get("content", "")
+                if not content:
+                    continue
+                try:
+                    data = json.loads(content)
+                    task = ScheduledTask.from_dict(data)
+                    _ = task.config  # validate the schedule expression
+                    self._tasks[task.name] = task
+                except Exception as e:
+                    logger.warning("Failed to parse schedule entry %s: %s", rkey, e)
+
+            cursor = resp.get("cursor")
+            if not cursor or not documents:
+                break
 
         logger.info("Loaded %d schedule(s)", len(self._tasks))
 
@@ -106,6 +223,12 @@ class Scheduler:
 
     async def create_task(self, task: ScheduledTask) -> str:
         """Create a new scheduled task."""
+        if not _SCHEDULE_NAME_PATTERN.match(task.name):
+            return (
+                f"Error: schedule name '{task.name}' is invalid. "
+                "Allowed: alphanumeric, dash, underscore, dot (1-128 chars)"
+            )
+
         # validate the schedule expression
         _ = task.config
 
@@ -113,13 +236,35 @@ class Scheduler:
         if not task.last_run:
             task.last_run = datetime.now(timezone.utc).isoformat()
 
+        # Create-only: reject duplicates rather than upserting
+        rkey = f"{SCHEDULE_RKEY_PREFIX}{task.name}"
+        content = json.dumps(task.to_dict())
+        try:
+            await self._store.create(rkey, content)
+        except Exception as e:
+            from src.store.store import StoreConflict
+
+            if isinstance(e, StoreConflict):
+                return f"Error: schedule '{task.name}' already exists."
+            raise
+
         self._tasks[task.name] = task
-        self._save()
 
         next_run = task.config.next_run(datetime.now(timezone.utc))
-        return f"Schedule '{task.name}' created ({task.config}). Next run: {next_run.strftime('%Y-%m-%d %H:%M UTC')}."
+        msg = f"Schedule '{task.name}' created ({task.config}). Next run: {next_run.strftime('%Y-%m-%d %H:%M UTC')}."
+        if task.condition_code is not None and not task.approved:
+            msg += " Schedule has condition code — pending operator approval before it will fire."
+        return msg
 
-    ALLOWED_UPDATE_FIELDS = {"schedule", "prompt", "enabled", "last_run"}
+    ALLOWED_UPDATE_FIELDS = {
+        "schedule",
+        "prompt",
+        "enabled",
+        "last_run",
+        "condition_code",
+        "requires_net",
+        "secrets",
+    }
 
     async def update_task(self, name: str, **fields: Any) -> str:
         """Update an existing scheduled task."""
@@ -128,12 +273,32 @@ class Scheduler:
             return f"Schedule '{name}' not found."
 
         skipped = []
+        resets_approval = False
+        # Snapshot for rollback if schedule validation fails
+        old_values: dict[str, Any] = {}
+
         for key, value in fields.items():
             if key not in self.ALLOWED_UPDATE_FIELDS:
                 skipped.append(key)
                 continue
-            if value is not None:
-                setattr(task, key, value)
+            if value is None:
+                continue
+
+            # Approval reset: condition_code changes, requires_net goes
+            # False -> True (broadens permissions), or secrets are added
+            # (new secret access not covered by prior approval).
+            if key == "condition_code" and task.condition_code != value:
+                resets_approval = True
+            elif key == "requires_net" and not task.requires_net and value:
+                resets_approval = True
+            elif key == "secrets" and value is not None:
+                old_set = set(task.secrets)
+                new_set = set(value)
+                if new_set - old_set:  # new secrets added (broadened)
+                    resets_approval = True
+
+            old_values[key] = getattr(task, key)
+            setattr(task, key, value)
 
         if skipped:
             logger.warning(
@@ -142,15 +307,29 @@ class Scheduler:
                 ", ".join(skipped),
             )
 
-        # re-validate and clear cache if schedule changed
-        if "schedule" in fields and "schedule" in self.ALLOWED_UPDATE_FIELDS:
-            task._config = None
-            _ = task.config
+        if resets_approval:
+            task.approved = False
 
-        self._save()
+        # Validate the new schedule expression if it changed. Roll back
+        # on failure so the in-memory task isn't poisoned.
+        if "schedule" in fields and fields["schedule"] is not None:
+            task._config = None
+            try:
+                _ = task.config
+            except ValueError as e:
+                # Roll back all changes
+                for k, v in old_values.items():
+                    setattr(task, k, v)
+                task._config = None
+                _ = task.config
+                return f"Error: invalid schedule expression — {e}"
+
+        await self._save_task(task)
         msg = f"Schedule '{name}' updated."
         if skipped:
             msg += f" Ignored unknown field(s): {', '.join(skipped)}."
+        if resets_approval:
+            msg += " Approval reset — pending operator re-approval."
         return msg
 
     async def delete_task(self, name: str) -> str:
@@ -159,7 +338,7 @@ class Scheduler:
             return f"Schedule '{name}' not found."
 
         self._tasks.pop(name, None)
-        self._save()
+        await self._delete_task(name)
         return f"Schedule '{name}' deleted."
 
     async def enable_task(self, name: str) -> str:
@@ -167,6 +346,28 @@ class Scheduler:
 
     async def disable_task(self, name: str) -> str:
         return await self.update_task(name, enabled=False)
+
+    async def approve_task(self, name: str) -> str:
+        """Approve a task's condition code for autonomous execution."""
+        task = self._tasks.get(name)
+        if task is None:
+            return f"Schedule '{name}' not found."
+        if task.condition_code is None:
+            return f"Schedule '{name}' has no condition code — nothing to approve."
+
+        task.approved = True
+        await self._save_task(task)
+        return f"Schedule '{name}' condition code approved."
+
+    async def revoke_task(self, name: str) -> str:
+        """Revoke approval for a task's condition code."""
+        task = self._tasks.get(name)
+        if task is None:
+            return f"Schedule '{name}' not found."
+
+        task.approved = False
+        await self._save_task(task)
+        return f"Schedule '{name}' condition code approval revoked."
 
     async def run(self) -> None:
         """Main scheduler loop. Run as a background asyncio task."""
@@ -212,6 +413,29 @@ class Scheduler:
         """Execute a scheduled task."""
         logger.info("Firing schedule '%s': %s", task.name, task.prompt[:100])
 
+        # --- Condition evaluation ---
+        if task.condition_code:
+            if not task.approved:
+                logger.warning(
+                    "Task '%s' has unapproved condition code — skipping", task.name
+                )
+                task.last_run = now.isoformat()
+                await self._save_task(task)
+                return
+
+            outcome = await self._evaluate_condition(task)
+            if outcome == "skip":
+                task.last_run = now.isoformat()
+                task._retry_count = 0
+                task._condition_retry_count = 0
+                await self._save_task(task)
+                return
+            elif outcome == "failed":
+                await self._handle_condition_failure(task, now)
+                return
+            # outcome == "wake" — fall through to agent wake
+
+        # --- Agent wake ---
         if self._on_fire:
             try:
                 response = await self._on_fire(task.name, task.prompt)
@@ -223,7 +447,8 @@ class Scheduler:
                 # Success — advance last_run and reset retry count
                 task.last_run = now.isoformat()
                 task._retry_count = 0
-                self._save()
+                task._condition_retry_count = 0
+                await self._save_task(task)
             except Exception:
                 task._retry_count += 1
                 if task._retry_count >= 3:
@@ -235,7 +460,7 @@ class Scheduler:
                     )
                     task.last_run = now.isoformat()
                     task._retry_count = 0
-                    self._save()
+                    await self._save_task(task)
                 else:
                     logger.exception(
                         "Schedule '%s' callback failed (attempt %d/3) — "
@@ -246,4 +471,51 @@ class Scheduler:
         else:
             logger.info("Schedule '%s' fired (no callback wired)", task.name)
             task.last_run = now.isoformat()
-            self._save()
+            await self._save_task(task)
+
+    async def _evaluate_condition(self, task: ScheduledTask) -> str:
+        """Run the condition script. Returns 'wake', 'skip', or 'failed'."""
+        if self._condition_runner is None:
+            logger.error("No condition_runner wired for task '%s'", task.name)
+            return "failed"
+
+        try:
+            result = await self._condition_runner(
+                task.condition_code, task.requires_net, task.secrets
+            )
+        except Exception:
+            logger.exception("Condition runner failed for task '%s'", task.name)
+            return "failed"
+
+        if not result.get("success"):
+            logger.warning(
+                "Condition script failed for '%s': %s",
+                task.name,
+                result.get("error", ""),
+            )
+            return "failed"
+
+        output = result.get("output")
+        if isinstance(output, dict) and output.get("wake", False):
+            return "wake"
+        return "skip"
+
+    async def _handle_condition_failure(self, task: ScheduledTask, now: datetime) -> None:
+        """Handle a condition script failure with 3-strike auto-disable."""
+        task._condition_retry_count += 1
+        if task._condition_retry_count >= 3:
+            logger.warning(
+                "Condition for '%s' failed %d consecutive times — auto-disabling",
+                task.name,
+                task._condition_retry_count,
+            )
+            task.enabled = False
+            task.last_run = now.isoformat()
+            task._condition_retry_count = 0
+            await self._save_task(task)
+        else:
+            logger.warning(
+                "Condition for '%s' failed (attempt %d/3) — will retry on next tick",
+                task.name,
+                task._condition_retry_count,
+            )

--- a/src/tools/definitions/scheduler.py
+++ b/src/tools/definitions/scheduler.py
@@ -5,6 +5,8 @@ from src.tools.registry import TOOL_REGISTRY, ToolContext, ToolParameter
 
 logger = logging.getLogger(__name__)
 
+MAX_CODE_SIZE = 50_000
+
 
 @TOOL_REGISTRY.tool(
     name="scheduler.list_schedules",
@@ -40,8 +42,21 @@ async def list_schedules(ctx: ToolContext) -> str:
             desc = task.schedule
             next_str = "unknown"
 
-        lines.append(f"- **{task.name}** [{status}] ({desc})")
+        trigger_badge = ""
+        if task.condition_code is not None:
+            trigger_badge = " [trigger"
+            if task.approved:
+                trigger_badge += ":approved]"
+            else:
+                trigger_badge += ":pending]"
+
+        lines.append(f"- **{task.name}** [{status}]{trigger_badge} ({desc})")
         lines.append(f"  prompt: {task.prompt[:80]}")
+        if task.condition_code is not None:
+            preview = task.condition_code[:80]
+            if len(task.condition_code) > 80:
+                preview += "…"
+            lines.append(f"  condition: {preview}")
         if task.enabled:
             lines.append(f"  next run: {next_str}")
 
@@ -68,7 +83,13 @@ async def get_schedule(ctx: ToolContext, name: str) -> str:
     if task is None:
         return f"Schedule '{name}' not found."
 
-    return json.dumps(task.to_dict(), indent=2)
+    d = task.to_dict()
+    # Truncate condition_code to avoid bloating the agent's context
+    if d.get("condition_code"):
+        d["condition_code"] = d["condition_code"][:200]
+        if len(task.condition_code) > 200:
+            d["condition_code"] += "…"
+    return json.dumps(d, indent=2)
 
 
 SCHEDULE_SYNTAX_HELP = """Supported schedule expressions:
@@ -85,6 +106,8 @@ SCHEDULE_SYNTAX_HELP = """Supported schedule expressions:
     description=f"""Create a new scheduled task that will fire a prompt on a recurring schedule. When the schedule fires, the agent runs the prompt in a fresh conversation (no prior history) with full access to tools and notes, and the run is saved as its own chat session.
 
 Use this to give yourself recurring work — daily summaries, periodic checks, reminders. The prompt should be self-contained since scheduled runs start with no conversation context.
+
+Optionally, you can attach a **condition script** (TypeScript) that runs on schedule *before* waking you. The script calls `output({{ wake: true }})` to wake you, or `output({{ wake: false }})` to skip this cycle. This avoids wasting a turn when there's nothing to act on. Condition code requires operator approval before it will fire.
 
 {SCHEDULE_SYNTAX_HELP}""",
     parameters=[
@@ -103,10 +126,34 @@ Use this to give yourself recurring work — daily summaries, periodic checks, r
             type="string",
             description="The prompt to send yourself when the schedule fires. Must be self-contained (scheduled runs start with no conversation history).",
         ),
+        ToolParameter(
+            name="condition_code",
+            type="string",
+            required=False,
+            description="Optional TypeScript condition script. If provided, the script runs on schedule before waking you. Call output({ wake: true }) to wake, output({ wake: false }) to skip. Requires operator approval before it will fire. Max 50,000 chars.",
+        ),
+        ToolParameter(
+            name="requires_net",
+            type="boolean",
+            required=False,
+            description="Set true if the condition code needs network access (fetch, HTTP). Defaults to false.",
+        ),
+        ToolParameter(
+            name="secrets",
+            type="array",
+            required=False,
+            description="Optional list of secret names to inject as env vars into the condition script.",
+        ),
     ],
 )
 async def create_schedule(
-    ctx: ToolContext, name: str, schedule: str, prompt: str
+    ctx: ToolContext,
+    name: str,
+    schedule: str,
+    prompt: str,
+    condition_code: str | None = None,
+    requires_net: bool = False,
+    secrets: list[str] | None = None,
 ) -> str:
     sched = ctx.scheduler
     if sched is None:
@@ -118,10 +165,35 @@ async def create_schedule(
     if sched.get_task(name) is not None:
         return f"Error: schedule '{name}' already exists. Use update_schedule to modify it, or delete_schedule first."
 
+    if condition_code is not None:
+        if not condition_code.strip():
+            return "Error: condition_code must not be empty."
+        if len(condition_code) > MAX_CODE_SIZE:
+            return f"Error: condition_code too large ({len(condition_code)} chars, max {MAX_CODE_SIZE})."
+
+    # Coerce/validate untyped tool-bridge params
+    requires_net = bool(requires_net)
+    if secrets is not None:
+        if not isinstance(secrets, list) or not all(
+            isinstance(s, str) for s in secrets
+        ):
+            return "Error: secrets must be a list of strings."
+        secrets = list(dict.fromkeys(secrets))  # dedupe, preserve order
+    else:
+        secrets = []
+
     from src.scheduler.scheduler import ScheduledTask
 
     try:
-        task = ScheduledTask(name=name, schedule=schedule, prompt=prompt)
+        task = ScheduledTask(
+            name=name,
+            schedule=schedule,
+            prompt=prompt,
+            condition_code=condition_code,
+            requires_net=requires_net,
+            secrets=secrets or [],
+            approved=False,
+        )
         return await sched.create_task(task)
     except ValueError as e:
         return f"Error: invalid schedule expression — {e}"
@@ -134,6 +206,8 @@ async def create_schedule(
     name="scheduler.update_schedule",
     description=f"""Update an existing scheduled task. Any unspecified field is left unchanged.
 
+If you change the condition_code or broaden requires_net (false→true), approval is reset — the operator must re-approve before the task will fire.
+
 {SCHEDULE_SYNTAX_HELP}""",
     parameters=[
         ToolParameter(
@@ -144,20 +218,38 @@ async def create_schedule(
         ToolParameter(
             name="schedule",
             type="string",
-            description="New schedule expression.",
             required=False,
+            description="New schedule expression.",
         ),
         ToolParameter(
             name="prompt",
             type="string",
-            description="New prompt to fire on this schedule.",
             required=False,
+            description="New prompt to fire on this schedule.",
         ),
         ToolParameter(
             name="enabled",
             type="boolean",
-            description="Enable or disable the schedule.",
             required=False,
+            description="Enable or disable the schedule.",
+        ),
+        ToolParameter(
+            name="condition_code",
+            type="string",
+            required=False,
+            description="New TypeScript condition script. Changing this resets operator approval.",
+        ),
+        ToolParameter(
+            name="requires_net",
+            type="boolean",
+            required=False,
+            description="Whether the condition code needs network access.",
+        ),
+        ToolParameter(
+            name="secrets",
+            type="array",
+            required=False,
+            description="List of secret names to inject as env vars into the condition script.",
         ),
     ],
 )
@@ -167,6 +259,9 @@ async def update_schedule(
     schedule: str | None = None,
     prompt: str | None = None,
     enabled: bool | None = None,
+    condition_code: str | None = None,
+    requires_net: bool | None = None,
+    secrets: list[str] | None = None,
 ) -> str:
     sched = ctx.scheduler
     if sched is None:
@@ -175,9 +270,31 @@ async def update_schedule(
     if sched.get_task(name) is None:
         return f"Schedule '{name}' not found."
 
+    if condition_code is not None:
+        if not condition_code.strip():
+            return "Error: condition_code must not be empty."
+        if len(condition_code) > MAX_CODE_SIZE:
+            return f"Error: condition_code too large ({len(condition_code)} chars, max {MAX_CODE_SIZE})."
+
+    # Coerce/validate untyped tool-bridge params
+    if requires_net is not None:
+        requires_net = bool(requires_net)
+    if secrets is not None:
+        if not isinstance(secrets, list) or not all(
+            isinstance(s, str) for s in secrets
+        ):
+            return "Error: secrets must be a list of strings."
+        secrets = list(dict.fromkeys(secrets))  # dedupe, preserve order
+
     try:
         return await sched.update_task(
-            name, schedule=schedule, prompt=prompt, enabled=enabled
+            name,
+            schedule=schedule,
+            prompt=prompt,
+            enabled=enabled,
+            condition_code=condition_code,
+            requires_net=requires_net,
+            secrets=secrets,
         )
     except ValueError as e:
         return f"Error: invalid schedule expression — {e}"

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -91,11 +91,14 @@ class ToolExecutor:
         except Exception:
             logger.warning("Failed to initialize secrets", exc_info=True)
 
-        # initialize scheduler (local file storage)
+        # initialize scheduler (DocumentStore-backed)
         try:
             from src.scheduler.scheduler import Scheduler
 
-            self._scheduler = Scheduler(path=data_dir / "schedules.json")
+            self._scheduler = Scheduler(
+                store=store.documents,
+                legacy_path=data_dir / "schedules.json",
+            )
             await self._scheduler.load_tasks()
             self._ctx._scheduler = self._scheduler
         except Exception:
@@ -236,6 +239,49 @@ const params = {params_json};
         finally:
             os.unlink(temp_path)
 
+    async def execute_condition_code(
+        self,
+        code: str,
+        env: dict[str, str] | None = None,
+        allow_net: bool = False,
+    ) -> dict[str, Any]:
+        """Execute trigger condition TypeScript code WITHOUT the tools bridge.
+
+        Condition scripts only have access to ``output()`` and ``debug()`` —
+        no backend tools. This prevents a condition predicate from performing
+        side effects via the tool registry.
+        """
+
+        if len(code) > MAX_CODE_SIZE:
+            return {
+                "success": False,
+                "error": f"code too large ({len(code)} chars, max {MAX_CODE_SIZE})",
+                "debug": [],
+            }
+
+        full_code = f"""
+import {{ output, debug }} from "./runtime.ts";
+
+// --- condition code ---
+{code}
+"""
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".ts", delete=False, dir=DENO_DIR
+        ) as f:
+            f.write(full_code)
+            temp_path = f.name
+
+        try:
+            return await self._run_deno_with_permissions(
+                temp_path,
+                allow_net=allow_net,
+                env=env or {},
+                allow_tool_calls=False,
+            )
+        finally:
+            os.unlink(temp_path)
+
     def _write_generated_tools(self) -> None:
         """generate tool stubs and write them to the deno directory"""
 
@@ -284,6 +330,7 @@ const params = {params_json};
         script_path: str,
         allow_net: bool = False,
         env: dict[str, str] | None = None,
+        allow_tool_calls: bool = True,
     ) -> dict[str, Any]:
         """Run deno with configurable permissions for custom tools."""
 
@@ -301,7 +348,12 @@ const params = {params_json};
         ]
 
         if allow_net:
+            # Allow outbound fetch() but NOT remote module loading —
+            # approved code is reviewed as-is, and remote imports could
+            # change behavior after approval.
             args.append("--allow-net")
+            args.append("--no-remote")
+            args.append("--no-npm")
         else:
             args.append("--deny-net")
             args.append("--no-remote")
@@ -335,12 +387,19 @@ const params = {params_json};
             env=proc_env,
         )
 
-        return await self._process_deno_output(process)
+        return await self._process_deno_output(process, allow_tool_calls=allow_tool_calls)
 
     async def _process_deno_output(
-        self, process: asyncio.subprocess.Process
+        self, process: asyncio.subprocess.Process, allow_tool_calls: bool = True
     ) -> dict[str, Any]:
-        """Shared logic for processing deno subprocess output."""
+        """Shared logic for processing deno subprocess output.
+
+        When ``allow_tool_calls`` is False, any ``__tool_call__`` message on
+        stdout is treated as an error — the process is killed and the result
+        is marked as failed. This prevents code that shouldn't have tool
+        access (e.g. trigger condition scripts) from forging tool-call
+        protocol messages to invoke backend tools.
+        """
 
         if process.stdin is None:
             raise RuntimeError("Process stdin is not available")
@@ -403,6 +462,11 @@ const params = {params_json};
                 # whenever we encounter a tool call, we then need to execute that tool and give
                 # it the response
                 if "__tool_call__" in message:
+                    if not allow_tool_calls:
+                        self._kill_process(process)
+                        error = "tool calls are not allowed in this execution mode"
+                        break
+
                     tool_call_count += 1
                     if tool_call_count > MAX_TOOL_CALLS:
                         self._kill_process(process)

--- a/src/web/routers/schedules.py
+++ b/src/web/routers/schedules.py
@@ -38,6 +38,10 @@ def _to_response(task: Any) -> ScheduleResponse:
         enabled=task.enabled,
         last_run=task.last_run,
         next_run=next_run,
+        condition_code=task.condition_code,
+        requires_net=task.requires_net,
+        secrets=list(task.secrets) if task.secrets else [],
+        approved=task.approved,
     )
 
 
@@ -67,16 +71,32 @@ async def create_schedule(
 
     from src.scheduler.scheduler import ScheduledTask
 
+    if scheduler.get_task(body.name) is not None:
+        raise HTTPException(409, f"Schedule '{body.name}' already exists")
+
+    # Normalize empty/whitespace condition_code to None
+    condition_code = body.condition_code
+    if condition_code is not None and not condition_code.strip():
+        condition_code = None
+
     task = ScheduledTask(
         name=body.name,
         schedule=body.schedule,
         prompt=body.prompt,
         enabled=True,
+        condition_code=condition_code,
+        requires_net=body.requires_net,
+        secrets=list(body.secrets) if body.secrets else [],
+        approved=False,
     )
     try:
-        await scheduler.create_task(task)
+        result = await scheduler.create_task(task)
     except (ValueError, RuntimeError) as e:
         raise HTTPException(400, str(e))
+    if result.startswith("Error:"):
+        if "already exists" in result:
+            raise HTTPException(409, result)
+        raise HTTPException(400, result)
     return _to_response(task)
 
 
@@ -104,6 +124,79 @@ async def disable_schedule(
         raise HTTPException(404, f"Schedule '{name}' not found")
     await scheduler.disable_task(name)
     return _to_response(scheduler.get_task(name))
+
+
+@router.post("/schedules/{name}/approve", response_model=ScheduleResponse)
+async def approve_schedule(
+    name: str,
+    executor: ToolExecutor = Depends(get_executor),
+) -> ScheduleResponse:
+    scheduler = _get_scheduler(executor)
+    task = scheduler.get_task(name)
+    if task is None:
+        raise HTTPException(404, f"Schedule '{name}' not found")
+
+    if task.condition_code is None:
+        raise HTTPException(400, "This schedule has no condition code to approve")
+
+    # Check secrets are available (same pattern as tools router)
+    sm = executor.secret_manager
+    if sm:
+        known = set(sm.list_secret_names())
+        missing = [s for s in task.secrets if s not in known]
+        if missing:
+            raise HTTPException(
+                400,
+                detail={
+                    "message": "Schedule has missing secrets",
+                    "missing_secrets": missing,
+                },
+            )
+
+    result = await scheduler.approve_task(name)
+    return _to_response(scheduler.get_task(name))
+
+
+@router.post("/schedules/{name}/revoke", response_model=ScheduleResponse)
+async def revoke_schedule(
+    name: str,
+    executor: ToolExecutor = Depends(get_executor),
+) -> ScheduleResponse:
+    scheduler = _get_scheduler(executor)
+    task = scheduler.get_task(name)
+    if task is None:
+        raise HTTPException(404, f"Schedule '{name}' not found")
+    await scheduler.revoke_task(name)
+    return _to_response(scheduler.get_task(name))
+
+
+@router.post("/schedules/{name}/test")
+async def test_schedule(
+    name: str,
+    executor: ToolExecutor = Depends(get_executor),
+) -> dict[str, Any]:
+    scheduler = _get_scheduler(executor)
+    task = scheduler.get_task(name)
+    if task is None:
+        raise HTTPException(404, f"Schedule '{name}' not found")
+    if not task.condition_code:
+        raise HTTPException(400, "This schedule has no condition code to test")
+
+    # Build env from secrets
+    env: dict[str, str] = {}
+    sm = executor.secret_manager
+    if sm:
+        for secret_name in task.secrets:
+            val = sm.get_secret(secret_name)
+            if val:
+                env[secret_name.upper()] = val
+
+    result = await executor.execute_condition_code(
+        code=task.condition_code,
+        env=env,
+        allow_net=task.requires_net,
+    )
+    return result
 
 
 @router.delete("/schedules/{name}", status_code=204)

--- a/src/web/routers/status.py
+++ b/src/web/routers/status.py
@@ -28,6 +28,15 @@ def get_status(
     scheduler = executor.scheduler
     task_count = len(scheduler.list_tasks()) if scheduler else 0
 
+    # schedules pending approval (have condition_code but not approved)
+    pending_count = 0
+    if scheduler:
+        pending_count = sum(
+            1
+            for t in scheduler.list_tasks()
+            if t.condition_code is not None and not t.approved
+        )
+
     # secret count
     sm = executor.secret_manager
     secret_count = len(sm.list_secret_names()) if sm else 0
@@ -48,6 +57,7 @@ def get_status(
         model=model_name,
         discord=discord_on,
         schedules=task_count,
+        schedules_pending=pending_count,
         secrets=secret_count,
         custom_tools_approved=approved,
         custom_tools_pending=pending,

--- a/src/web/routers/tools.py
+++ b/src/web/routers/tools.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from src.tools.executor import ToolExecutor
 from src.web.dependencies import get_executor
-from src.web.schemas import ToolDetailResponse, ToolSummary
+from src.web.schemas import TestCodeRequest, ToolDetailResponse, ToolSummary
 
 router = APIRouter()
 
@@ -121,3 +121,31 @@ async def delete_tool(
     if tool is None:
         raise HTTPException(404, f"Tool '{name}' not found")
     await mgr.delete_tool(name)
+
+
+@router.post("/tools/{name}/test")
+async def test_tool(
+    name: str,
+    body: TestCodeRequest,
+    executor: ToolExecutor = Depends(get_executor),
+) -> dict[str, Any]:
+    mgr = _get_manager(executor)
+    tool = mgr.get_tool(name)
+    if tool is None:
+        raise HTTPException(404, f"Tool '{name}' not found")
+
+    # Build env from secrets
+    env: dict[str, str] = {}
+    sm = _get_sm(executor)
+    for secret_name in tool.secrets:
+        val = sm.get_secret(secret_name)
+        if val:
+            env[secret_name.upper()] = val
+
+    result = await executor.execute_custom_tool_code(
+        code=tool.code,
+        params=body.params or {},
+        env=env,
+        allow_net=tool.requires_net,
+    )
+    return result

--- a/src/web/schemas.py
+++ b/src/web/schemas.py
@@ -26,6 +26,13 @@ class CreateScheduleRequest(BaseModel):
     name: str
     schedule: str
     prompt: str
+    condition_code: str | None = None
+    requires_net: bool = False
+    secrets: list[str] = []
+
+
+class TestCodeRequest(BaseModel):
+    params: dict = {}
 
 
 # -- response models --
@@ -59,6 +66,7 @@ class StatusResponse(BaseModel):
     model: str
     discord: bool
     schedules: int
+    schedules_pending: int = 0
     secrets: int
     custom_tools_approved: int
     custom_tools_pending: int
@@ -94,6 +102,10 @@ class ScheduleResponse(BaseModel):
     enabled: bool
     last_run: str | None = None
     next_run: str | None = None
+    condition_code: str | None = None
+    requires_net: bool = False
+    secrets: list[str] = []
+    approved: bool = False
 
 
 class SystemPromptResponse(BaseModel):

--- a/tests/test_pr12_scheduler_retry.py
+++ b/tests/test_pr12_scheduler_retry.py
@@ -8,10 +8,21 @@ from src.scheduler.scheduler import Scheduler, ScheduledTask
 
 
 @pytest.fixture
-def scheduler(tmp_path):
-    """Create a scheduler with a temp path."""
-    s = Scheduler(path=tmp_path / "schedules.json")
+async def scheduler_with_store(tmp_path):
+    """Create a scheduler backed by a real DocumentStore."""
+    from src.store.store import Store
+
+    store = Store(path=tmp_path / "test.db")
+    await store.initialize()
+    s = Scheduler(store=store.documents)
     s._on_fire = AsyncMock(return_value="ok")
+    yield s, store
+    await store.close()
+
+
+@pytest.fixture
+async def scheduler(scheduler_with_store):
+    s, _store = scheduler_with_store
     return s
 
 
@@ -79,7 +90,7 @@ async def test_retry_count_resets_on_success(scheduler):
 
 def test_is_due_no_write_side_effect():
     """_is_due should not modify task.last_run when it's None."""
-    scheduler = Scheduler(path=MagicMock())
+    scheduler = Scheduler(store=MagicMock())
     task = ScheduledTask(name="test", schedule="interval:1h", prompt="hello")
     task.last_run = None  # never run
 

--- a/tests/test_pr13_scheduler_allowlist.py
+++ b/tests/test_pr13_scheduler_allowlist.py
@@ -7,12 +7,17 @@ from src.scheduler.scheduler import Scheduler, ScheduledTask
 
 
 @pytest.fixture
-def scheduler_with_task(tmp_path):
-    """Create a scheduler with a test task."""
-    s = Scheduler(path=tmp_path / "schedules.json")
+async def scheduler_with_task(tmp_path):
+    """Create a scheduler with a test task backed by a real DocumentStore."""
+    from src.store.store import Store
+
+    store = Store(path=tmp_path / "test.db")
+    await store.initialize()
+    s = Scheduler(store=store.documents)
     task = ScheduledTask(name="test", schedule="interval:1h", prompt="hello")
     s._tasks["test"] = task
-    return s, task
+    yield s, task
+    await store.close()
 
 
 @pytest.mark.asyncio
@@ -52,11 +57,16 @@ async def test_update_task_skips_none_values(scheduler_with_task):
 @pytest.mark.asyncio
 async def test_update_task_not_found(tmp_path):
     """update_task should return not found for unknown task."""
-    s = Scheduler(path=tmp_path / "schedules.json")
+    from src.store.store import Store
+
+    store = Store(path=tmp_path / "test.db")
+    await store.initialize()
+    s = Scheduler(store=store.documents)
 
     result = await s.update_task("nonexistent", prompt="test")
 
     assert "not found" in result.lower()
+    await store.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_triggers_approval.py
+++ b/tests/test_triggers_approval.py
@@ -1,0 +1,216 @@
+"""Tests for trigger approval gating and agent-facing tool integration."""
+
+import pytest
+from pathlib import Path
+
+from src.scheduler.scheduler import Scheduler, ScheduledTask
+
+
+@pytest.fixture
+async def store(tmp_path):
+    from src.store.store import Store
+
+    s = Store(path=tmp_path / "test.db")
+    await s.initialize()
+    yield s
+    await s.close()
+
+
+@pytest.fixture
+async def scheduler(store):
+    s = Scheduler(store=store.documents)
+    return s
+
+
+# --- approve_task / revoke_task ---
+
+@pytest.mark.asyncio
+async def test_approve_task_sets_approved(scheduler):
+    task = ScheduledTask(
+        name="t1",
+        schedule="1h",
+        prompt="hello",
+        condition_code="output({ wake: true })",
+        approved=False,
+    )
+    scheduler._tasks["t1"] = task
+
+    result = await scheduler.approve_task("t1")
+
+    assert task.approved is True
+    assert "approved" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_approve_task_no_condition_code(scheduler):
+    """Approving a task without condition code returns a message."""
+    task = ScheduledTask(name="t1", schedule="1h", prompt="hello")
+    scheduler._tasks["t1"] = task
+
+    result = await scheduler.approve_task("t1")
+
+    assert task.approved is False  # unchanged
+    assert "no condition code" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_approve_task_not_found(scheduler):
+    result = await scheduler.approve_task("nonexistent")
+    assert "not found" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_revoke_task_sets_unapproved(scheduler):
+    task = ScheduledTask(
+        name="t1",
+        schedule="1h",
+        prompt="hello",
+        condition_code="output({ wake: true })",
+        approved=True,
+    )
+    scheduler._tasks["t1"] = task
+
+    result = await scheduler.revoke_task("t1")
+
+    assert task.approved is False
+    assert "revoked" in result.lower()
+
+
+# --- update_task approval reset ---
+
+@pytest.mark.asyncio
+async def test_update_condition_code_resets_approval(scheduler):
+    """Changing condition_code resets approved to False."""
+    task = ScheduledTask(
+        name="t1",
+        schedule="1h",
+        prompt="hello",
+        condition_code="output({ wake: false })",
+        approved=True,
+    )
+    scheduler._tasks["t1"] = task
+
+    await scheduler.update_task("t1", condition_code="output({ wake: true })")
+
+    assert task.condition_code == "output({ wake: true })"
+    assert task.approved is False  # reset
+
+
+@pytest.mark.asyncio
+async def test_update_requires_net_broadening_resets_approval(scheduler):
+    """Changing requires_net from False to True resets approval."""
+    task = ScheduledTask(
+        name="t1",
+        schedule="1h",
+        prompt="hello",
+        condition_code="output({ wake: true })",
+        requires_net=False,
+        approved=True,
+    )
+    scheduler._tasks["t1"] = task
+
+    await scheduler.update_task("t1", requires_net=True)
+
+    assert task.requires_net is True
+    assert task.approved is False  # reset (broadened permissions)
+
+
+@pytest.mark.asyncio
+async def test_update_requires_net_narrowing_does_not_reset(scheduler):
+    """Changing requires_net from True to False does NOT reset approval."""
+    task = ScheduledTask(
+        name="t1",
+        schedule="1h",
+        prompt="hello",
+        condition_code="output({ wake: true })",
+        requires_net=True,
+        approved=True,
+    )
+    scheduler._tasks["t1"] = task
+
+    await scheduler.update_task("t1", requires_net=False)
+
+    assert task.requires_net is False
+    assert task.approved is True  # NOT reset (narrowed permissions)
+
+
+@pytest.mark.asyncio
+async def test_update_secrets_add_resets_approval(scheduler):
+    """Adding secrets to an approved trigger resets approval."""
+    task = ScheduledTask(
+        name="t1",
+        schedule="1h",
+        prompt="hello",
+        condition_code="output({ wake: true })",
+        secrets=[],
+        approved=True,
+    )
+    scheduler._tasks["t1"] = task
+
+    await scheduler.update_task("t1", secrets=["API_KEY"])
+
+    assert task.secrets == ["API_KEY"]
+    assert task.approved is False  # reset — new secret access
+
+
+@pytest.mark.asyncio
+async def test_update_secrets_remove_does_not_reset(scheduler):
+    """Removing secrets (narrowing) does NOT reset approval."""
+    task = ScheduledTask(
+        name="t1",
+        schedule="1h",
+        prompt="hello",
+        condition_code="output({ wake: true })",
+        secrets=["API_KEY"],
+        approved=True,
+    )
+    scheduler._tasks["t1"] = task
+
+    await scheduler.update_task("t1", secrets=[])
+
+    assert task.secrets == []
+    assert task.approved is True  # NOT reset (narrowed)
+
+
+@pytest.mark.asyncio
+async def test_create_task_rejects_invalid_name(scheduler):
+    """Scheduler.create_task should reject names with path separators."""
+    from src.scheduler.scheduler import ScheduledTask
+
+    task = ScheduledTask(name="bad/name", schedule="1h", prompt="hello")
+    result = await scheduler.create_task(task)
+
+    assert "invalid" in result.lower()
+    assert scheduler.get_task("bad/name") is None
+
+
+# --- AC.6: agent can create schedule with condition_code ---
+
+@pytest.mark.asyncio
+async def test_create_schedule_with_condition_code(store):
+    """scheduler.create_schedule tool creates task with approved=False."""
+    from src.tools.registry import ToolContext
+
+    sched = Scheduler(store=store.documents)
+    ctx = ToolContext()
+    ctx._scheduler = sched
+
+    from src.tools.definitions.scheduler import create_schedule
+
+    result = await create_schedule(
+        ctx,
+        name="my_trigger",
+        schedule="30m",
+        prompt="check stuff",
+        condition_code="output({ wake: true })",
+        requires_net=True,
+        secrets=["API_KEY"],
+    )
+
+    task = sched.get_task("my_trigger")
+    assert task is not None
+    assert task.condition_code == "output({ wake: true })"
+    assert task.approved is False  # pending approval
+    assert task.requires_net is True
+    assert task.secrets == ["API_KEY"]
+    assert "pending operator approval" in result

--- a/tests/test_triggers_condition.py
+++ b/tests/test_triggers_condition.py
@@ -1,0 +1,234 @@
+"""Tests for trigger condition evaluation in the scheduler."""
+
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+from src.scheduler.scheduler import Scheduler, ScheduledTask
+
+
+@pytest.fixture
+async def store(tmp_path):
+    from src.store.store import Store
+
+    s = Store(path=tmp_path / "test.db")
+    await s.initialize()
+    yield s
+    await store_close(s)
+
+
+async def store_close(s):
+    await s.close()
+
+
+@pytest.fixture
+async def scheduler(store):
+    s = Scheduler(store=store.documents)
+    s._on_fire = AsyncMock(return_value="ok")
+    return s
+
+
+def _make_task(**kwargs):
+    """Create a task with a last_run 2 hours ago."""
+    now = datetime.now(timezone.utc)
+    defaults = dict(
+        name="test",
+        schedule="1h",
+        prompt="hello",
+        last_run=(now - timedelta(hours=2)).isoformat(),
+    )
+    defaults.update(kwargs)
+    return ScheduledTask(**defaults)
+
+
+# --- AC.2: wake:false skips agent, advances last_run ---
+
+@pytest.mark.asyncio
+async def test_condition_wake_false_skips_agent(scheduler):
+    """When condition returns {wake: false}, agent is NOT woken and last_run advances."""
+    now = datetime.now(timezone.utc)
+    task = _make_task(condition_code="output({ wake: false })", approved=True)
+    original_last_run = task.last_run
+
+    scheduler._condition_runner = AsyncMock(
+        return_value={"success": True, "output": {"wake": False}}
+    )
+
+    await scheduler._fire(task, now)
+
+    assert scheduler._on_fire.call_count == 0  # agent NOT woken
+    assert task.last_run == now.isoformat()  # last_run advanced
+    assert task._condition_retry_count == 0
+
+
+# --- AC.3: wake:true wakes the agent ---
+
+@pytest.mark.asyncio
+async def test_condition_wake_true_wakes_agent(scheduler):
+    """When condition returns {wake: true}, agent IS woken."""
+    now = datetime.now(timezone.utc)
+    task = _make_task(condition_code="output({ wake: true })", approved=True)
+
+    scheduler._condition_runner = AsyncMock(
+        return_value={"success": True, "output": {"wake": True}}
+    )
+
+    await scheduler._fire(task, now)
+
+    assert scheduler._on_fire.call_count == 1  # agent woken
+    assert task.last_run == now.isoformat()
+    assert task._retry_count == 0
+    assert task._condition_retry_count == 0
+
+
+# --- AC.4: unapproved condition task does not fire ---
+
+@pytest.mark.asyncio
+async def test_unapproved_condition_skipped(scheduler):
+    """Unapproved condition task does not run condition or wake agent; last_run advanced."""
+    now = datetime.now(timezone.utc)
+    original_last_run = (now - timedelta(hours=2)).isoformat()
+    task = _make_task(
+        condition_code="output({ wake: true })",
+        approved=False,
+        last_run=original_last_run,
+    )
+
+    scheduler._condition_runner = AsyncMock(
+        return_value={"success": True, "output": {"wake": True}}
+    )
+
+    await scheduler._fire(task, now)
+
+    assert scheduler._condition_runner.call_count == 0  # condition NOT evaluated
+    assert scheduler._on_fire.call_count == 0  # agent NOT woken
+    assert task.last_run == now.isoformat()  # last_run advanced (prevents log spam)
+
+
+# --- AC.10: condition failure 3-strike auto-disable ---
+
+@pytest.mark.asyncio
+async def test_condition_failure_does_not_advance_last_run(scheduler):
+    """First condition failure does not advance last_run or wake agent."""
+    now = datetime.now(timezone.utc)
+    original_last_run = (now - timedelta(hours=2)).isoformat()
+    task = _make_task(
+        condition_code="throw new Error('boom')",
+        approved=True,
+        last_run=original_last_run,
+    )
+
+    scheduler._condition_runner = AsyncMock(
+        return_value={"success": False, "error": "boom"}
+    )
+
+    await scheduler._fire(task, now)
+
+    assert scheduler._on_fire.call_count == 0
+    assert task.last_run == original_last_run  # NOT advanced
+    assert task._condition_retry_count == 1
+
+
+@pytest.mark.asyncio
+async def test_condition_failure_second_strike(scheduler):
+    """Second failure still does not advance last_run."""
+    now = datetime.now(timezone.utc)
+    original_last_run = (now - timedelta(hours=2)).isoformat()
+    task = _make_task(
+        condition_code="throw new Error('boom')",
+        approved=True,
+        last_run=original_last_run,
+    )
+    task._condition_retry_count = 1  # already failed once
+
+    scheduler._condition_runner = AsyncMock(
+        return_value={"success": False, "error": "boom"}
+    )
+
+    await scheduler._fire(task, now)
+
+    assert task.last_run == original_last_run  # NOT advanced
+    assert task._condition_retry_count == 2
+    assert task.enabled is True  # still enabled
+
+
+@pytest.mark.asyncio
+async def test_condition_failure_third_strike_auto_disables(scheduler):
+    """Third consecutive failure auto-disables the task and advances last_run."""
+    now = datetime.now(timezone.utc)
+    original_last_run = (now - timedelta(hours=2)).isoformat()
+    task = _make_task(
+        condition_code="throw new Error('boom')",
+        approved=True,
+        last_run=original_last_run,
+    )
+    task._condition_retry_count = 2  # already failed twice
+
+    scheduler._condition_runner = AsyncMock(
+        return_value={"success": False, "error": "boom"}
+    )
+
+    await scheduler._fire(task, now)
+
+    assert task.enabled is False  # auto-disabled
+    assert task.last_run == now.isoformat()  # last_run advanced
+    assert task._condition_retry_count == 0  # reset
+    assert scheduler._on_fire.call_count == 0  # never woken
+
+
+# --- Condition runner exception ---
+
+@pytest.mark.asyncio
+async def test_condition_runner_exception_treated_as_failure(scheduler):
+    """If condition_runner itself throws, it's treated as a failure."""
+    now = datetime.now(timezone.utc)
+    original_last_run = (now - timedelta(hours=2)).isoformat()
+    task = _make_task(
+        condition_code="output({ wake: true })",
+        approved=True,
+        last_run=original_last_run,
+    )
+
+    scheduler._condition_runner = AsyncMock(side_effect=RuntimeError("runner crashed"))
+
+    await scheduler._fire(task, now)
+
+    assert scheduler._on_fire.call_count == 0
+    assert task.last_run == original_last_run  # NOT advanced
+    assert task._condition_retry_count == 1
+
+
+# --- No condition_runner wired ---
+
+@pytest.mark.asyncio
+async def test_no_condition_runner_treated_as_failure(scheduler):
+    """If no condition_runner is wired, the task fails."""
+    now = datetime.now(timezone.utc)
+    original_last_run = (now - timedelta(hours=2)).isoformat()
+    task = _make_task(
+        condition_code="output({ wake: true })",
+        approved=True,
+        last_run=original_last_run,
+    )
+
+    scheduler._condition_runner = None
+
+    await scheduler._fire(task, now)
+
+    assert scheduler._on_fire.call_count == 0
+    assert task.last_run == original_last_run  # NOT advanced
+    assert task._condition_retry_count == 1
+
+
+# --- AC.1: no condition_code fires as before ---
+
+@pytest.mark.asyncio
+async def test_no_condition_code_fires_normally(scheduler):
+    """Task without condition_code wakes the agent directly."""
+    now = datetime.now(timezone.utc)
+    task = _make_task()  # no condition_code
+
+    await scheduler._fire(task, now)
+
+    assert scheduler._on_fire.call_count == 1
+    assert task.last_run == now.isoformat()

--- a/tests/test_triggers_migration.py
+++ b/tests/test_triggers_migration.py
@@ -1,0 +1,117 @@
+"""Tests for schedule storage migration from JSON to DocumentStore."""
+
+import json
+import pytest
+from pathlib import Path
+
+from src.scheduler.scheduler import Scheduler, ScheduledTask
+
+
+@pytest.fixture
+async def store(tmp_path):
+    from src.store.store import Store
+
+    s = Store(path=tmp_path / "test.db")
+    await s.initialize()
+    yield s
+    await s.close()
+
+
+def _write_legacy(path: Path, tasks: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(tasks, indent=2) + "\n")
+
+
+@pytest.mark.asyncio
+async def test_migration_imports_tasks(store, tmp_path):
+    """schedules.json entries are migrated to DocumentStore and file renamed."""
+    legacy = tmp_path / "schedules.json"
+    _write_legacy(legacy, [
+        {
+            "name": "task1",
+            "schedule": "1h",
+            "prompt": "do thing 1",
+            "enabled": True,
+        },
+        {
+            "name": "task2",
+            "schedule": "daily@9:00",
+            "prompt": "do thing 2",
+            "enabled": False,
+        },
+    ])
+
+    sched = Scheduler(store=store.documents, legacy_path=legacy)
+    await sched.load_tasks()
+
+    # Both tasks loaded
+    assert len(sched.list_tasks()) == 2
+    t1 = sched.get_task("task1")
+    t2 = sched.get_task("task2")
+    assert t1 is not None and t2 is not None
+
+    # New fields have defaults
+    assert t1.condition_code is None
+    assert t1.requires_net is False
+    assert t1.secrets == []
+    assert t1.approved is False
+
+    # Legacy file renamed
+    assert not legacy.exists()
+    assert (tmp_path / "schedules.json.migrated").exists()
+
+
+@pytest.mark.asyncio
+async def test_migration_idempotent(store, tmp_path):
+    """Re-running with already-migrated file does not error or duplicate."""
+    legacy = tmp_path / "schedules.json"
+    _write_legacy(legacy, [
+        {"name": "task1", "schedule": "1h", "prompt": "p1", "enabled": True},
+    ])
+
+    sched = Scheduler(store=store.documents, legacy_path=legacy)
+    await sched.load_tasks()
+    assert len(sched.list_tasks()) == 1
+
+    # The file is renamed, so a second load should be a no-op
+    assert not legacy.exists()
+    sched2 = Scheduler(store=store.documents, legacy_path=legacy)
+    await sched2.load_tasks()
+    assert len(sched2.list_tasks()) == 1  # no duplicate
+
+
+@pytest.mark.asyncio
+async def test_no_legacy_file(store, tmp_path):
+    """No legacy file → no error, empty task list."""
+    legacy = tmp_path / "schedules.json"  # doesn't exist
+    sched = Scheduler(store=store.documents, legacy_path=legacy)
+    await sched.load_tasks()
+    assert len(sched.list_tasks()) == 0
+
+
+@pytest.mark.asyncio
+async def test_round_trip_persisted_fields(store, tmp_path):
+    """Tasks with condition fields round-trip through DocumentStore."""
+    sched = Scheduler(store=store.documents, legacy_path=None)
+
+    task = ScheduledTask(
+        name="trigger1",
+        schedule="30m",
+        prompt="check stuff",
+        condition_code="output({ wake: true })",
+        requires_net=True,
+        secrets=["API_KEY"],
+        approved=True,
+    )
+    await sched.create_task(task)
+
+    # Reload from store
+    sched2 = Scheduler(store=store.documents, legacy_path=None)
+    await sched2.load_tasks()
+
+    loaded = sched2.get_task("trigger1")
+    assert loaded is not None
+    assert loaded.condition_code == "output({ wake: true })"
+    assert loaded.requires_net is True
+    assert loaded.secrets == ["API_KEY"]
+    assert loaded.approved is True

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -36,7 +36,7 @@ async def _build_full_executor(tmp_path: Path) -> ToolExecutor:
     ctx._secret_manager = sm
 
     # attach scheduler
-    scheduler = Scheduler(path=tmp_path / "schedules.json")
+    scheduler = Scheduler(store=store.documents)
     await scheduler.load_tasks()
     executor._scheduler = scheduler
     ctx._scheduler = scheduler

--- a/web/src/components/schedules/SchedulesView.test.tsx
+++ b/web/src/components/schedules/SchedulesView.test.tsx
@@ -8,10 +8,11 @@ const { mockApi, ApiError } = vi.hoisted(() => ({
     getStatus: vi.fn(), listSessions: vi.fn(), createSession: vi.fn(),
     getSession: vi.fn(), deleteSession: vi.fn(), listMessages: vi.fn(),
     chat: vi.fn(), listTools: vi.fn(), getTool: vi.fn(), approveTool: vi.fn(),
-    revokeTool: vi.fn(), deleteTool: vi.fn(), listSecrets: vi.fn(),
-    setSecret: vi.fn(), deleteSecret: vi.fn(), listSchedules: vi.fn(),
-    createSchedule: vi.fn(), enableSchedule: vi.fn(), disableSchedule: vi.fn(),
-    deleteSchedule: vi.fn(), getSystemPrompt: vi.fn(),
+    revokeTool: vi.fn(), deleteTool: vi.fn(), testTool: vi.fn(),
+    listSecrets: vi.fn(), setSecret: vi.fn(), deleteSecret: vi.fn(),
+    listSchedules: vi.fn(), createSchedule: vi.fn(), enableSchedule: vi.fn(),
+    disableSchedule: vi.fn(), deleteSchedule: vi.fn(), approveSchedule: vi.fn(),
+    revokeSchedule: vi.fn(), testSchedule: vi.fn(), getSystemPrompt: vi.fn(),
   },
   ApiError: class ApiError extends Error {
     status: number; detail: unknown;
@@ -76,7 +77,7 @@ describe("SchedulesView", () => {
     fireEvent.click(screen.getByText("New"));
     await waitFor(() => expect(screen.getByText("Create")).toBeInTheDocument());
     fireEvent.click(screen.getByText("Create"));
-    expect(screen.getByText("All fields are required")).toBeInTheDocument();
+    expect(screen.getByText("Name, schedule, and prompt are required")).toBeInTheDocument();
   });
 
   it("creates a schedule with all fields filled", async () => {
@@ -88,6 +89,15 @@ describe("SchedulesView", () => {
     fireEvent.change(screen.getByPlaceholderText(/30m/), { target: { value: "1h" } });
     fireEvent.change(screen.getByPlaceholderText("Instruction for the agent…"), { target: { value: "Do something" } });
     fireEvent.click(screen.getByText("Create"));
-    await waitFor(() => expect(api.createSchedule).toHaveBeenCalledWith("my_task", "1h", "Do something"));
+    await waitFor(() =>
+      expect(api.createSchedule).toHaveBeenCalledWith(
+        "my_task",
+        "1h",
+        "Do something",
+        undefined,
+        undefined,
+        undefined,
+      ),
+    );
   });
 });

--- a/web/src/components/schedules/SchedulesView.tsx
+++ b/web/src/components/schedules/SchedulesView.tsx
@@ -1,13 +1,18 @@
 import { useEffect, useState, useCallback } from "react";
-import { Plus, Trash2, Power, PowerOff } from "lucide-react";
-import { api } from "@/lib/api";
+import { Plus, Trash2, Power, PowerOff, FlaskConical, Check, X } from "lucide-react";
+import { api, ApiError } from "@/lib/api";
 import type { Schedule } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 export function SchedulesView() {
   const [schedules, setSchedules] = useState<Schedule[]>([]);
@@ -16,7 +21,13 @@ export function SchedulesView() {
   const [name, setName] = useState("");
   const [schedule, setSchedule] = useState("");
   const [prompt, setPrompt] = useState("");
+  const [conditionCode, setConditionCode] = useState("");
+  const [requiresNet, setRequiresNet] = useState(false);
+  const [secretsInput, setSecretsInput] = useState("");
   const [error, setError] = useState("");
+  const [testResult, setTestResult] = useState<Record<string, unknown> | null>(null);
+  const [testingName, setTestingName] = useState<string | null>(null);
+  const [approveError, setApproveError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -35,14 +46,28 @@ export function SchedulesView() {
   const handleCreate = async () => {
     setError("");
     if (!name || !schedule || !prompt) {
-      setError("All fields are required");
+      setError("Name, schedule, and prompt are required");
       return;
     }
     try {
-      await api.createSchedule(name, schedule, prompt);
+      const secrets = secretsInput
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      await api.createSchedule(
+        name,
+        schedule,
+        prompt,
+        conditionCode || undefined,
+        requiresNet || undefined,
+        secrets.length > 0 ? secrets : undefined,
+      );
       setName("");
       setSchedule("");
       setPrompt("");
+      setConditionCode("");
+      setRequiresNet(false);
+      setSecretsInput("");
       setShowAdd(false);
       await refresh();
     } catch (e) {
@@ -73,6 +98,47 @@ export function SchedulesView() {
     }
   };
 
+  const handleApprove = async (s: Schedule) => {
+    setApproveError(null);
+    try {
+      await api.approveSchedule(s.name);
+      await refresh();
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 400) {
+        const detail = e.detail as { missing_secrets?: string[]; message?: string };
+        if (detail?.missing_secrets) {
+          setApproveError(
+            `Missing secrets: ${detail.missing_secrets.join(", ")}`,
+          );
+        } else {
+          setApproveError(detail?.message || "Approval failed");
+        }
+      } else {
+        setApproveError("Failed to approve schedule");
+      }
+    }
+  };
+
+  const handleRevoke = async (s: Schedule) => {
+    try {
+      await api.revokeSchedule(s.name);
+      await refresh();
+    } catch (e) {
+      console.error("Failed to revoke schedule:", e);
+    }
+  };
+
+  const handleTest = async (s: Schedule) => {
+    setTestingName(s.name);
+    setTestResult(null);
+    try {
+      const result = await api.testSchedule(s.name);
+      setTestResult(result);
+    } catch (e) {
+      setTestResult({ error: e instanceof Error ? e.message : "Test failed" });
+    }
+  };
+
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between px-6 py-3">
@@ -81,6 +147,9 @@ export function SchedulesView() {
           <Plus className="mr-1 h-4 w-4" /> New
         </Button>
       </div>
+      {approveError && (
+        <div className="px-6 pb-2 text-sm text-red-500">{approveError}</div>
+      )}
       <ScrollArea className="flex-1">
         <div className="px-3 pb-4">
           {loading ? (
@@ -97,12 +166,31 @@ export function SchedulesView() {
                   className="group flex items-center gap-3 rounded-md px-3 py-2.5 hover:bg-accent"
                 >
                   <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 flex-wrap">
                       <span className="text-sm font-medium">{s.name}</span>
                       {s.enabled ? (
                         <Badge className="bg-green-600 text-white">enabled</Badge>
                       ) : (
                         <Badge variant="secondary" className="bg-red-600 text-white">disabled</Badge>
+                      )}
+                      {s.condition_code && (
+                        <>
+                          <Badge variant="outline" className="border-blue-500 text-blue-500">
+                            trigger
+                          </Badge>
+                          {s.approved ? (
+                            <Badge className="bg-green-600 text-white">approved</Badge>
+                          ) : (
+                            <Badge variant="secondary" className="bg-yellow-600 text-white">
+                              pending
+                            </Badge>
+                          )}
+                          {s.requires_net && (
+                            <Badge variant="outline" className="border-orange-500 text-orange-500">
+                              net
+                            </Badge>
+                          )}
+                        </>
                       )}
                     </div>
                     <div className="truncate text-xs text-muted-foreground">
@@ -115,6 +203,40 @@ export function SchedulesView() {
                     )}
                   </div>
                   <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100">
+                    {s.condition_code && (
+                      <>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          title="Test condition"
+                          onClick={() => handleTest(s)}
+                        >
+                          <FlaskConical className="h-3.5 w-3.5 text-blue-500" />
+                        </Button>
+                        {s.approved ? (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            title="Revoke approval"
+                            onClick={() => handleRevoke(s)}
+                          >
+                            <X className="h-3.5 w-3.5 text-yellow-500" />
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            title="Approve condition"
+                            onClick={() => handleApprove(s)}
+                          >
+                            <Check className="h-3.5 w-3.5 text-green-500" />
+                          </Button>
+                        )}
+                      </>
+                    )}
                     <Button
                       variant="ghost"
                       size="icon"
@@ -144,7 +266,7 @@ export function SchedulesView() {
       </ScrollArea>
 
       <Dialog open={showAdd} onOpenChange={setShowAdd}>
-        <DialogContent>
+        <DialogContent className="max-h-[85vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>New Schedule</DialogTitle>
           </DialogHeader>
@@ -170,8 +292,59 @@ export function SchedulesView() {
                 placeholder="Instruction for the agent…"
               />
             </div>
+            <div className="border-t pt-3">
+              <div className="text-sm font-medium mb-1">
+                Condition script (optional)
+              </div>
+              <p className="text-xs text-muted-foreground mb-2">
+                TypeScript that runs on schedule before waking the agent. Call
+                <code className="mx-1 px-1 bg-muted rounded">output(&#123; wake: true &#125;)</code>
+                to wake, or
+                <code className="mx-1 px-1 bg-muted rounded">output(&#123; wake: false &#125;)</code>
+                to skip. Requires operator approval.
+              </p>
+              <Textarea
+                value={conditionCode}
+                onChange={(e) => setConditionCode(e.target.value)}
+                placeholder="// Optional: TypeScript condition script"
+                className="font-mono text-xs"
+                rows={5}
+              />
+              <div className="flex items-center gap-4 mt-2">
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={requiresNet}
+                    onChange={(e) => setRequiresNet(e.target.checked)}
+                  />
+                  Requires network
+                </label>
+              </div>
+              <div className="mt-2">
+                <label className="text-sm font-medium">Secrets (comma-separated)</label>
+                <Input
+                  value={secretsInput}
+                  onChange={(e) => setSecretsInput(e.target.value)}
+                  placeholder="API_KEY, CALENDAR_URL"
+                />
+              </div>
+            </div>
             <Button onClick={handleCreate}>Create</Button>
           </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={testResult !== null}
+        onOpenChange={(o) => !o && setTestResult(null)}
+      >
+        <DialogContent className="max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Condition test result{testingName ? `: ${testingName}` : ""}</DialogTitle>
+          </DialogHeader>
+          <pre className="overflow-x-auto rounded-md bg-zinc-900 p-3 text-xs text-zinc-100">
+            <code>{JSON.stringify(testResult, null, 2)}</code>
+          </pre>
         </DialogContent>
       </Dialog>
     </div>

--- a/web/src/components/tools/ToolDetail.test.tsx
+++ b/web/src/components/tools/ToolDetail.test.tsx
@@ -9,10 +9,10 @@ const { mockApi, ApiError } = vi.hoisted(() => ({
     getStatus: vi.fn(), listSessions: vi.fn(), createSession: vi.fn(),
     getSession: vi.fn(), deleteSession: vi.fn(), listMessages: vi.fn(),
     chat: vi.fn(), listTools: vi.fn(), getTool: vi.fn(), approveTool: vi.fn(),
-    revokeTool: vi.fn(), deleteTool: vi.fn(), listSecrets: vi.fn(),
-    setSecret: vi.fn(), deleteSecret: vi.fn(), listSchedules: vi.fn(),
-    createSchedule: vi.fn(), enableSchedule: vi.fn(), disableSchedule: vi.fn(),
-    deleteSchedule: vi.fn(), getSystemPrompt: vi.fn(),
+    revokeTool: vi.fn(), deleteTool: vi.fn(), testTool: vi.fn(),
+    listSecrets: vi.fn(), setSecret: vi.fn(), deleteSecret: vi.fn(),
+    listSchedules: vi.fn(), createSchedule: vi.fn(), enableSchedule: vi.fn(),
+    disableSchedule: vi.fn(), deleteSchedule: vi.fn(), getSystemPrompt: vi.fn(),
   },
   ApiError: class ApiError extends Error {
     status: number; detail: unknown;

--- a/web/src/components/tools/ToolDetail.tsx
+++ b/web/src/components/tools/ToolDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { ArrowLeft, Check, X, Trash2 } from "lucide-react";
+import { ArrowLeft, Check, X, Trash2, FlaskConical } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import type { ToolDetail as ToolDetailType } from "@/lib/types";
 import { Button } from "@/components/ui/button";
@@ -96,6 +96,23 @@ export function ToolDetail() {
     }
   };
 
+  const [testResult, setTestResult] = useState<Record<string, unknown> | null>(null);
+  const [testing, setTesting] = useState(false);
+
+  const handleTest = async () => {
+    if (!name) return;
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await api.testTool(name);
+      setTestResult(result);
+    } catch (e) {
+      setTestResult({ error: e instanceof Error ? e.message : "Test failed" });
+    } finally {
+      setTesting(false);
+    }
+  };
+
   if (loading) return <div className="p-6 text-muted-foreground">Loading…</div>;
   if (!tool) return <div className="p-6 text-muted-foreground">Tool not found.</div>;
 
@@ -122,6 +139,9 @@ export function ToolDetail() {
               <X className="mr-1 h-4 w-4" /> Revoke
             </Button>
           )}
+          <Button size="sm" variant="outline" onClick={handleTest} disabled={testing}>
+            <FlaskConical className="mr-1 h-4 w-4" /> Test
+          </Button>
           <Button size="sm" variant="destructive" onClick={handleDelete}>
             <Trash2 className="mr-1 h-4 w-4" /> Delete
           </Button>
@@ -170,6 +190,15 @@ export function ToolDetail() {
             <code>{tool.code}</code>
           </pre>
         </div>
+
+        {testResult !== null && (
+          <div>
+            <div className="mb-1 text-xs font-medium text-muted-foreground">Test Result</div>
+            <pre className="overflow-x-auto rounded-md bg-zinc-900 p-3 text-xs text-zinc-100">
+              <code>{JSON.stringify(testResult, null, 2)}</code>
+            </pre>
+          </div>
+        )}
       </div>
 
       {/* Missing secret dialog */}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -142,11 +142,25 @@ export const api = {
   // -- schedules --
 
   listSchedules: () => fetchJSON<Schedule[]>(`${API_BASE}/schedules`),
-  createSchedule: (name: string, schedule: string, prompt: string) =>
+  createSchedule: (
+    name: string,
+    schedule: string,
+    prompt: string,
+    condition_code?: string,
+    requires_net?: boolean,
+    secrets?: string[],
+  ) =>
     fetchJSON<Schedule>(`${API_BASE}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name, schedule, prompt }),
+      body: JSON.stringify({
+        name,
+        schedule,
+        prompt,
+        condition_code: condition_code || null,
+        requires_net: requires_net || false,
+        secrets: secrets || [],
+      }),
     }),
   enableSchedule: (name: string) =>
     fetchJSON<Schedule>(`${API_BASE}/schedules/${enc(name)}/enable`, {
@@ -158,6 +172,26 @@ export const api = {
     }),
   deleteSchedule: (name: string) =>
     fetchJSON<void>(`${API_BASE}/schedules/${enc(name)}`, { method: "DELETE" }),
+  approveSchedule: (name: string) =>
+    fetchJSON<Schedule>(`${API_BASE}/schedules/${enc(name)}/approve`, {
+      method: "POST",
+    }),
+  revokeSchedule: (name: string) =>
+    fetchJSON<Schedule>(`${API_BASE}/schedules/${enc(name)}/revoke`, {
+      method: "POST",
+    }),
+  testSchedule: (name: string) =>
+    fetchJSON<Record<string, unknown>>(`${API_BASE}/schedules/${enc(name)}/test`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    }),
+  testTool: (name: string, params: Record<string, unknown> = {}) =>
+    fetchJSON<Record<string, unknown>>(`${API_BASE}/tools/${enc(name)}/test`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ params }),
+    }),
 
   // -- system prompt --
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -28,6 +28,7 @@ export interface Status {
   model: string;
   discord: boolean;
   schedules: number;
+  schedules_pending: number;
   secrets: number;
   custom_tools_approved: number;
   custom_tools_pending: number;
@@ -63,6 +64,10 @@ export interface Schedule {
   enabled: boolean;
   last_run: string | null;
   next_run: string | null;
+  condition_code: string | null;
+  requires_net: boolean;
+  secrets: string[];
+  approved: boolean;
 }
 
 export interface SystemPrompt {

--- a/web/src/test/mockApi.ts
+++ b/web/src/test/mockApi.ts
@@ -56,6 +56,7 @@ export const mockStatus: Status = {
   model: "claude-sonnet-4-5",
   discord: true,
   schedules: 3,
+  schedules_pending: 1,
   secrets: 5,
   custom_tools_approved: 2,
   custom_tools_pending: 1,
@@ -138,6 +139,10 @@ export const mockSchedules: Schedule[] = [
     enabled: true,
     last_run: "2024-01-01T09:00:00.000Z",
     next_run: "2024-01-02T09:00:00.000Z",
+    condition_code: null,
+    requires_net: false,
+    secrets: [],
+    approved: false,
   },
   {
     name: "weekly_cleanup",
@@ -146,6 +151,10 @@ export const mockSchedules: Schedule[] = [
     enabled: false,
     last_run: null,
     next_run: null,
+    condition_code: null,
+    requires_net: false,
+    secrets: [],
+    approved: false,
   },
 ];
 


### PR DESCRIPTION
## Summary

Replace the always-wake scheduler with a unified model where each scheduled task can optionally have a **condition script** — TypeScript that runs in Deno on schedule and only wakes the agent when it returns `{ wake: true }`. This eliminates token waste for recurring checks that usually find nothing to act on.

## Changes

### Data model + storage (`scheduler.py`)
- `ScheduledTask` gains `condition_code`, `requires_net`, `secrets`, `approved` fields
- Storage migrates from `schedules.json` to SQLite via `DocumentStore` (rkey prefix `schedule:`)
- One-time migration: imports legacy JSON entries, renames file to `.migrated` (idempotent)
- `_save_task` is an upsert (try create → except `StoreConflict` → update)

### Condition evaluation (`scheduler.py`, `main.py`)
- `_fire` layers condition evaluation *before* the existing agent-wake logic
- `_evaluate_condition` returns tri-state: `"wake"` | `"skip"` | `"failed"`
- Condition failures use the same 3-strike retry pattern as agent-wake failures
- Unapproved condition tasks are skipped without advancing `last_run`
- `condition_runner` callback wired in `main.py` alongside `on_fire`

### Approval gating
- `approve_task` / `revoke_task` methods on `Scheduler`
- `update_task` resets approval when `condition_code` changes or `requires_net` goes False→True (broadens permissions)

### Agent-facing tools (`definitions/scheduler.py`)
- `create_schedule` and `update_schedule` extended with `condition_code`, `requires_net`, `secrets` params
- `list_schedules` / `get_schedule` show trigger status and condition preview
- Code size validation (max 50,000 chars)

### Web API
- `POST /schedules/{name}/approve` — checks secrets, sets approved
- `POST /schedules/{name}/revoke` — sets unapproved
- `POST /schedules/{name}/test` — runs condition code with full net + secrets
- `POST /tools/{name}/test` — runs tool code with full net + secrets
- `ScheduleResponse` includes `condition_code`, `requires_net`, `secrets`, `approved`
- `StatusResponse` includes `schedules_pending` count

### Web UI
- Trigger badge + pending/approved badges on schedule list
- Approve/revoke/test buttons for trigger tasks
- Condition code, requires_net, secrets fields in New Schedule dialog
- Test button on ToolDetail with inline result display

### Docs
- System prompt describes triggers and how to use them
- README updated with scheduling/triggers section and migration notes

## Tests
- `test_triggers_condition.py` — wake:true wakes agent, wake:false skips, unapproved skips, 3-strike auto-disable, runner exception, no-runner, no-condition fires normally
- `test_triggers_migration.py` — JSON→SQLite migration, idempotency, no-legacy-file, round-trip persisted fields
- `test_triggers_approval.py` — approve/revoke, approval reset on condition_code change, requires_net broadening/narrowing, agent tool creates with approved=False
- `test_pr12_scheduler_retry.py` / `test_pr13_scheduler_allowlist.py` — updated for new `Scheduler(store=...)` constructor, all original behavior preserved

## Notes
- The `test_create_schedule_with_condition_code` test was hanging on import; this is fixed in the worktree but I want to verify it passes cleanly before merge.
- Tasks without `condition_code` behave exactly as before (AC.1).