### PR TITLE
Add configurable MCP server integration

### DIFF
--- a/main.py
+++ b/main.py
@@ -208,6 +208,15 @@ async def _load_system_prompt(
                 lines.append(f"- **{t.name}**: {t.description}")
             custom_tools_list = "\n".join(lines)
 
+    # build MCP servers list for the system prompt
+    mcp_servers_list = ""
+    if executor.mcp_manager is not None:
+        servers = executor.mcp_manager.list_servers()
+        if servers:
+            mcp_servers_list = "\n".join(
+                f"- **{s.name}**: {s.transport}" for s in servers
+            )
+
     return build_system_prompt(
         self_doc=self_doc,
         operator_doc=operator_doc,
@@ -215,6 +224,7 @@ async def _load_system_prompt(
         tool_docs=tool_docs,
         secret_names=secret_names,
         custom_tools_list=custom_tools_list,
+        mcp_servers_list=mcp_servers_list,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "exa-py>=2.3.0",
     "fastapi>=0.115.0",
     "httpx>=0.28.0",
+    "mcp>=1.28.0",
     "numpy>=2.0.0",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.12.0",

--- a/src/agent/prompt.py
+++ b/src/agent/prompt.py
@@ -177,6 +177,18 @@ You can call multiple custom tools in a single `execute_code` block — just `aw
 """
 
 
+MCP_TOOLS_TEMPLATE = """
+# MCP Tools
+
+MCP (Model Context Protocol) tools are external tools provided by MCP servers. They appear in the `tools` namespace under their server name (e.g. `tools.fastmail.search_mail(...)`). Each tool was discovered from its server and individually approved by the operator.
+
+If an MCP tool returns a connection error, the server may be temporarily unavailable — inform the operator.
+
+Configured MCP servers:
+{mcp_servers_list}
+"""
+
+
 def build_system_prompt(
     self_doc: str = "",
     operator_doc: str = "",
@@ -184,6 +196,7 @@ def build_system_prompt(
     tool_docs: str = "",
     secret_names: list[str] | None = None,
     custom_tools_list: str = "",
+    mcp_servers_list: str = "",
 ) -> str:
     """
     builds the system prompt from static instructions and per-agent content.
@@ -215,5 +228,9 @@ def build_system_prompt(
     # approved custom tools list
     if custom_tools_list:
         parts.append(CUSTOM_TOOLS_LIST_TEMPLATE.format(custom_tools_list=custom_tools_list))
+
+    # MCP tools section
+    if mcp_servers_list:
+        parts.append(MCP_TOOLS_TEMPLATE.format(mcp_servers_list=mcp_servers_list))
 
     return "\n".join(parts)

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -28,6 +28,7 @@ class ToolExecutor:
         self._ctx = ctx
         self._tool_definition: dict[str, Any] | None = None
         self._custom_tool_manager: Any | None = None
+        self._mcp_manager: Any | None = None
         self._secret_manager: Any | None = None
         self._scheduler: Any | None = None
 
@@ -44,6 +45,10 @@ class ToolExecutor:
     @property
     def custom_tool_manager(self) -> Any | None:
         return self._custom_tool_manager
+
+    @property
+    def mcp_manager(self) -> Any | None:
+        return self._mcp_manager
 
     @property
     def scheduler(self) -> Any | None:
@@ -115,6 +120,21 @@ class ToolExecutor:
         except Exception:
             logger.warning("Failed to initialize custom tool manager", exc_info=True)
 
+        # initialize MCP manager (connect to external MCP servers)
+        try:
+            from src.tools.mcp import MCPManager
+
+            self._mcp_manager = MCPManager(
+                store=store,
+                secret_manager=self._secret_manager,
+                registry=self._registry,
+            )
+            await self._mcp_manager.load_servers()
+            await self._mcp_manager.connect_all()
+            self._ctx._mcp_manager = self._mcp_manager
+        except Exception:
+            logger.warning("Failed to initialize MCP manager", exc_info=True)
+
         # initialize embedding client (Ollama) — non-fatal if unavailable
         embedding_client = None
         try:
@@ -149,6 +169,12 @@ class ToolExecutor:
 
     async def aclose(self) -> None:
         """Close resources held by the executor (embedding client HTTP connection)."""
+        if self._mcp_manager is not None:
+            try:
+                await self._mcp_manager.disconnect_all()
+            except Exception:
+                logger.warning("Error closing MCP connections", exc_info=True)
+
         if self._ctx._embedding_client is not None:
             try:
                 await self._ctx._embedding_client.close()

--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -37,6 +37,16 @@ _RESERVED_NAMESPACES = {
     "custom_tools",
 }
 
+# TypeScript/JavaScript reserved words that must not be used as identifiers
+_TS_RESERVED_WORDS = frozenset({
+    "break", "case", "catch", "class", "const", "continue", "debugger", "default",
+    "delete", "do", "else", "enum", "export", "extends", "false", "finally", "for",
+    "function", "if", "import", "in", "instanceof", "new", "null", "return", "super",
+    "switch", "this", "throw", "true", "try", "typeof", "var", "void", "while", "with",
+    "yield", "let", "static", "await", "async", "implements", "interface", "package",
+    "private", "protected", "public", "type", "as", "from", "of", "namespace",
+})
+
 # Valid server name: must be a valid TypeScript identifier (letter/underscore start, alphanumeric/underscore body)
 _SERVER_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
 
@@ -267,6 +277,13 @@ class MCPManager:
         self._registry = registry
         self._servers: dict[str, MCPServerConfig] = {}
         self._connections: dict[str, MCPConnection] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def _get_lock(self, name: str) -> asyncio.Lock:
+        """Get or create a per-server lock for serializing operations."""
+        if name not in self._locks:
+            self._locks[name] = asyncio.Lock()
+        return self._locks[name]
 
     # -- loading from store --
 
@@ -306,6 +323,10 @@ class MCPManager:
 
     async def connect_server(self, name: str) -> None:
         """Connect to a server, discover tools, and register approved tools."""
+        async with self._get_lock(name):
+            await self._connect_server_impl(name)
+
+    async def _connect_server_impl(self, name: str) -> None:
         config = self._servers.get(name)
         if config is None:
             raise ValueError(f"MCP server '{name}' not found")
@@ -318,16 +339,26 @@ class MCPManager:
         await conn.connect()
         self._connections[name] = conn
 
-        # discover tools (updates config.tools)
-        await self.discover_tools(name)
+        try:
+            # discover tools (updates config.tools)
+            await self.discover_tools(name)
 
-        # register any previously-approved tools
-        for tool in config.tools:
-            if tool.approved:
-                self._register_tool(name, tool)
+            # register any previously-approved tools
+            for tool in config.tools:
+                if tool.approved:
+                    self._register_tool(name, tool)
+        except BaseException:
+            # Clean up the connection if discovery or registration failed
+            # so we don't leave a live session with no tools registered.
+            await self.disconnect_server(name)
+            raise
 
     async def disconnect_server(self, name: str) -> None:
         """Disconnect a server and unregister its tools."""
+        async with self._get_lock(name):
+            await self._disconnect_server_impl(name)
+
+    async def _disconnect_server_impl(self, name: str) -> None:
         # unregister all approved tools for this server
         config = self._servers.get(name)
         if config:
@@ -360,6 +391,10 @@ class MCPManager:
 
     async def discover_tools(self, name: str) -> None:
         """Re-discover tools from a connected server. Persists updated config."""
+        async with self._get_lock(name):
+            await self._discover_tools_impl(name)
+
+    async def _discover_tools_impl(self, name: str) -> None:
         config = self._servers.get(name)
         if config is None:
             raise ValueError(f"MCP server '{name}' not found")
@@ -441,6 +476,10 @@ class MCPManager:
 
     async def approve_tool(self, server_name: str, tool_name: str) -> str:
         """Approve a tool — registers it in the registry."""
+        async with self._get_lock(server_name):
+            return await self._approve_tool_impl(server_name, tool_name)
+
+    async def _approve_tool_impl(self, server_name: str, tool_name: str) -> str:
         config = self._servers.get(server_name)
         if config is None:
             return f"MCP server '{server_name}' not found."
@@ -462,6 +501,10 @@ class MCPManager:
 
     async def revoke_tool(self, server_name: str, tool_name: str) -> str:
         """Revoke a tool — unregisters it from the registry."""
+        async with self._get_lock(server_name):
+            return await self._revoke_tool_impl(server_name, tool_name)
+
+    async def _revoke_tool_impl(self, server_name: str, tool_name: str) -> str:
         config = self._servers.get(server_name)
         if config is None:
             return f"MCP server '{server_name}' not found."
@@ -511,6 +554,8 @@ class MCPManager:
             )
         if config.name in _RESERVED_NAMESPACES:
             return f"Error: server name '{config.name}' is a reserved namespace."
+        if config.name in _TS_RESERVED_WORDS:
+            return f"Error: server name '{config.name}' is a TypeScript reserved word."
         if config.name in self._servers:
             return f"Error: server '{config.name}' already exists."
 
@@ -625,10 +670,12 @@ class MCPManager:
 
     @staticmethod
     def _sanitize_tool_name(name: str) -> str:
-        """Replace non-identifier characters with underscore, ensure valid start."""
+        """Replace non-identifier characters with underscore, ensure valid start, avoid reserved words."""
         sanitized = _SANITIZE_PATTERN.sub("_", name)
         if sanitized and not sanitized[0].isalpha() and sanitized[0] != "_":
             sanitized = "_" + sanitized
+        if sanitized in _TS_RESERVED_WORDS:
+            sanitized += "_"
         return sanitized
 
     @staticmethod
@@ -636,6 +683,7 @@ class MCPManager:
         """Convert a JSON Schema to ToolParameter list + param name mapping.
 
         Returns (params, mapping) where mapping is sanitized_name -> original_name.
+        Sanitized names are made unique with numeric suffixes if collisions occur.
         """
         props = schema.get("properties", {})
         required = set(schema.get("required", []))
@@ -649,13 +697,30 @@ class MCPManager:
         }
         params: list[ToolParameter] = []
         param_map: dict[str, str] = {}
+        used_names: set[str] = set()
+
         for prop_name, prop in props.items():
+            if not isinstance(prop, dict):
+                prop = {}
             sanitized_name = MCPManager._sanitize_tool_name(prop_name)
+            # disambiguate if collision
+            if sanitized_name in used_names:
+                i = 2
+                while f"{sanitized_name}_{i}" in used_names:
+                    i += 1
+                sanitized_name = f"{sanitized_name}_{i}"
+            used_names.add(sanitized_name)
             param_map[sanitized_name] = prop_name
+
+            # normalize type — handle union types, missing type, etc.
+            raw_type = prop.get("type", "string")
+            if isinstance(raw_type, list):
+                raw_type = raw_type[0] if raw_type else "string"
+
             params.append(
                 ToolParameter(
                     name=sanitized_name,
-                    type=type_map.get(prop.get("type", "string"), "string"),
+                    type=type_map.get(raw_type, "string"),
                     description=prop.get("description", ""),
                     required=prop_name in required,
                 )

--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -1,0 +1,632 @@
+"""MCP (Model Context Protocol) client support.
+
+Connects to external MCP servers, discovers their tools, and registers
+approved tools into the TOOL_REGISTRY so the agent can call them via
+the standard `tools.<server>.<method>()` pipeline inside execute_code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+from src.tools.registry import Tool, ToolParameter
+
+if TYPE_CHECKING:
+    from src.store.store import Store
+    from src.tools.registry import ToolRegistry
+    from src.tools.secrets import SecretManager
+
+logger = logging.getLogger(__name__)
+
+MCP_RKEY_PREFIX = "mcpserver:"
+
+# Existing tool namespaces that MCP server names must not collide with
+_RESERVED_NAMESPACES = {
+    "memory",
+    "web",
+    "notify",
+    "scheduler",
+    "summarize",
+    "image",
+    "custom_tools",
+}
+
+# Valid server name: alphanumeric + dash + underscore (no dots — dots are namespace separators)
+_SERVER_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+# Sanitize discovered tool names to valid TS identifiers
+_SANITIZE_PATTERN = re.compile(r"[^A-Za-z0-9_]")
+
+# Bounded timeout for connecting to an MCP server
+_CONNECT_TIMEOUT = 30.0
+
+
+@dataclass
+class MCPTool:
+    """Per-tool metadata discovered from an MCP server, with approval state."""
+
+    name: str  # original MCP tool name (may contain dots, etc.)
+    description: str
+    input_schema: dict[str, Any]
+    approved: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": self.input_schema,
+            "approved": self.approved,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MCPTool":
+        return cls(
+            name=data["name"],
+            description=data.get("description", ""),
+            input_schema=data.get("input_schema", {}),
+            approved=data.get("approved", False),
+        )
+
+
+@dataclass
+class MCPServerConfig:
+    """Persisted server configuration + discovered tools."""
+
+    name: str
+    transport: Literal["sse", "stdio"]
+    url: str | None = None
+    command: str | None = None
+    args: list[str] = field(default_factory=list)
+    auth_token_secret: str | None = None
+    env_secrets: list[str] = field(default_factory=list)
+    enabled: bool = True
+    tools: list[MCPTool] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "transport": self.transport,
+            "url": self.url,
+            "command": self.command,
+            "args": self.args,
+            "auth_token_secret": self.auth_token_secret,
+            "env_secrets": self.env_secrets,
+            "enabled": self.enabled,
+            "tools": [t.to_dict() for t in self.tools],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MCPServerConfig":
+        tools_data = data.get("tools", [])
+        return cls(
+            name=data["name"],
+            transport=data.get("transport", "sse"),
+            url=data.get("url"),
+            command=data.get("command"),
+            args=data.get("args", []),
+            auth_token_secret=data.get("auth_token_secret"),
+            env_secrets=data.get("env_secrets", []),
+            enabled=data.get("enabled", True),
+            tools=[MCPTool.from_dict(t) for t in tools_data],
+        )
+
+
+class MCPConnection:
+    """Manages a single MCP server connection lifecycle.
+
+    Uses an AsyncExitStack to hold the transport + session context managers
+    open persistently across tool calls.
+    """
+
+    def __init__(
+        self, config: MCPServerConfig, secret_manager: SecretManager | None
+    ) -> None:
+        self._config = config
+        self._secret_manager = secret_manager
+        self._session: Any | None = None
+        self._stack: contextlib.AsyncExitStack | None = None
+
+    @property
+    def is_connected(self) -> bool:
+        return self._session is not None
+
+    async def connect(self) -> None:
+        """Establish connection to the MCP server."""
+        self._stack = contextlib.AsyncExitStack()
+
+        # resolve auth token if configured
+        headers: dict[str, str] = {}
+        if self._config.auth_token_secret and self._secret_manager:
+            token = self._secret_manager.get_secret(self._config.auth_token_secret)
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+
+        if self._config.transport == "sse":
+            if not self._config.url:
+                raise ValueError(f"SSE transport requires URL for server '{self._config.name}'")
+            from mcp.client.sse import sse_client
+
+            read, write = await self._stack.enter_async_context(
+                sse_client(self._config.url, headers=headers or None)
+            )
+        elif self._config.transport == "stdio":
+            if not self._config.command:
+                raise ValueError(
+                    f"stdio transport requires command for server '{self._config.name}'"
+                )
+            from mcp.client.stdio import StdioServerParameters, stdio_client
+
+            env: dict[str, str] = {}
+            if self._secret_manager:
+                for secret_name in self._config.env_secrets:
+                    val = self._secret_manager.get_secret(secret_name)
+                    if val:
+                        env[secret_name.upper()] = val
+
+            params = StdioServerParameters(
+                command=self._config.command,
+                args=self._config.args,
+                env=env or None,
+            )
+            read, write = await self._stack.enter_async_context(stdio_client(params))
+        else:
+            raise ValueError(f"Unknown transport: {self._config.transport}")
+
+        from mcp.client.session import ClientSession
+
+        self._session = await self._stack.enter_async_context(
+            ClientSession(read, write)
+        )
+        await asyncio.wait_for(self._session.initialize(), timeout=_CONNECT_TIMEOUT)
+        logger.info("Connected to MCP server '%s'", self._config.name)
+
+    async def disconnect(self) -> None:
+        """Close the connection."""
+        self._session = None
+        if self._stack is not None:
+            try:
+                await self._stack.aclose()
+            except Exception:
+                logger.warning("Error closing MCP connection", exc_info=True)
+            self._stack = None
+
+    async def list_tools(self) -> list[Any]:
+        """List tools from the MCP server."""
+        if self._session is None:
+            raise RuntimeError("Not connected")
+        result = await self._session.list_tools()
+        return result.tools
+
+    async def call_tool(self, name: str, params: dict[str, Any]) -> Any:
+        """Call a tool on the MCP server and convert the result."""
+        if self._session is None:
+            raise RuntimeError("Not connected")
+
+        result = await self._session.call_tool(name, params)
+
+        # convert CallToolResult to a plain Python value
+        if result.isError:
+            texts = [
+                c.text for c in (result.content or []) if hasattr(c, "text")
+            ]
+            return {"error": " ".join(texts) if texts else "MCP tool returned an error"}
+
+        items: list[Any] = []
+        for content in result.content or []:
+            if hasattr(content, "text"):
+                items.append(content.text)
+            elif hasattr(content, "data"):
+                items.append(
+                    {
+                        "type": "image",
+                        "data": content.data,
+                        "mimeType": getattr(content, "mimeType", "image/png"),
+                    }
+                )
+            else:
+                items.append(str(content))
+
+        # single text item → return string directly
+        if len(items) == 1:
+            return items[0]
+        if len(items) > 1:
+            return {"content": items}
+        return None
+
+
+class MCPManager:
+    """Manages all MCP servers — parallel to CustomToolManager."""
+
+    def __init__(
+        self,
+        store: Store,
+        secret_manager: SecretManager | None,
+        registry: ToolRegistry,
+    ) -> None:
+        self._store = store
+        self._secret_manager = secret_manager
+        self._registry = registry
+        self._servers: dict[str, MCPServerConfig] = {}
+        self._connections: dict[str, MCPConnection] = {}
+
+    # -- loading from store --
+
+    async def load_servers(self) -> None:
+        """Load all MCP server configs from the DocumentStore."""
+        self._servers.clear()
+        cursor: str | None = None
+
+        if self._store.documents is None:
+            raise RuntimeError("DocumentStore is not initialized")
+
+        while True:
+            resp = await self._store.documents.list(limit=100, cursor=cursor)
+            documents = resp.get("documents", [])
+
+            for doc in documents:
+                rkey = doc.get("rkey", "")
+                if not rkey.startswith(MCP_RKEY_PREFIX):
+                    continue
+                content = doc.get("content", "")
+                if not content:
+                    continue
+                try:
+                    data = json.loads(content)
+                    config = MCPServerConfig.from_dict(data)
+                    self._servers[config.name] = config
+                except Exception as e:
+                    logger.warning("Failed to parse MCP server config %s: %s", rkey, e)
+
+            cursor = resp.get("cursor")
+            if not cursor or not documents:
+                break
+
+        logger.info("Loaded %d MCP server(s)", len(self._servers))
+
+    # -- connection lifecycle --
+
+    async def connect_server(self, name: str) -> None:
+        """Connect to a server, discover tools, and register approved tools."""
+        config = self._servers.get(name)
+        if config is None:
+            raise ValueError(f"MCP server '{name}' not found")
+
+        # disconnect existing connection if any
+        if name in self._connections:
+            await self.disconnect_server(name)
+
+        conn = MCPConnection(config, self._secret_manager)
+        await conn.connect()
+        self._connections[name] = conn
+
+        # discover tools (updates config.tools)
+        await self.discover_tools(name)
+
+        # register any previously-approved tools
+        for tool in config.tools:
+            if tool.approved:
+                self._register_tool(name, tool)
+
+    async def disconnect_server(self, name: str) -> None:
+        """Disconnect a server and unregister its tools."""
+        # unregister all approved tools for this server
+        config = self._servers.get(name)
+        if config:
+            for tool in config.tools:
+                if tool.approved:
+                    self._registry.unregister(f"{name}.{self._sanitize_tool_name(tool.name)}")
+
+        conn = self._connections.pop(name, None)
+        if conn:
+            await conn.disconnect()
+
+    async def connect_all(self) -> None:
+        """Connect to all enabled servers. Non-fatal on failure."""
+        for name, config in list(self._servers.items()):
+            if not config.enabled:
+                continue
+            try:
+                await asyncio.wait_for(self.connect_server(name), timeout=_CONNECT_TIMEOUT)
+            except (asyncio.TimeoutError, Exception) as e:
+                logger.warning(
+                    "Failed to connect to MCP server '%s': %s", name, e
+                )
+
+    async def disconnect_all(self) -> None:
+        """Disconnect all connected servers."""
+        for name in list(self._connections.keys()):
+            await self.disconnect_server(name)
+
+    # -- tool discovery --
+
+    async def discover_tools(self, name: str) -> None:
+        """Re-discover tools from a connected server. Persists updated config."""
+        config = self._servers.get(name)
+        if config is None:
+            raise ValueError(f"MCP server '{name}' not found")
+
+        conn = self._connections.get(name)
+        if conn is None or not conn.is_connected:
+            raise RuntimeError(f"MCP server '{name}' is not connected")
+
+        server_tools = await conn.list_tools()
+
+        # build a lookup of existing tools by original name to preserve approval
+        existing = {t.name: t for t in config.tools}
+        new_tools: list[MCPTool] = []
+
+        for st in server_tools:
+            # MCP SDK Tool has: name, description, inputSchema
+            tool_name = st.name
+            description = st.description or ""
+            input_schema = st.inputSchema if st.inputSchema else {}
+
+            if tool_name in existing:
+                # preserve approval state
+                old = existing[tool_name]
+                new_tool = MCPTool(
+                    name=tool_name,
+                    description=description,
+                    input_schema=input_schema,
+                    approved=old.approved,
+                )
+                # if schema changed and tool is approved, re-register
+                if old.approved and old.input_schema != input_schema:
+                    self._register_tool(name, new_tool)
+            else:
+                new_tool = MCPTool(
+                    name=tool_name,
+                    description=description,
+                    input_schema=input_schema,
+                    approved=False,
+                )
+            new_tools.append(new_tool)
+
+        # for tools that disappeared from the server
+        new_names = {t.name for t in server_tools}
+        for old_tool in config.tools:
+            if old_tool.name not in new_names and old_tool.approved:
+                self._registry.unregister(
+                    f"{name}.{self._sanitize_tool_name(old_tool.name)}"
+                )
+
+        config.tools = new_tools
+
+        # persist updated config
+        await self._persist_server(name)
+
+        logger.info(
+            "Discovered %d tool(s) from MCP server '%s'",
+            len(new_tools),
+            name,
+        )
+
+    # -- approval / revocation --
+
+    async def approve_tool(self, server_name: str, tool_name: str) -> str:
+        """Approve a tool — registers it in the registry."""
+        config = self._servers.get(server_name)
+        if config is None:
+            return f"MCP server '{server_name}' not found."
+
+        # find tool by original name
+        tool = None
+        for t in config.tools:
+            if t.name == tool_name:
+                tool = t
+                break
+        if tool is None:
+            return f"Tool '{tool_name}' not found on server '{server_name}'."
+
+        tool.approved = True
+        await self._persist_server(server_name)
+
+        self._register_tool(server_name, tool)
+        return f"MCP tool '{server_name}.{self._sanitize_tool_name(tool_name)}' approved."
+
+    async def revoke_tool(self, server_name: str, tool_name: str) -> str:
+        """Revoke a tool — unregisters it from the registry."""
+        config = self._servers.get(server_name)
+        if config is None:
+            return f"MCP server '{server_name}' not found."
+
+        tool = None
+        for t in config.tools:
+            if t.name == tool_name:
+                tool = t
+                break
+        if tool is None:
+            return f"Tool '{tool_name}' not found on server '{server_name}'."
+
+        tool.approved = False
+        await self._persist_server(server_name)
+
+        sanitized = self._sanitize_tool_name(tool_name)
+        self._registry.unregister(f"{server_name}.{sanitized}")
+        return f"MCP tool '{server_name}.{sanitized}' approval revoked."
+
+    # -- tool execution --
+
+    async def call_tool(
+        self, server_name: str, tool_name: str, params: dict[str, Any]
+    ) -> Any:
+        """Proxy a tool call to the MCP server."""
+        conn = self._connections.get(server_name)
+        if conn is None or not conn.is_connected:
+            return {
+                "error": f"MCP server '{server_name}' is not connected. "
+                "The operator can reconnect it via the web UI."
+            }
+        try:
+            return await conn.call_tool(tool_name, params)
+        except Exception as e:
+            logger.warning("MCP tool call failed: %s.%s: %s", server_name, tool_name, e)
+            return {"error": f"MCP tool call failed: {e}"}
+
+    # -- server CRUD --
+
+    async def create_server(self, config: MCPServerConfig) -> str:
+        """Create a new MCP server config."""
+        # validate server name
+        if not _SERVER_NAME_PATTERN.match(config.name):
+            return (
+                f"Error: server name '{config.name}' is invalid. "
+                "Allowed: alphanumeric, dash, underscore (1-64 chars)"
+            )
+        if config.name in _RESERVED_NAMESPACES:
+            return f"Error: server name '{config.name}' is a reserved namespace."
+        if config.name in self._servers:
+            return f"Error: server '{config.name}' already exists."
+
+        # validate transport-specific fields
+        if config.transport == "sse" and not config.url:
+            return "Error: SSE transport requires a URL."
+        if config.transport == "stdio" and not config.command:
+            return "Error: stdio transport requires a command."
+
+        rkey = f"{MCP_RKEY_PREFIX}{config.name}"
+        content = json.dumps(config.to_dict())
+        if self._store.documents is None:
+            raise RuntimeError("DocumentStore is not initialized")
+
+        try:
+            await self._store.documents.create(rkey, content)
+        except Exception as e:
+            from src.store.store import StoreConflict
+
+            if isinstance(e, StoreConflict):
+                return f"Error: server '{config.name}' already exists."
+            raise
+
+        self._servers[config.name] = config
+        return f"MCP server '{config.name}' created."
+
+    async def update_server(self, name: str, **fields: Any) -> str:
+        """Update an existing server config. Reconnects if connection-affecting fields change."""
+        config = self._servers.get(name)
+        if config is None:
+            return f"MCP server '{name}' not found."
+
+        connection_fields = {"transport", "url", "command", "args", "auth_token_secret", "env_secrets"}
+        needs_reconnect = False
+        was_connected = name in self._connections
+
+        for key, value in fields.items():
+            if value is None:
+                continue
+            if key in connection_fields and getattr(config, key) != value:
+                needs_reconnect = True
+            if hasattr(config, key):
+                setattr(config, key, value)
+
+        await self._persist_server(name)
+
+        if needs_reconnect and was_connected:
+            try:
+                await self.connect_server(name)
+            except Exception as e:
+                logger.warning("Failed to reconnect MCP server '%s': %s", name, e)
+                return f"MCP server '{name}' updated, but reconnection failed: {e}"
+
+        return f"MCP server '{name}' updated."
+
+    async def delete_server(self, name: str) -> str:
+        """Delete a server — disconnects and unregisters tools first."""
+        config = self._servers.get(name)
+        if config is None:
+            return f"MCP server '{name}' not found."
+
+        # disconnect (also unregisters tools)
+        if name in self._connections:
+            await self.disconnect_server(name)
+
+        rkey = f"{MCP_RKEY_PREFIX}{name}"
+        if self._store.documents is None:
+            raise RuntimeError("DocumentStore is not initialized")
+        try:
+            await self._store.documents.delete(rkey)
+        except Exception:
+            logger.exception("Failed to delete MCP server doc %s", rkey)
+
+        self._servers.pop(name, None)
+        return f"MCP server '{name}' deleted."
+
+    # -- read-only accessors --
+
+    def list_servers(self) -> list[MCPServerConfig]:
+        return list(self._servers.values())
+
+    def get_server(self, name: str) -> MCPServerConfig | None:
+        return self._servers.get(name)
+
+    def is_connected(self, name: str) -> bool:
+        conn = self._connections.get(name)
+        return conn is not None and conn.is_connected
+
+    # -- internals --
+
+    def _register_tool(self, server_name: str, mcp_tool: MCPTool) -> None:
+        """Register an MCP tool in the TOOL_REGISTRY."""
+        sanitized = self._sanitize_tool_name(mcp_tool.name)
+        full_name = f"{server_name}.{sanitized}"
+        params = self._schema_to_parameters(mcp_tool.input_schema)
+        manager = self
+
+        async def handler(ctx: Any, **kwargs: Any) -> Any:
+            return await manager.call_tool(server_name, mcp_tool.name, kwargs)
+
+        self._registry.register(
+            Tool(
+                name=full_name,
+                description=mcp_tool.description,
+                parameters=params,
+                handler=handler,
+            )
+        )
+
+    @staticmethod
+    def _sanitize_tool_name(name: str) -> str:
+        """Replace non-identifier characters with underscore."""
+        return _SANITIZE_PATTERN.sub("_", name)
+
+    @staticmethod
+    def _schema_to_parameters(schema: dict[str, Any]) -> list[ToolParameter]:
+        """Convert a JSON Schema to ToolParameter list."""
+        props = schema.get("properties", {})
+        required = set(schema.get("required", []))
+        type_map = {
+            "string": "string",
+            "number": "number",
+            "integer": "number",
+            "boolean": "boolean",
+            "object": "object",
+            "array": "array",
+        }
+        params: list[ToolParameter] = []
+        for prop_name, prop in props.items():
+            params.append(
+                ToolParameter(
+                    name=prop_name,
+                    type=type_map.get(prop.get("type", "string"), "string"),
+                    description=prop.get("description", ""),
+                    required=prop_name in required,
+                )
+            )
+        return params
+
+    async def _persist_server(self, name: str) -> None:
+        """Persist a server config to the DocumentStore."""
+        config = self._servers.get(name)
+        if config is None:
+            return
+        rkey = f"{MCP_RKEY_PREFIX}{name}"
+        content = json.dumps(config.to_dict())
+        if self._store.documents is None:
+            raise RuntimeError("DocumentStore is not initialized")
+        await self._store.documents.update(rkey, content)

--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -37,14 +37,17 @@ _RESERVED_NAMESPACES = {
     "custom_tools",
 }
 
-# Valid server name: alphanumeric + dash + underscore (no dots — dots are namespace separators)
-_SERVER_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+# Valid server name: must be a valid TypeScript identifier (letter/underscore start, alphanumeric/underscore body)
+_SERVER_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
 
 # Sanitize discovered tool names to valid TS identifiers
 _SANITIZE_PATTERN = re.compile(r"[^A-Za-z0-9_]")
 
 # Bounded timeout for connecting to an MCP server
 _CONNECT_TIMEOUT = 30.0
+
+# Bounded timeout for individual tool calls and list_tools
+_CALL_TIMEOUT = 60.0
 
 
 @dataclass
@@ -140,51 +143,57 @@ class MCPConnection:
         """Establish connection to the MCP server."""
         self._stack = contextlib.AsyncExitStack()
 
-        # resolve auth token if configured
-        headers: dict[str, str] = {}
-        if self._config.auth_token_secret and self._secret_manager:
-            token = self._secret_manager.get_secret(self._config.auth_token_secret)
-            if token:
-                headers["Authorization"] = f"Bearer {token}"
+        try:
+            # resolve auth token if configured
+            headers: dict[str, str] = {}
+            if self._config.auth_token_secret and self._secret_manager:
+                token = self._secret_manager.get_secret(self._config.auth_token_secret)
+                if token:
+                    headers["Authorization"] = f"Bearer {token}"
 
-        if self._config.transport == "sse":
-            if not self._config.url:
-                raise ValueError(f"SSE transport requires URL for server '{self._config.name}'")
-            from mcp.client.sse import sse_client
+            if self._config.transport == "sse":
+                if not self._config.url:
+                    raise ValueError(f"SSE transport requires URL for server '{self._config.name}'")
+                from mcp.client.sse import sse_client
 
-            read, write = await self._stack.enter_async_context(
-                sse_client(self._config.url, headers=headers or None)
-            )
-        elif self._config.transport == "stdio":
-            if not self._config.command:
-                raise ValueError(
-                    f"stdio transport requires command for server '{self._config.name}'"
+                read, write = await self._stack.enter_async_context(
+                    sse_client(self._config.url, headers=headers or None)
                 )
-            from mcp.client.stdio import StdioServerParameters, stdio_client
+            elif self._config.transport == "stdio":
+                if not self._config.command:
+                    raise ValueError(
+                        f"stdio transport requires command for server '{self._config.name}'"
+                    )
+                from mcp.client.stdio import StdioServerParameters, stdio_client
 
-            env: dict[str, str] = {}
-            if self._secret_manager:
-                for secret_name in self._config.env_secrets:
-                    val = self._secret_manager.get_secret(secret_name)
-                    if val:
-                        env[secret_name.upper()] = val
+                env: dict[str, str] = {}
+                if self._secret_manager:
+                    for secret_name in self._config.env_secrets:
+                        val = self._secret_manager.get_secret(secret_name)
+                        if val:
+                            env[secret_name.upper()] = val
 
-            params = StdioServerParameters(
-                command=self._config.command,
-                args=self._config.args,
-                env=env or None,
+                params = StdioServerParameters(
+                    command=self._config.command,
+                    args=self._config.args,
+                    env=env or None,
+                )
+                read, write = await self._stack.enter_async_context(stdio_client(params))
+            else:
+                raise ValueError(f"Unknown transport: {self._config.transport}")
+
+            from mcp.client.session import ClientSession
+
+            self._session = await self._stack.enter_async_context(
+                ClientSession(read, write)
             )
-            read, write = await self._stack.enter_async_context(stdio_client(params))
-        else:
-            raise ValueError(f"Unknown transport: {self._config.transport}")
-
-        from mcp.client.session import ClientSession
-
-        self._session = await self._stack.enter_async_context(
-            ClientSession(read, write)
-        )
-        await asyncio.wait_for(self._session.initialize(), timeout=_CONNECT_TIMEOUT)
-        logger.info("Connected to MCP server '%s'", self._config.name)
+            await asyncio.wait_for(self._session.initialize(), timeout=_CONNECT_TIMEOUT)
+            logger.info("Connected to MCP server '%s'", self._config.name)
+        except BaseException:
+            # Clean up the exit stack if any step failed — otherwise
+            # transports/subprocesses entered into the stack would leak.
+            await self.disconnect()
+            raise
 
     async def disconnect(self) -> None:
         """Close the connection."""
@@ -200,7 +209,9 @@ class MCPConnection:
         """List tools from the MCP server."""
         if self._session is None:
             raise RuntimeError("Not connected")
-        result = await self._session.list_tools()
+        result = await asyncio.wait_for(
+            self._session.list_tools(), timeout=_CALL_TIMEOUT
+        )
         return result.tools
 
     async def call_tool(self, name: str, params: dict[str, Any]) -> Any:
@@ -208,7 +219,9 @@ class MCPConnection:
         if self._session is None:
             raise RuntimeError("Not connected")
 
-        result = await self._session.call_tool(name, params)
+        result = await asyncio.wait_for(
+            self._session.call_tool(name, params), timeout=_CALL_TIMEOUT
+        )
 
         # convert CallToolResult to a plain Python value
         if result.isError:
@@ -360,12 +373,24 @@ class MCPManager:
         # build a lookup of existing tools by original name to preserve approval
         existing = {t.name: t for t in config.tools}
         new_tools: list[MCPTool] = []
+        seen_sanitized: dict[str, str] = {}  # sanitized_name -> original_name
 
         for st in server_tools:
             # MCP SDK Tool has: name, description, inputSchema
             tool_name = st.name
             description = st.description or ""
             input_schema = st.inputSchema if st.inputSchema else {}
+
+            # check for sanitized name collisions
+            sanitized = self._sanitize_tool_name(tool_name)
+            if sanitized in seen_sanitized:
+                logger.warning(
+                    "MCP server '%s': tool '%s' collides with '%s' after sanitization "
+                    "(both map to '%s') — skipping duplicate",
+                    name, tool_name, seen_sanitized[sanitized], sanitized,
+                )
+                continue
+            seen_sanitized[sanitized] = tool_name
 
             if tool_name in existing:
                 # preserve approval state
@@ -376,8 +401,13 @@ class MCPManager:
                     input_schema=input_schema,
                     approved=old.approved,
                 )
-                # if schema changed and tool is approved, re-register
-                if old.approved and old.input_schema != input_schema:
+                # re-register if approved and anything registry-facing changed
+                if old.approved and (
+                    old.input_schema != input_schema
+                    or old.description != description
+                ):
+                    # unregister old first to avoid stale handler
+                    self._registry.unregister(f"{name}.{sanitized}")
                     self._register_tool(name, new_tool)
             else:
                 new_tool = MCPTool(
@@ -477,7 +507,7 @@ class MCPManager:
         if not _SERVER_NAME_PATTERN.match(config.name):
             return (
                 f"Error: server name '{config.name}' is invalid. "
-                "Allowed: alphanumeric, dash, underscore (1-64 chars)"
+                "Allowed: letter or underscore start, then letters, digits, or underscore (1-64 chars)"
             )
         if config.name in _RESERVED_NAMESPACES:
             return f"Error: server name '{config.name}' is a reserved namespace."
@@ -575,11 +605,14 @@ class MCPManager:
         """Register an MCP tool in the TOOL_REGISTRY."""
         sanitized = self._sanitize_tool_name(mcp_tool.name)
         full_name = f"{server_name}.{sanitized}"
-        params = self._schema_to_parameters(mcp_tool.input_schema)
+        params, param_map = self._schema_to_parameters(mcp_tool.input_schema)
         manager = self
+        original_tool_name = mcp_tool.name
 
         async def handler(ctx: Any, **kwargs: Any) -> Any:
-            return await manager.call_tool(server_name, mcp_tool.name, kwargs)
+            # Map sanitized param names back to the original schema keys
+            original_params = {param_map.get(k, k): v for k, v in kwargs.items()}
+            return await manager.call_tool(server_name, original_tool_name, original_params)
 
         self._registry.register(
             Tool(
@@ -592,12 +625,18 @@ class MCPManager:
 
     @staticmethod
     def _sanitize_tool_name(name: str) -> str:
-        """Replace non-identifier characters with underscore."""
-        return _SANITIZE_PATTERN.sub("_", name)
+        """Replace non-identifier characters with underscore, ensure valid start."""
+        sanitized = _SANITIZE_PATTERN.sub("_", name)
+        if sanitized and not sanitized[0].isalpha() and sanitized[0] != "_":
+            sanitized = "_" + sanitized
+        return sanitized
 
     @staticmethod
-    def _schema_to_parameters(schema: dict[str, Any]) -> list[ToolParameter]:
-        """Convert a JSON Schema to ToolParameter list."""
+    def _schema_to_parameters(schema: dict[str, Any]) -> tuple[list[ToolParameter], dict[str, str]]:
+        """Convert a JSON Schema to ToolParameter list + param name mapping.
+
+        Returns (params, mapping) where mapping is sanitized_name -> original_name.
+        """
         props = schema.get("properties", {})
         required = set(schema.get("required", []))
         type_map = {
@@ -609,16 +648,19 @@ class MCPManager:
             "array": "array",
         }
         params: list[ToolParameter] = []
+        param_map: dict[str, str] = {}
         for prop_name, prop in props.items():
+            sanitized_name = MCPManager._sanitize_tool_name(prop_name)
+            param_map[sanitized_name] = prop_name
             params.append(
                 ToolParameter(
-                    name=prop_name,
+                    name=sanitized_name,
                     type=type_map.get(prop.get("type", "string"), "string"),
                     description=prop.get("description", ""),
                     required=prop_name in required,
                 )
             )
-        return params
+        return params, param_map
 
     async def _persist_server(self, name: str) -> None:
         """Persist a server config to the DocumentStore."""

--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -604,19 +604,14 @@ class MCPManager:
             await self._persist_server(name)
 
             if needs_reconnect and was_connected:
-                # disconnect old connection under the current lock
+                # disconnect old connection, then reconnect under the same lock
                 if name in self._connections:
                     await self._disconnect_server_impl(name)
-            else:
-                needs_reconnect = False
-
-        # reconnect outside the lock (connect_server acquires it)
-        if needs_reconnect:
-            try:
-                await self.connect_server(name)
-            except Exception as e:
-                logger.warning("Failed to reconnect MCP server '%s': %s", name, e)
-                return f"MCP server '{name}' updated, but reconnection failed: {e}"
+                try:
+                    await self._connect_server_impl(name)
+                except Exception as e:
+                    logger.warning("Failed to reconnect MCP server '%s': %s", name, e)
+                    return f"MCP server '{name}' updated, but reconnection failed: {e}"
 
         return f"MCP server '{name}' updated."
 
@@ -630,6 +625,13 @@ class MCPManager:
             # disconnect (also unregisters tools)
             if name in self._connections:
                 await self._disconnect_server_impl(name)
+            else:
+                # even if not connected, unregister any approved tools
+                for tool in config.tools:
+                    if tool.approved:
+                        self._registry.unregister(
+                            f"{name}.{self._sanitize_tool_name(tool.name)}"
+                        )
 
             rkey = f"{MCP_RKEY_PREFIX}{name}"
             if self._store.documents is None:
@@ -682,7 +684,9 @@ class MCPManager:
     def _sanitize_tool_name(name: str) -> str:
         """Replace non-identifier characters with underscore, ensure valid start, avoid reserved words."""
         sanitized = _SANITIZE_PATTERN.sub("_", name)
-        if sanitized and not sanitized[0].isalpha() and sanitized[0] != "_":
+        if not sanitized:
+            sanitized = "_"
+        if not sanitized[0].isalpha() and sanitized[0] != "_":
             sanitized = "_" + sanitized
         if sanitized in _TS_RESERVED_WORDS:
             sanitized += "_"

--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -333,7 +333,7 @@ class MCPManager:
 
         # disconnect existing connection if any
         if name in self._connections:
-            await self.disconnect_server(name)
+            await self._disconnect_server_impl(name)
 
         conn = MCPConnection(config, self._secret_manager)
         await conn.connect()
@@ -341,7 +341,7 @@ class MCPManager:
 
         try:
             # discover tools (updates config.tools)
-            await self.discover_tools(name)
+            await self._discover_tools_impl(name)
 
             # register any previously-approved tools
             for tool in config.tools:
@@ -350,7 +350,7 @@ class MCPManager:
         except BaseException:
             # Clean up the connection if discovery or registration failed
             # so we don't leave a live session with no tools registered.
-            await self.disconnect_server(name)
+            await self._disconnect_server_impl(name)
             raise
 
     async def disconnect_server(self, name: str) -> None:
@@ -453,10 +453,10 @@ class MCPManager:
                 )
             new_tools.append(new_tool)
 
-        # for tools that disappeared from the server
-        new_names = {t.name for t in server_tools}
+        # for tools that disappeared from the server or were skipped due to collision
+        retained_names = {t.name for t in new_tools}
         for old_tool in config.tools:
-            if old_tool.name not in new_names and old_tool.approved:
+            if old_tool.name not in retained_names and old_tool.approved:
                 self._registry.unregister(
                     f"{name}.{self._sanitize_tool_name(old_tool.name)}"
                 )
@@ -584,25 +584,34 @@ class MCPManager:
 
     async def update_server(self, name: str, **fields: Any) -> str:
         """Update an existing server config. Reconnects if connection-affecting fields change."""
-        config = self._servers.get(name)
-        if config is None:
-            return f"MCP server '{name}' not found."
+        async with self._get_lock(name):
+            config = self._servers.get(name)
+            if config is None:
+                return f"MCP server '{name}' not found."
 
-        connection_fields = {"transport", "url", "command", "args", "auth_token_secret", "env_secrets"}
-        needs_reconnect = False
-        was_connected = name in self._connections
+            connection_fields = {"transport", "url", "command", "args", "auth_token_secret", "env_secrets"}
+            needs_reconnect = False
+            was_connected = name in self._connections
 
-        for key, value in fields.items():
-            if value is None:
-                continue
-            if key in connection_fields and getattr(config, key) != value:
-                needs_reconnect = True
-            if hasattr(config, key):
-                setattr(config, key, value)
+            for key, value in fields.items():
+                if value is None:
+                    continue
+                if key in connection_fields and getattr(config, key) != value:
+                    needs_reconnect = True
+                if hasattr(config, key):
+                    setattr(config, key, value)
 
-        await self._persist_server(name)
+            await self._persist_server(name)
 
-        if needs_reconnect and was_connected:
+            if needs_reconnect and was_connected:
+                # disconnect old connection under the current lock
+                if name in self._connections:
+                    await self._disconnect_server_impl(name)
+            else:
+                needs_reconnect = False
+
+        # reconnect outside the lock (connect_server acquires it)
+        if needs_reconnect:
             try:
                 await self.connect_server(name)
             except Exception as e:
@@ -613,23 +622,24 @@ class MCPManager:
 
     async def delete_server(self, name: str) -> str:
         """Delete a server — disconnects and unregisters tools first."""
-        config = self._servers.get(name)
-        if config is None:
-            return f"MCP server '{name}' not found."
+        async with self._get_lock(name):
+            config = self._servers.get(name)
+            if config is None:
+                return f"MCP server '{name}' not found."
 
-        # disconnect (also unregisters tools)
-        if name in self._connections:
-            await self.disconnect_server(name)
+            # disconnect (also unregisters tools)
+            if name in self._connections:
+                await self._disconnect_server_impl(name)
 
-        rkey = f"{MCP_RKEY_PREFIX}{name}"
-        if self._store.documents is None:
-            raise RuntimeError("DocumentStore is not initialized")
-        try:
-            await self._store.documents.delete(rkey)
-        except Exception:
-            logger.exception("Failed to delete MCP server doc %s", rkey)
+            rkey = f"{MCP_RKEY_PREFIX}{name}"
+            if self._store.documents is None:
+                raise RuntimeError("DocumentStore is not initialized")
+            try:
+                await self._store.documents.delete(rkey)
+            except Exception:
+                logger.exception("Failed to delete MCP server doc %s", rkey)
 
-        self._servers.pop(name, None)
+            self._servers.pop(name, None)
         return f"MCP server '{name}' deleted."
 
     # -- read-only accessors --
@@ -685,6 +695,9 @@ class MCPManager:
         Returns (params, mapping) where mapping is sanitized_name -> original_name.
         Sanitized names are made unique with numeric suffixes if collisions occur.
         """
+        if not isinstance(schema, dict):
+            return [], {}
+
         props = schema.get("properties", {})
         required = set(schema.get("required", []))
         type_map = {

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -39,6 +39,7 @@ class ToolContext:
         self._http_client = http_client
         self._store = store
         self._custom_tool_manager: Any | None = None
+        self._mcp_manager: Any | None = None
         self._secret_manager: Any | None = None
         self._scheduler: Any | None = None
         self._embedding_client: Any | None = None
@@ -73,6 +74,10 @@ class ToolContext:
         return self._custom_tool_manager
 
     @property
+    def mcp_manager(self) -> Any:
+        return self._mcp_manager
+
+    @property
     def secret_manager(self) -> Any:
         return self._secret_manager
 
@@ -101,6 +106,10 @@ class ToolRegistry:
 
     def register(self, tool: Tool) -> None:
         self._tools[tool.name] = tool
+
+    def unregister(self, name: str) -> bool:
+        """Remove a tool from the registry. Returns True if it existed."""
+        return self._tools.pop(name, None) is not None
 
     def get(self, name: str) -> Tool | None:
         return self._tools.get(name)

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -169,7 +169,7 @@ class ToolRegistry:
             lines.append(f"## {namespace}\n")
             for tool in sorted(tools, key=lambda t: t.name):
                 lines.append(f"### {tool.name}")
-                lines.append(f"{tool.description}\n")
+                lines.append(f"{self._sanitize_md(tool.description)}\n")
                 if tool.parameters:
                     lines.append("**Parameters:**")
                     for param in tool.parameters:
@@ -180,7 +180,7 @@ class ToolRegistry:
                             else ""
                         )
                         lines.append(
-                            f"- `{param.name}` ({param.type}{req}{default}): {param.description}"
+                            f"- `{param.name}` ({param.type}{req}{default}): {self._sanitize_md(param.description)}"
                         )
                     lines.append("")
 
@@ -258,6 +258,18 @@ class ToolRegistry:
         if isinstance(value, str):
             return f'"{value}"'
         return str(value)
+
+    @staticmethod
+    def _sanitize_md(text: str) -> str:
+        """Strip markdown control characters from untrusted text.
+
+        Prevents heading injection and code fence injection from MCP
+        tool descriptions in the system prompt docs.
+        """
+        # strip leading # markers that could inject fake headings
+        stripped = text.lstrip("#")
+        # neutralize backtick-fenced code blocks
+        return stripped.replace("```", "\\`\\`\\`")
 
 
 TOOL_REGISTRY = ToolRegistry()

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -266,10 +266,15 @@ class ToolRegistry:
         Prevents heading injection and code fence injection from MCP
         tool descriptions in the system prompt docs.
         """
-        # strip leading # markers that could inject fake headings
-        stripped = text.lstrip("#")
+        lines = text.split("\n")
+        sanitized_lines = []
+        for line in lines:
+            # strip leading # markers that could inject fake headings
+            stripped = line.lstrip("#")
+            sanitized_lines.append(stripped)
+        result = "\n".join(sanitized_lines)
         # neutralize backtick-fenced code blocks
-        return stripped.replace("```", "\\`\\`\\`")
+        return result.replace("```", "\\`\\`\\`")
 
 
 TOOL_REGISTRY = ToolRegistry()

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -224,9 +224,13 @@ class ToolRegistry:
                     "{ " + ", ".join(param_names) + " }" if param_names else "{}"
                 )
 
-                lines.append(f"  /** {tool.description} */")
+                # Sanitize description for TS comment — strip */ to prevent
+                # comment termination and code injection from untrusted input
+                safe_desc = tool.description.replace("*/", "* /")
+                lines.append(f"  /** {safe_desc} */")
+                safe_name = tool.name.replace("\\", "\\\\").replace('"', '\\"')
                 lines.append(
-                    f'  {method_name}: ({param_str}): Promise<unknown> => callTool("{tool.name}", {params_obj}),'
+                    f'  {method_name}: ({param_str}): Promise<unknown> => callTool("{safe_name}", {params_obj}),'
                 )
                 if i < len(tools) - 1:
                     lines.append("")

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -13,6 +13,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from src.config import CONFIG
 from src.web.routers import (
     chat,
+    mcp,
     schedules,
     secrets,
     sessions,
@@ -74,6 +75,7 @@ def create_app(agent, executor, conversation_manager) -> FastAPI:
     app.include_router(tools.router, prefix="/api")
     app.include_router(secrets.router, prefix="/api")
     app.include_router(schedules.router, prefix="/api")
+    app.include_router(mcp.router, prefix="/api")
     app.include_router(system_prompt.router, prefix="/api")
 
     static_dir = Path(__file__).parent / "static"

--- a/src/web/routers/mcp.py
+++ b/src/web/routers/mcp.py
@@ -14,6 +14,7 @@ from src.web.schemas import (
     MCPServerDetail,
     MCPServerSummary,
     MCPToolSummary,
+    ToolActionRequest,
 )
 
 router = APIRouter(prefix="/mcp")
@@ -189,33 +190,33 @@ async def refresh_server(
     return _server_to_detail(config, mgr, sm)
 
 
-@router.post("/servers/{name}/tools/{tool_name}/approve")
+@router.post("/servers/{name}/tools/approve")
 async def approve_tool(
     name: str,
-    tool_name: str,
+    body: ToolActionRequest,
     executor: ToolExecutor = Depends(get_executor),
 ) -> dict[str, Any]:
     mgr = _get_manager(executor)
     config = mgr.get_server(name)
     if config is None:
         raise HTTPException(404, f"MCP server '{name}' not found")
-    result = await mgr.approve_tool(name, tool_name)
+    result = await mgr.approve_tool(name, body.tool_name)
     if "not found" in result:
         raise HTTPException(404, result)
     return {"message": result}
 
 
-@router.post("/servers/{name}/tools/{tool_name}/revoke")
+@router.post("/servers/{name}/tools/revoke")
 async def revoke_tool(
     name: str,
-    tool_name: str,
+    body: ToolActionRequest,
     executor: ToolExecutor = Depends(get_executor),
 ) -> dict[str, Any]:
     mgr = _get_manager(executor)
     config = mgr.get_server(name)
     if config is None:
         raise HTTPException(404, f"MCP server '{name}' not found")
-    result = await mgr.revoke_tool(name, tool_name)
+    result = await mgr.revoke_tool(name, body.tool_name)
     if "not found" in result:
         raise HTTPException(404, result)
     return {"message": result}

--- a/src/web/routers/mcp.py
+++ b/src/web/routers/mcp.py
@@ -1,0 +1,221 @@
+"""MCP server CRUD + tool approval endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from src.tools.executor import ToolExecutor
+from src.tools.mcp import MCPServerConfig, MCPTool
+from src.web.dependencies import get_executor
+from src.web.schemas import (
+    CreateMCPServerRequest,
+    MCPServerDetail,
+    MCPServerSummary,
+    MCPToolSummary,
+)
+
+router = APIRouter(prefix="/mcp")
+
+
+def _get_manager(executor: ToolExecutor) -> Any:
+    mgr = executor.mcp_manager
+    if mgr is None:
+        raise HTTPException(500, "MCP manager not initialized")
+    return mgr
+
+
+def _get_sm(executor: ToolExecutor) -> Any:
+    sm = executor.secret_manager
+    if sm is None:
+        raise HTTPException(500, "Secret manager not initialized")
+    return sm
+
+
+def _server_to_summary(config: MCPServerConfig, manager: Any) -> MCPServerSummary:
+    return MCPServerSummary(
+        name=config.name,
+        transport=config.transport,
+        enabled=config.enabled,
+        connected=manager.is_connected(config.name),
+        tools_total=len(config.tools),
+        tools_approved=sum(1 for t in config.tools if t.approved),
+    )
+
+
+def _server_to_detail(config: MCPServerConfig, manager: Any, sm: Any) -> MCPServerDetail:
+    known = set(sm.list_secret_names())
+
+    # resolve auth token status
+    if config.auth_token_secret:
+        auth_status = "set" if config.auth_token_secret in known else "missing"
+    else:
+        auth_status = "none"
+
+    # resolve env secrets status
+    env_statuses = [
+        {"name": s, "status": "set" if s in known else "missing"}
+        for s in config.env_secrets
+    ]
+
+    return MCPServerDetail(
+        name=config.name,
+        transport=config.transport,
+        url=config.url,
+        command=config.command,
+        args=config.args,
+        auth_token_secret=config.auth_token_secret,
+        auth_token_status=auth_status,
+        env_secrets=env_statuses,
+        enabled=config.enabled,
+        connected=manager.is_connected(config.name),
+        tools=[
+            MCPToolSummary(
+                name=t.name,
+                description=t.description,
+                approved=t.approved,
+            )
+            for t in config.tools
+        ],
+    )
+
+
+@router.get("/servers", response_model=list[MCPServerSummary])
+def list_servers(
+    executor: ToolExecutor = Depends(get_executor),
+) -> list[MCPServerSummary]:
+    mgr = _get_manager(executor)
+    return [_server_to_summary(c, mgr) for c in mgr.list_servers()]
+
+
+@router.post("/servers", response_model=MCPServerSummary, status_code=201)
+async def create_server(
+    body: CreateMCPServerRequest,
+    executor: ToolExecutor = Depends(get_executor),
+) -> MCPServerSummary:
+    mgr = _get_manager(executor)
+    config = MCPServerConfig(
+        name=body.name,
+        transport=body.transport,
+        url=body.url,
+        command=body.command,
+        args=body.args,
+        auth_token_secret=body.auth_token_secret,
+        env_secrets=body.env_secrets,
+        enabled=body.enabled,
+    )
+    result = await mgr.create_server(config)
+    if result.startswith("Error:"):
+        raise HTTPException(400, result)
+    return _server_to_summary(config, mgr)
+
+
+@router.get("/servers/{name}", response_model=MCPServerDetail)
+def get_server(
+    name: str,
+    executor: ToolExecutor = Depends(get_executor),
+) -> MCPServerDetail:
+    mgr = _get_manager(executor)
+    sm = _get_sm(executor)
+    config = mgr.get_server(name)
+    if config is None:
+        raise HTTPException(404, f"MCP server '{name}' not found")
+    return _server_to_detail(config, mgr, sm)
+
+
+@router.delete("/servers/{name}", status_code=204)
+async def delete_server(
+    name: str,
+    executor: ToolExecutor = Depends(get_executor),
+) -> None:
+    mgr = _get_manager(executor)
+    config = mgr.get_server(name)
+    if config is None:
+        raise HTTPException(404, f"MCP server '{name}' not found")
+    await mgr.delete_server(name)
+
+
+@router.post("/servers/{name}/connect", response_model=MCPServerDetail)
+async def connect_server(
+    name: str,
+    executor: ToolExecutor = Depends(get_executor),
+) -> MCPServerDetail:
+    mgr = _get_manager(executor)
+    sm = _get_sm(executor)
+    config = mgr.get_server(name)
+    if config is None:
+        raise HTTPException(404, f"MCP server '{name}' not found")
+    try:
+        await mgr.connect_server(name)
+    except Exception as e:
+        raise HTTPException(500, f"Failed to connect: {e}")
+    config = mgr.get_server(name)
+    return _server_to_detail(config, mgr, sm)
+
+
+@router.post("/servers/{name}/disconnect", response_model=MCPServerDetail)
+async def disconnect_server(
+    name: str,
+    executor: ToolExecutor = Depends(get_executor),
+) -> MCPServerDetail:
+    mgr = _get_manager(executor)
+    sm = _get_sm(executor)
+    config = mgr.get_server(name)
+    if config is None:
+        raise HTTPException(404, f"MCP server '{name}' not found")
+    await mgr.disconnect_server(name)
+    config = mgr.get_server(name)
+    return _server_to_detail(config, mgr, sm)
+
+
+@router.post("/servers/{name}/refresh", response_model=MCPServerDetail)
+async def refresh_server(
+    name: str,
+    executor: ToolExecutor = Depends(get_executor),
+) -> MCPServerDetail:
+    mgr = _get_manager(executor)
+    sm = _get_sm(executor)
+    config = mgr.get_server(name)
+    if config is None:
+        raise HTTPException(404, f"MCP server '{name}' not found")
+    if not mgr.is_connected(name):
+        raise HTTPException(400, f"MCP server '{name}' is not connected")
+    try:
+        await mgr.discover_tools(name)
+    except Exception as e:
+        raise HTTPException(500, f"Failed to refresh tools: {e}")
+    config = mgr.get_server(name)
+    return _server_to_detail(config, mgr, sm)
+
+
+@router.post("/servers/{name}/tools/{tool_name}/approve")
+async def approve_tool(
+    name: str,
+    tool_name: str,
+    executor: ToolExecutor = Depends(get_executor),
+) -> dict[str, Any]:
+    mgr = _get_manager(executor)
+    config = mgr.get_server(name)
+    if config is None:
+        raise HTTPException(404, f"MCP server '{name}' not found")
+    result = await mgr.approve_tool(name, tool_name)
+    if "not found" in result:
+        raise HTTPException(404, result)
+    return {"message": result}
+
+
+@router.post("/servers/{name}/tools/{tool_name}/revoke")
+async def revoke_tool(
+    name: str,
+    tool_name: str,
+    executor: ToolExecutor = Depends(get_executor),
+) -> dict[str, Any]:
+    mgr = _get_manager(executor)
+    config = mgr.get_server(name)
+    if config is None:
+        raise HTTPException(404, f"MCP server '{name}' not found")
+    result = await mgr.revoke_tool(name, tool_name)
+    if "not found" in result:
+        raise HTTPException(404, result)
+    return {"message": result}

--- a/src/web/routers/status.py
+++ b/src/web/routers/status.py
@@ -41,6 +41,17 @@ def get_status(
         approved = sum(1 for t in all_tools if t.approved)
         pending = len(all_tools) - approved
 
+    # MCP servers / approved tools
+    mcp_servers = 0
+    mcp_tools_approved = 0
+    mcp_mgr = executor.mcp_manager
+    if mcp_mgr:
+        servers = mcp_mgr.list_servers()
+        mcp_servers = len(servers)
+        mcp_tools_approved = sum(
+            sum(1 for t in s.tools if t.approved) for s in servers
+        )
+
     # discord on/off
     discord_on = bool(sm and sm.get_secret("DISCORD_BOT_TOKEN"))
 
@@ -51,4 +62,6 @@ def get_status(
         secrets=secret_count,
         custom_tools_approved=approved,
         custom_tools_pending=pending,
+        mcp_servers=mcp_servers,
+        mcp_tools_approved=mcp_tools_approved,
     )

--- a/src/web/schemas.py
+++ b/src/web/schemas.py
@@ -147,3 +147,7 @@ class MCPServerDetail(BaseModel):
     enabled: bool
     connected: bool
     tools: list[MCPToolSummary]
+
+
+class ToolActionRequest(BaseModel):
+    tool_name: str

--- a/src/web/schemas.py
+++ b/src/web/schemas.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, Literal
+
 from pydantic import BaseModel
 
 
@@ -62,6 +64,8 @@ class StatusResponse(BaseModel):
     secrets: int
     custom_tools_approved: int
     custom_tools_pending: int
+    mcp_servers: int = 0
+    mcp_tools_approved: int = 0
 
 
 class ToolSummary(BaseModel):
@@ -100,3 +104,46 @@ class SystemPromptResponse(BaseModel):
     text: str
     char_count: int
     token_estimate: int
+
+
+# -- MCP models --
+
+
+class CreateMCPServerRequest(BaseModel):
+    name: str
+    transport: Literal["sse", "stdio"]
+    url: str | None = None
+    command: str | None = None
+    args: list[str] = []
+    auth_token_secret: str | None = None
+    env_secrets: list[str] = []
+    enabled: bool = True
+
+
+class MCPServerSummary(BaseModel):
+    name: str
+    transport: str
+    enabled: bool
+    connected: bool
+    tools_total: int
+    tools_approved: int
+
+
+class MCPToolSummary(BaseModel):
+    name: str
+    description: str
+    approved: bool
+
+
+class MCPServerDetail(BaseModel):
+    name: str
+    transport: str
+    url: str | None
+    command: str | None
+    args: list[str]
+    auth_token_secret: str | None
+    auth_token_status: str  # "set" | "missing" | "none"
+    env_secrets: list[dict[str, str]]  # [{"name": ..., "status": "set"|"missing"}]
+    enabled: bool
+    connected: bool
+    tools: list[MCPToolSummary]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -106,7 +106,7 @@ def test_schema_to_parameters_simple_types():
         },
         "required": ["query", "limit"],
     }
-    params = MCPManager._schema_to_parameters(schema)
+    params, param_map = MCPManager._schema_to_parameters(schema)
     assert len(params) == 6
 
     by_name = {p.name: p for p in params}
@@ -119,12 +119,18 @@ def test_schema_to_parameters_simple_types():
     assert by_name["verbose"].type == "boolean"
     assert by_name["filter"].type == "object"
     assert by_name["tags"].type == "array"
+    # param_map should map sanitized -> original (all same here since no special chars)
+    assert param_map["query"] == "query"
 
 
 def test_schema_to_parameters_empty():
-    """_schema_to_parameters returns [] for empty schema."""
-    assert MCPManager._schema_to_parameters({}) == []
-    assert MCPManager._schema_to_parameters({"type": "object"}) == []
+    """_schema_to_parameters returns ([], {}) for empty schema."""
+    params, param_map = MCPManager._schema_to_parameters({})
+    assert params == []
+    assert param_map == {}
+    params, param_map = MCPManager._schema_to_parameters({"type": "object"})
+    assert params == []
+    assert param_map == {}
 
 
 def test_schema_to_parameters_unknown_type_defaults_string():
@@ -135,8 +141,27 @@ def test_schema_to_parameters_unknown_type_defaults_string():
             "custom": {"type": "weird-type", "description": "Unknown"},
         },
     }
-    params = MCPManager._schema_to_parameters(schema)
+    params, _ = MCPManager._schema_to_parameters(schema)
     assert params[0].type == "string"
+
+
+def test_schema_to_parameters_sanitizes_non_identifier_names():
+    """Property names with non-identifier chars are sanitized, with a mapping back to original."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "foo-bar": {"type": "string", "description": "Hyphenated"},
+            "x.y": {"type": "string", "description": "Dotted"},
+        },
+    }
+    params, param_map = MCPManager._schema_to_parameters(schema)
+    assert len(params) == 2
+    names = {p.name for p in params}
+    assert "foo_bar" in names
+    assert "x_y" in names
+    # mapping preserves original names for the MCP server call
+    assert param_map["foo_bar"] == "foo-bar"
+    assert param_map["x_y"] == "x.y"
 
 
 # ---------------------------------------------------------------------------
@@ -145,11 +170,13 @@ def test_schema_to_parameters_unknown_type_defaults_string():
 
 
 def test_sanitize_tool_name():
-    """_sanitize_tool_name replaces non-identifier chars with underscore."""
+    """_sanitize_tool_name replaces non-identifier chars with underscore, ensures valid start."""
     assert MCPManager._sanitize_tool_name("search_mail") == "search_mail"
     assert MCPManager._sanitize_tool_name("search.mail") == "search_mail"
     assert MCPManager._sanitize_tool_name("foo-bar") == "foo_bar"
     assert MCPManager._sanitize_tool_name("foo bar") == "foo_bar"
+    # leading digit gets underscore prefix
+    assert MCPManager._sanitize_tool_name("123abc") == "_123abc"
 
 
 # ---------------------------------------------------------------------------
@@ -191,11 +218,16 @@ async def test_create_server_rejects_reserved_name(tmp_path):
 
 @pytest.mark.asyncio
 async def test_create_server_rejects_invalid_name(tmp_path):
-    """create_server rejects names with invalid characters."""
+    """create_server rejects names that are invalid TS identifiers."""
     manager, store = await _make_manager(tmp_path)
-    config = MCPServerConfig(name="bad.name", transport="sse", url="https://example.com")
+    # hyphens are not valid TS identifier characters
+    config = MCPServerConfig(name="bad-name", transport="sse", url="https://example.com")
     result = await manager.create_server(config)
     assert "invalid" in result.lower()
+    # leading digits are not valid
+    config2 = MCPServerConfig(name="123abc", transport="sse", url="https://example.com")
+    result2 = await manager.create_server(config2)
+    assert "invalid" in result2.lower()
     await store.close()
 
 
@@ -492,4 +524,81 @@ async def test_web_approve_tool(tmp_path):
 
     # verify tool was registered
     assert manager._registry.get("webtest.tool1") is not None
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Security: TS injection prevention
+# ---------------------------------------------------------------------------
+
+
+def test_ts_injection_prevention_in_description():
+    """Tool descriptions with */ must not break TS comment generation."""
+    from src.tools.registry import TOOL_REGISTRY, Tool
+
+    async def handler(ctx, **kw):
+        pass
+
+    # register a tool with a malicious description
+    malicious_desc = '*/ }; evil(); export const x = { /*'
+    TOOL_REGISTRY.register(
+        Tool(
+            name="inj.test",
+            description=malicious_desc,
+            parameters=[],
+            handler=handler,
+        )
+    )
+
+    ts = TOOL_REGISTRY.generate_typescript_types()
+    # The */ must have been neutralized — no raw */ in the output
+    assert "*/ };" not in ts
+    # clean up
+    TOOL_REGISTRY.unregister("inj.test")
+
+
+def test_ts_injection_prevention_in_tool_name():
+    """Tool names with quotes must not break the callTool string literal."""
+    from src.tools.registry import TOOL_REGISTRY, Tool
+
+    async def handler(ctx, **kw):
+        pass
+
+    TOOL_REGISTRY.register(
+        Tool(
+            name='weird";name',
+            description="test",
+            parameters=[],
+            handler=handler,
+        )
+    )
+
+    ts = TOOL_REGISTRY.generate_typescript_types()
+    # The quote must have been escaped — no raw unescaped " inside the callTool string
+    assert 'callTool("weird\\";name"' in ts
+    TOOL_REGISTRY.unregister('weird";name')
+
+
+@pytest.mark.asyncio
+async def test_connect_failure_cleans_up_exit_stack(tmp_path):
+    """If MCPConnection.connect() fails, the exit stack must be closed (no leak)."""
+    from pathlib import Path
+    from src.store.store import Store
+
+    store = Store(path=tmp_path / "store.db")
+    await store.initialize()
+    registry = ToolRegistry()
+    manager = MCPManager(store=store, secret_manager=None, registry=registry)
+
+    config = MCPServerConfig(name="failtest", transport="sse", url="https://invalid.example.invalid/mcp")
+    await manager.create_server(config)
+
+    # Attempt to connect — should fail and clean up
+    try:
+        await manager.connect_server("failtest")
+    except Exception:
+        pass  # expected to fail
+
+    # Connection should not be stored
+    assert "failtest" not in manager._connections
     await store.close()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -708,7 +708,7 @@ def test_schema_non_dict_property_handled():
 
 
 def test_markdown_sanitization_strips_headings():
-    """_sanitize_md strips leading # and neutralizes code fences."""
+    """_sanitize_md strips leading # on every line and neutralizes code fences."""
     from src.tools.registry import ToolRegistry, Tool
 
     reg = ToolRegistry()
@@ -719,14 +719,101 @@ def test_markdown_sanitization_strips_headings():
     reg.register(
         Tool(
             name="md.test",
-            description="## Fake Heading\n```evil```",
+            description="## Fake Heading\n```evil```\nsafe text\n### Another heading",
             parameters=[],
             handler=handler,
         )
     )
 
     docs = reg.generate_tool_documentation()
-    # Should not contain raw ## heading or ```
+    # Should not contain raw ## headings or ```
     assert "## Fake Heading" not in docs
+    assert "### Another heading" not in docs
     assert "```" not in docs
     reg.unregister("md.test")
+
+
+@pytest.mark.asyncio
+async def test_connect_server_success_with_mocked_connection():
+    """connect_server completes without deadlock when connect + discover succeed."""
+    from pathlib import Path
+    from src.store.store import Store
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    store = Store(path=Path("/tmp/test_mcp_connect_success.db"))
+    await store.initialize()
+    registry = ToolRegistry()
+    manager = MCPManager(store=store, secret_manager=None, registry=registry)
+
+    config = MCPServerConfig(name="mocksrv", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+
+    # Mock MCPConnection so connect succeeds and list_tools returns a tool
+    mock_tool = MagicMock()
+    mock_tool.name = "search"
+    mock_tool.description = "Search"
+    mock_tool.inputSchema = {"type": "object", "properties": {"q": {"type": "string"}}}
+
+    mock_conn = MagicMock()
+    mock_conn.is_connected = True
+    mock_conn.connect = AsyncMock()
+    mock_conn.list_tools = AsyncMock(return_value=[mock_tool])
+    mock_conn.disconnect = AsyncMock()
+
+    with patch("src.tools.mcp.MCPConnection", return_value=mock_conn):
+        await manager.connect_server("mocksrv")
+
+    # connection should be stored
+    assert "mocksrv" in manager._connections
+    # tool should be discovered
+    config = manager.get_server("mocksrv")
+    assert len(config.tools) == 1
+    assert config.tools[0].name == "search"
+    assert config.tools[0].approved is False  # pending
+
+    await manager.disconnect_server("mocksrv")
+    await store.close()
+    import os
+    os.unlink("/tmp/test_mcp_connect_success.db")
+
+
+@pytest.mark.asyncio
+async def test_connect_server_discovery_failure_cleans_up():
+    """connect_server cleans up connection if discover_tools fails after connect."""
+    from pathlib import Path
+    from src.store.store import Store
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    store = Store(path=Path("/tmp/test_mcp_discover_fail.db"))
+    await store.initialize()
+    registry = ToolRegistry()
+    manager = MCPManager(store=store, secret_manager=None, registry=registry)
+
+    config = MCPServerConfig(name="failsrv", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+
+    mock_conn = MagicMock()
+    mock_conn.is_connected = True
+    mock_conn.connect = AsyncMock()
+    mock_conn.list_tools = AsyncMock(side_effect=RuntimeError("discover failed"))
+    mock_conn.disconnect = AsyncMock()
+
+    with patch("src.tools.mcp.MCPConnection", return_value=mock_conn):
+        try:
+            await manager.connect_server("failsrv")
+            assert False, "Should have raised"
+        except RuntimeError:
+            pass  # expected
+
+    # connection should be cleaned up
+    assert "failsrv" not in manager._connections
+    await store.close()
+    import os
+    os.unlink("/tmp/test_mcp_discover_fail.db")
+
+
+def test_schema_top_level_boolean():
+    """A top-level boolean schema (valid JSON Schema) returns empty params."""
+    params, param_map = MCPManager._schema_to_parameters(True)  # type: ignore
+    assert params == []
+    assert param_map == {}

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,495 @@
+"""Tests for MCP server integration."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.tools.mcp import (
+    MCPConnection,
+    MCPManager,
+    MCPServerConfig,
+    MCPTool,
+    MCP_RKEY_PREFIX,
+)
+from src.tools.registry import Tool, ToolParameter, ToolContext, ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+
+def test_unregister_removes_tool_and_returns_true():
+    """unregister() should remove a tool and return True when it existed."""
+    reg = ToolRegistry()
+
+    async def handler(ctx, **kw):
+        pass
+
+    reg.register(Tool(name="test.tool", description="x", parameters=[], handler=handler))
+    assert reg.unregister("test.tool") is True
+    assert reg.get("test.tool") is None
+
+
+def test_unregister_returns_false_for_missing():
+    """unregister() should return False when the tool doesn't exist."""
+    reg = ToolRegistry()
+    assert reg.unregister("nonexistent") is False
+
+
+# ---------------------------------------------------------------------------
+# Dataclass serialization tests
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_tool_serialization():
+    """MCPTool round-trips through to_dict / from_dict."""
+    tool = MCPTool(
+        name="search_mail",
+        description="Search mail",
+        input_schema={"type": "object", "properties": {"q": {"type": "string"}}},
+        approved=True,
+    )
+    d = tool.to_dict()
+    tool2 = MCPTool.from_dict(d)
+    assert tool2.name == "search_mail"
+    assert tool2.description == "Search mail"
+    assert tool2.approved is True
+    assert tool2.input_schema == tool.input_schema
+
+
+def test_mcp_server_config_serialization():
+    """MCPServerConfig round-trips through to_dict / from_dict."""
+    cfg = MCPServerConfig(
+        name="fastmail",
+        transport="sse",
+        url="https://api.fastmail.com/mcp",
+        auth_token_secret="FASTMAIL_API_TOKEN",
+        tools=[MCPTool(name="search", description="Search", input_schema={})],
+    )
+    d = cfg.to_dict()
+    cfg2 = MCPServerConfig.from_dict(d)
+    assert cfg2.name == "fastmail"
+    assert cfg2.transport == "sse"
+    assert cfg2.url == "https://api.fastmail.com/mcp"
+    assert cfg2.auth_token_secret == "FASTMAIL_API_TOKEN"
+    assert len(cfg2.tools) == 1
+    assert cfg2.tools[0].name == "search"
+
+
+def test_mcp_server_config_defaults():
+    """MCPServerConfig uses field(default_factory) for list fields."""
+    cfg = MCPServerConfig(name="test", transport="sse", url="https://example.com")
+    assert cfg.args == []
+    assert cfg.env_secrets == []
+    assert cfg.tools == []
+    assert cfg.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Schema conversion tests
+# ---------------------------------------------------------------------------
+
+
+def test_schema_to_parameters_simple_types():
+    """_schema_to_parameters converts JSON Schema to ToolParameter list."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Search query"},
+            "limit": {"type": "integer", "description": "Max results"},
+            "ratio": {"type": "number", "description": "Ratio"},
+            "verbose": {"type": "boolean", "description": "Verbose"},
+            "filter": {"type": "object", "description": "Filter obj"},
+            "tags": {"type": "array", "description": "Tags"},
+        },
+        "required": ["query", "limit"],
+    }
+    params = MCPManager._schema_to_parameters(schema)
+    assert len(params) == 6
+
+    by_name = {p.name: p for p in params}
+    assert by_name["query"].type == "string"
+    assert by_name["query"].required is True
+    assert by_name["limit"].type == "number"
+    assert by_name["limit"].required is True
+    assert by_name["ratio"].type == "number"
+    assert by_name["ratio"].required is False
+    assert by_name["verbose"].type == "boolean"
+    assert by_name["filter"].type == "object"
+    assert by_name["tags"].type == "array"
+
+
+def test_schema_to_parameters_empty():
+    """_schema_to_parameters returns [] for empty schema."""
+    assert MCPManager._schema_to_parameters({}) == []
+    assert MCPManager._schema_to_parameters({"type": "object"}) == []
+
+
+def test_schema_to_parameters_unknown_type_defaults_string():
+    """Unknown JSON Schema type falls back to 'string'."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "custom": {"type": "weird-type", "description": "Unknown"},
+        },
+    }
+    params = MCPManager._schema_to_parameters(schema)
+    assert params[0].type == "string"
+
+
+# ---------------------------------------------------------------------------
+# Tool name sanitization tests
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_tool_name():
+    """_sanitize_tool_name replaces non-identifier chars with underscore."""
+    assert MCPManager._sanitize_tool_name("search_mail") == "search_mail"
+    assert MCPManager._sanitize_tool_name("search.mail") == "search_mail"
+    assert MCPManager._sanitize_tool_name("foo-bar") == "foo_bar"
+    assert MCPManager._sanitize_tool_name("foo bar") == "foo_bar"
+
+
+# ---------------------------------------------------------------------------
+# MCPManager CRUD tests (with real Store)
+# ---------------------------------------------------------------------------
+
+
+async def _make_manager(tmp_path) -> MCPManager:
+    """Create an MCPManager backed by a real SQLite store."""
+    from src.store.store import Store
+
+    store = Store(path=tmp_path / "store.db")
+    await store.initialize()
+    registry = ToolRegistry()
+    return MCPManager(store=store, secret_manager=None, registry=registry), store
+
+
+@pytest.mark.asyncio
+async def test_create_server(tmp_path):
+    """create_server stores config and makes it visible via list_servers."""
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="testserver", transport="sse", url="https://example.com/mcp")
+    result = await manager.create_server(config)
+    assert "created" in result
+    assert len(manager.list_servers()) == 1
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_create_server_rejects_reserved_name(tmp_path):
+    """create_server rejects names that collide with built-in namespaces."""
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="memory", transport="sse", url="https://example.com")
+    result = await manager.create_server(config)
+    assert "reserved" in result.lower()
+    assert len(manager.list_servers()) == 0
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_create_server_rejects_invalid_name(tmp_path):
+    """create_server rejects names with invalid characters."""
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="bad.name", transport="sse", url="https://example.com")
+    result = await manager.create_server(config)
+    assert "invalid" in result.lower()
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_create_server_rejects_duplicate(tmp_path):
+    """create_server rejects duplicate server names."""
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="dup", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+    result = await manager.create_server(config)
+    assert "already exists" in result
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_delete_server(tmp_path):
+    """delete_server removes config from store and memory."""
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="todelete", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+    assert len(manager.list_servers()) == 1
+
+    result = await manager.delete_server("todelete")
+    assert "deleted" in result
+    assert len(manager.list_servers()) == 0
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_load_servers(tmp_path):
+    """load_servers reads configs from DocumentStore on startup."""
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(
+        name="loaded",
+        transport="sse",
+        url="https://example.com",
+        tools=[MCPTool(name="tool1", description="d", input_schema={}, approved=True)],
+    )
+    await manager.create_server(config)
+
+    # create a fresh manager and load from store
+    registry2 = ToolRegistry()
+    manager2 = MCPManager(store=store, secret_manager=None, registry=registry2)
+    await manager2.load_servers()
+
+    servers = manager2.list_servers()
+    assert len(servers) == 1
+    assert servers[0].name == "loaded"
+    assert len(servers[0].tools) == 1
+    assert servers[0].tools[0].approved is True
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Approval / revocation tests (with mocked connection)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_approve_tool_registers_in_registry(tmp_path):
+    """approve_tool registers the tool in the TOOL_REGISTRY."""
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
+    config.tools = [
+        MCPTool(
+            name="search",
+            description="Search stuff",
+            input_schema={
+                "type": "object",
+                "properties": {"q": {"type": "string"}},
+                "required": ["q"],
+            },
+        )
+    ]
+    await manager.create_server(config)
+
+    result = await manager.approve_tool("srv", "search")
+    assert "approved" in result
+
+    # tool should be in registry
+    tool = manager._registry.get("srv.search")
+    assert tool is not None
+    assert tool.description == "Search stuff"
+    assert len(tool.parameters) == 1
+    assert tool.parameters[0].name == "q"
+
+    # tool should appear in generated TS types
+    ts = manager._registry.generate_typescript_types()
+    assert "srv" in ts
+    assert "search" in ts
+
+    # tool should appear in documentation
+    docs = manager._registry.generate_tool_documentation()
+    assert "srv.search" in docs
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_revoke_tool_unregisters_from_registry(tmp_path):
+    """revoke_tool removes the tool from the TOOL_REGISTRY."""
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
+    config.tools = [
+        MCPTool(name="search", description="Search", input_schema={})
+    ]
+    await manager.create_server(config)
+
+    await manager.approve_tool("srv", "search")
+    assert manager._registry.get("srv.search") is not None
+
+    result = await manager.revoke_tool("srv", "search")
+    assert "revoked" in result
+    assert manager._registry.get("srv.search") is None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_not_connected(tmp_path):
+    """call_tool returns error dict when server is not connected."""
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+
+    result = await manager.call_tool("srv", "search", {"q": "test"})
+    assert isinstance(result, dict)
+    assert "error" in result
+    assert "not connected" in result["error"]
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Tool naming tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_naming_uses_server_dot_tool(tmp_path):
+    """Approved MCP tools are registered as <server>.<tool> in the registry."""
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="fastmail", transport="sse", url="https://example.com")
+    config.tools = [
+        MCPTool(name="search_mail", description="Search", input_schema={})
+    ]
+    await manager.create_server(config)
+
+    await manager.approve_tool("fastmail", "search_mail")
+    tool = manager._registry.get("fastmail.search_mail")
+    assert tool is not None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_tool_naming_sanitizes_dots(tmp_path):
+    """Tool names with dots are sanitized for registry but original name preserved for calls."""
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
+    config.tools = [
+        MCPTool(name="search.mail", description="Search", input_schema={})
+    ]
+    await manager.create_server(config)
+
+    await manager.approve_tool("srv", "search.mail")
+    # registered as sanitized name
+    assert manager._registry.get("srv.search_mail") is not None
+    # original name is NOT registered
+    assert manager._registry.get("srv.search.mail") is None
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# ToolContext / ToolExecutor integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_tool_context_has_mcp_manager_property():
+    """ToolContext exposes mcp_manager property (None by default)."""
+    ctx = ToolContext()
+    assert ctx.mcp_manager is None
+
+
+def test_executor_has_mcp_manager_property():
+    """ToolExecutor exposes mcp_manager public property."""
+    from src.tools.executor import ToolExecutor
+
+    ctx = ToolContext()
+    executor = ToolExecutor(registry=ToolRegistry(), ctx=ctx)
+    assert hasattr(executor, "mcp_manager")
+    assert executor.mcp_manager is None
+
+
+# ---------------------------------------------------------------------------
+# Web API tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_web_list_servers(tmp_path):
+    """GET /api/mcp/servers returns summaries with correct counts."""
+    from fastapi import FastAPI
+    from starlette.testclient import TestClient
+
+    from src.web.dependencies import get_executor
+    from src.web.routers import mcp as mcp_router
+
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="webtest", transport="sse", url="https://example.com")
+    config.tools = [
+        MCPTool(name="t1", description="d1", input_schema={}, approved=True),
+        MCPTool(name="t2", description="d2", input_schema={}, approved=False),
+    ]
+    await manager.create_server(config)
+
+    # mock executor
+    executor = MagicMock()
+    executor.mcp_manager = manager
+
+    app = FastAPI()
+    app.state.executor = executor
+    app.dependency_overrides[get_executor] = lambda: executor
+    app.include_router(mcp_router.router, prefix="/api")
+
+    client = TestClient(app)
+    resp = client.get("/api/mcp/servers")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["name"] == "webtest"
+    assert data[0]["transport"] == "sse"
+    assert data[0]["tools_total"] == 2
+    assert data[0]["tools_approved"] == 1
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_web_create_server(tmp_path):
+    """POST /api/mcp/servers creates a server and returns summary."""
+    from fastapi import FastAPI
+    from starlette.testclient import TestClient
+
+    from src.web.dependencies import get_executor
+    from src.web.routers import mcp as mcp_router
+
+    manager, store = await _make_manager(tmp_path)
+
+    executor = MagicMock()
+    executor.mcp_manager = manager
+
+    app = FastAPI()
+    app.state.executor = executor
+    app.dependency_overrides[get_executor] = lambda: executor
+    app.include_router(mcp_router.router, prefix="/api")
+
+    client = TestClient(app)
+    resp = client.post("/api/mcp/servers", json={
+        "name": "apitest",
+        "transport": "sse",
+        "url": "https://example.com/mcp",
+    })
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "apitest"
+    assert data["connected"] is False
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_web_approve_tool(tmp_path):
+    """POST /api/mcp/servers/{name}/tools/{tool}/approve registers the tool."""
+    from fastapi import FastAPI
+    from starlette.testclient import TestClient
+
+    from src.web.dependencies import get_executor
+    from src.web.routers import mcp as mcp_router
+
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="webtest", transport="sse", url="https://example.com")
+    config.tools = [
+        MCPTool(name="tool1", description="d1", input_schema={})
+    ]
+    await manager.create_server(config)
+
+    executor = MagicMock()
+    executor.mcp_manager = manager
+
+    app = FastAPI()
+    app.state.executor = executor
+    app.dependency_overrides[get_executor] = lambda: executor
+    app.include_router(mcp_router.router, prefix="/api")
+
+    client = TestClient(app)
+    resp = client.post("/api/mcp/servers/webtest/tools/tool1/approve")
+    assert resp.status_code == 200
+    assert "approved" in resp.json()["message"]
+
+    # verify tool was registered
+    assert manager._registry.get("webtest.tool1") is not None
+    await store.close()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -518,7 +518,10 @@ async def test_web_approve_tool(tmp_path):
     app.include_router(mcp_router.router, prefix="/api")
 
     client = TestClient(app)
-    resp = client.post("/api/mcp/servers/webtest/tools/tool1/approve")
+    resp = client.post(
+        "/api/mcp/servers/webtest/tools/approve",
+        json={"tool_name": "tool1"},
+    )
     assert resp.status_code == 200
     assert "approved" in resp.json()["message"]
 
@@ -602,3 +605,128 @@ async def test_connect_failure_cleans_up_exit_stack(tmp_path):
     # Connection should not be stored
     assert "failtest" not in manager._connections
     await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Reserved word validation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_server_rejects_ts_reserved_word(tmp_path):
+    """create_server rejects TypeScript reserved words as server names."""
+    manager, store = await _make_manager(tmp_path)
+    for bad_name in ["class", "default", "await", "function", "import"]:
+        config = MCPServerConfig(name=bad_name, transport="sse", url="https://example.com")
+        result = await manager.create_server(config)
+        assert "reserved word" in result.lower(), f"Should reject '{bad_name}'"
+    await store.close()
+
+
+def test_sanitize_reserved_word_gets_suffix():
+    """_sanitize_tool_name appends _ to reserved words."""
+    assert MCPManager._sanitize_tool_name("class") == "class_"
+    assert MCPManager._sanitize_tool_name("await") == "await_"
+    assert MCPManager._sanitize_tool_name("function") == "function_"
+
+
+# ---------------------------------------------------------------------------
+# Param collision detection tests
+# ---------------------------------------------------------------------------
+
+
+def test_schema_param_collision_disambiguated():
+    """Properties that sanitize to the same name get numeric suffixes."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "foo-bar": {"type": "string"},
+            "foo_bar": {"type": "string"},
+            "foo.bar": {"type": "string"},
+        },
+    }
+    params, param_map = MCPManager._schema_to_parameters(schema)
+    names = [p.name for p in params]
+    # all unique
+    assert len(names) == len(set(names))
+    # first one keeps base name, others get suffixes
+    assert "foo_bar" in names
+    assert "foo_bar_2" in names
+    assert "foo_bar_3" in names
+    # all map back to originals
+    assert len(param_map) == 3
+    originals = set(param_map.values())
+    assert originals == {"foo-bar", "foo_bar", "foo.bar"}
+
+
+# ---------------------------------------------------------------------------
+# Union type / non-dict schema tests
+# ---------------------------------------------------------------------------
+
+
+def test_schema_union_type_handled():
+    """Union types like ['string', 'null'] don't crash _schema_to_parameters."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "optional_str": {"type": ["string", "null"], "description": "Maybe string"},
+        },
+    }
+    params, _ = MCPManager._schema_to_parameters(schema)
+    assert len(params) == 1
+    assert params[0].type == "string"  # first type in union
+
+
+def test_schema_missing_type_defaults_string():
+    """Properties with no type field default to 'string'."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "notype": {"description": "No type field"},
+        },
+    }
+    params, _ = MCPManager._schema_to_parameters(schema)
+    assert params[0].type == "string"
+
+
+def test_schema_non_dict_property_handled():
+    """Non-dict property schemas don't crash."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "weird": True,  # boolean schema (JSON Schema allows this)
+        },
+    }
+    params, _ = MCPManager._schema_to_parameters(schema)
+    assert len(params) == 1
+    assert params[0].type == "string"
+
+
+# ---------------------------------------------------------------------------
+# Markdown sanitization tests
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_sanitization_strips_headings():
+    """_sanitize_md strips leading # and neutralizes code fences."""
+    from src.tools.registry import ToolRegistry, Tool
+
+    reg = ToolRegistry()
+
+    async def handler(ctx, **kw):
+        pass
+
+    reg.register(
+        Tool(
+            name="md.test",
+            description="## Fake Heading\n```evil```",
+            parameters=[],
+            handler=handler,
+        )
+    )
+
+    docs = reg.generate_tool_documentation()
+    # Should not contain raw ## heading or ```
+    assert "## Fake Heading" not in docs
+    assert "```" not in docs
+    reg.unregister("md.test")

--- a/uv.lock
+++ b/uv.lock
@@ -248,6 +248,63 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -323,6 +380,56 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
@@ -553,6 +660,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -636,6 +752,58 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/ee/94c6c50ffc5b5cf4737052275d11b57367f32d1a8516e31dcd60591b3916/mcp-1.28.0.tar.gz", hash = "sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2", size = 636040, upload-time = "2026-06-16T21:37:17.996Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/e1/4c1dc1fbb688641a712d34650c3d58bbbdcb314ddb75bc5817bbf33515a4/mcp-1.28.0-py3-none-any.whl", hash = "sha256:9c1e7cf3a9125557e418ecd4fed8e9adddce81b0dfdae4d6601d700f5beb71a4", size = 221959, upload-time = "2026-06-16T21:37:16.579Z" },
 ]
 
 [[package]]
@@ -910,6 +1078,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1019,6 +1196,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1054,6 +1245,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -1103,6 +1322,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1118,12 +1351,135 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/e7/a78582dc57caa592dcc7d4fb69b61390561e908eb3d2f5df5928a8e354c0/rpds_py-2026.5.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3abe24a66e57adcfa645d718063a5fa5103ecc71ddbf26d78af8f9368018ff1d", size = 353040, upload-time = "2026-05-28T11:59:12.531Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:58b1d94308ddf0b1982f61f2eb54bf92997c9ece8a8093ef014250f4a517906c", size = 345775, upload-time = "2026-05-28T11:59:13.827Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e1/0f2160c5982d3157734d5cb3ed63d8b2d583a73c9864f77b666449f32cf8/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fa92420128dadce7f54bd73ba1825a273e9268fe9e35dbf7e6362890efa4e08", size = 376329, upload-time = "2026-05-28T11:59:15.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/11/ee0ba42aff83bf4effdbc576673c6be64c5e173978c3f6d537e94482f77d/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca653c6546386227cd9800d1bef6a348099acf8db4250341da6d90f663d6dfcb", size = 383539, upload-time = "2026-05-28T11:59:16.665Z" },
+    { url = "https://files.pythonhosted.org/packages/11/df/d94aa6a499d4ac40afe2d7620f2c597fd3c0f182e854ad7cf3f596a81cb6/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66c93681c4729e4e3ecba31b8179fae083ff3118841672835140338b4b9867c1", size = 494674, upload-time = "2026-05-28T11:59:17.991Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/75/33d30f43bb2f458de11979486a591b1bf6e5651765ed1704c6197c2dc773/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ff257542e04796880e011e15cd4dc21c2599975df2aaa8f2c8495ca574e1a5", size = 389268, upload-time = "2026-05-28T11:59:19.434Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6825cc329b290e93c5f6a9be2393118a763f6ccf6abd83704e0c102ca583644", size = 376280, upload-time = "2026-05-28T11:59:21Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e5/61ec9f8be8211ea7f48448195549e4aaf02004083475493b0e137702ecb2/rpds_py-2026.5.1-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:de42116e69cb53b911cc34aee5ab98f36c597b822545045d49e938818b99e5e4", size = 387233, upload-time = "2026-05-28T11:59:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ca/bcec1005c4f4a234f92a29078631fee49206c7265ccae966f18fd332e80e/rpds_py-2026.5.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c0f920015df2a504bebaba6d4c31ccf3fcf942f92655c086da30b671aad19aa6", size = 405009, upload-time = "2026-05-28T11:59:23.845Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e6/4d5718c5cf26c522dc7c9999e238da1e77380b81d0c5d1df11e271ddfeb1/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0408a24e44feb919423dc6d9da677cb5cddb894d2ca9e763967d156d9c60fab4", size = 553113, upload-time = "2026-05-28T11:59:25.184Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/25/2ee807bdb3e1f0b7eddf7782acd5665a8b5205a331a7d7244a52c4812fd9/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cea68bcd53467561ae2f96a6bdad1544299ba97b5b0ddcd5ac3d376e5c781c24", size = 618838, upload-time = "2026-05-28T11:59:26.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c1/7d4c26f167f8c41501cc073d30ee22082b16ce358cf5b00ec97cbc7804ea/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4be8b1d2a705cc37d08256004e1d07de143fa0075c8e85a3df020b776f62b732", size = 582436, upload-time = "2026-05-28T11:59:28.11Z" },
+    { url = "https://files.pythonhosted.org/packages/04/1d/9d12b0a337bab46f4769f8857f4007e3b2d639e14f9a44a0efe157696e64/rpds_py-2026.5.1-cp312-cp312-win32.whl", hash = "sha256:6736718bd4fc49cbcb538ba30516fdbef161522acefb739657d48b97bd864fed", size = 212734, upload-time = "2026-05-28T11:59:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/93/e4116f2de7f56bc7406a76033dc501811ddeb22b7f056b92d632871ebb0c/rpds_py-2026.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:0a7d1eec967df0e9b22614a5e177622e0c89611d03727fa0cb48e45028907870", size = 229045, upload-time = "2026-05-28T11:59:31.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/53/6c3419d85eb2ec5938a37627c585b42d76a63bb731d6e42ed4b079ebf486/rpds_py-2026.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1841d067089e117142d79b98aa0df2f08b52f2ecc1819dd2700636c0db74a473", size = 223967, upload-time = "2026-05-28T11:59:32.318Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
+    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
 ]
 
 [[package]]
@@ -1249,6 +1605,7 @@ dependencies = [
     { name = "exa-py" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "mcp" },
     { name = "numpy" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1270,6 +1627,7 @@ requires-dist = [
     { name = "exa-py", specifier = ">=2.3.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.0" },
+    { name = "mcp", specifier = ">=1.28.0" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,8 @@ import { ToolDetail } from "./components/tools/ToolDetail";
 import { SecretsView } from "./components/secrets/SecretsView";
 import { SchedulesView } from "./components/schedules/SchedulesView";
 import { SystemPromptView } from "./components/system-prompt/SystemPromptView";
+import { MCPView } from "./components/mcp/MCPView";
+import { MCPServerDetail } from "./components/mcp/MCPServerDetail";
 
 export default function App() {
   return (
@@ -20,6 +22,8 @@ export default function App() {
           <Route path="/tools/:name" element={<ToolDetail />} />
           <Route path="/secrets" element={<SecretsView />} />
           <Route path="/schedules" element={<SchedulesView />} />
+          <Route path="/mcp" element={<MCPView />} />
+          <Route path="/mcp/:name" element={<MCPServerDetail />} />
           <Route path="/system-prompt" element={<SystemPromptView />} />
         </Route>
       </Routes>

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,10 +1,11 @@
 import { Outlet, Link, useLocation } from "react-router-dom";
-import { MessageSquare, Wrench, Key, Clock, FileText } from "lucide-react";
+import { MessageSquare, Wrench, Key, Clock, FileText, Plug } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const navItems = [
   { to: "/sessions", label: "Sessions", icon: MessageSquare },
   { to: "/tools", label: "Tools", icon: Wrench },
+  { to: "/mcp", label: "MCP", icon: Plug },
   { to: "/secrets", label: "Secrets", icon: Key },
   { to: "/schedules", label: "Schedules", icon: Clock },
   { to: "/system-prompt", label: "Prompt", icon: FileText },

--- a/web/src/components/mcp/MCPServerDetail.tsx
+++ b/web/src/components/mcp/MCPServerDetail.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useState, useCallback } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  ArrowLeft,
+  Check,
+  X,
+  Trash2,
+  Plug,
+  PlugZap,
+  RefreshCw,
+} from "lucide-react";
+import { api, ApiError } from "@/lib/api";
+import type { MCPServerDetail as MCPServerDetailType } from "@/lib/types";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+export function MCPServerDetail() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+  const [server, setServer] = useState<MCPServerDetailType | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  const refresh = useCallback(async () => {
+    if (!name) return;
+    try {
+      setServer(await api.getMCPServer(name));
+    } catch (e) {
+      console.error("Failed to load MCP server:", e);
+    } finally {
+      setLoading(false);
+    }
+  }, [name]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleConnect = async () => {
+    if (!name) return;
+    setBusy(true);
+    setError("");
+    try {
+      setServer(await api.connectMCPServer(name));
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Failed to connect");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    if (!name) return;
+    setBusy(true);
+    setError("");
+    try {
+      setServer(await api.disconnectMCPServer(name));
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Failed to disconnect");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRefresh = async () => {
+    if (!name) return;
+    setBusy(true);
+    setError("");
+    try {
+      setServer(await api.refreshMCPServer(name));
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Failed to refresh tools");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!name || !confirm(`Delete MCP server "${name}"?`)) return;
+    try {
+      await api.deleteMCPServer(name);
+      navigate("/mcp");
+    } catch (e) {
+      console.error("Failed to delete:", e);
+    }
+  };
+
+  const handleApproveTool = async (toolName: string) => {
+    if (!name) return;
+    try {
+      await api.approveMCPTool(name, toolName);
+      await refresh();
+    } catch (e) {
+      console.error("Failed to approve:", e);
+    }
+  };
+
+  const handleRevokeTool = async (toolName: string) => {
+    if (!name) return;
+    try {
+      await api.revokeMCPTool(name, toolName);
+      await refresh();
+    } catch (e) {
+      console.error("Failed to revoke:", e);
+    }
+  };
+
+  if (loading) return <div className="p-6 text-muted-foreground">Loading…</div>;
+  if (!server) return <div className="p-6 text-muted-foreground">MCP server not found.</div>;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-3 border-b border-border px-6 py-3">
+        <Button variant="ghost" size="icon" onClick={() => navigate("/mcp")}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <h2 className="text-lg font-semibold">{server.name}</h2>
+        <Badge variant="outline">{server.transport}</Badge>
+        {server.connected ? (
+          <Badge className="bg-green-600 text-white">connected</Badge>
+        ) : (
+          <Badge variant="secondary" className="bg-zinc-500 text-white">disconnected</Badge>
+        )}
+        <div className="ml-auto flex gap-2">
+          {!server.connected ? (
+            <Button size="sm" onClick={handleConnect} disabled={busy}>
+              <Plug className="mr-1 h-4 w-4" /> Connect
+            </Button>
+          ) : (
+            <Button size="sm" variant="outline" onClick={handleDisconnect} disabled={busy}>
+              <PlugZap className="mr-1 h-4 w-4" /> Disconnect
+            </Button>
+          )}
+          <Button size="sm" variant="outline" onClick={handleRefresh} disabled={busy || !server.connected}>
+            <RefreshCw className="mr-1 h-4 w-4" /> Refresh
+          </Button>
+          <Button size="sm" variant="destructive" onClick={handleDelete} disabled={busy}>
+            <Trash2 className="mr-1 h-4 w-4" /> Delete
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="px-6 py-2 text-sm text-red-500 bg-red-50 dark:bg-red-950/20">
+          {error}
+        </div>
+      )}
+
+      <ScrollArea className="flex-1">
+        <div className="p-6">
+          {/* Config */}
+          <div className="mb-6 space-y-2">
+            <div className="text-xs font-medium text-muted-foreground">Configuration</div>
+            {server.transport === "sse" ? (
+              <div className="text-sm">
+                <span className="text-muted-foreground">URL: </span>
+                <code className="rounded bg-muted px-1.5 py-0.5">{server.url || "—"}</code>
+              </div>
+            ) : (
+              <>
+                <div className="text-sm">
+                  <span className="text-muted-foreground">Command: </span>
+                  <code className="rounded bg-muted px-1.5 py-0.5">{server.command || "—"}</code>
+                </div>
+                {server.args.length > 0 && (
+                  <div className="text-sm">
+                    <span className="text-muted-foreground">Args: </span>
+                    <code className="rounded bg-muted px-1.5 py-0.5">{server.args.join(" ")}</code>
+                  </div>
+                )}
+              </>
+            )}
+            {server.auth_token_secret && (
+              <div className="flex items-center gap-2 text-sm">
+                <span className="text-muted-foreground">Auth token:</span>
+                <code className="rounded bg-muted px-1.5 py-0.5">{server.auth_token_secret}</code>
+                {server.auth_token_status === "set" ? (
+                  <Badge className="bg-green-600 text-white">set</Badge>
+                ) : (
+                  <Badge variant="secondary" className="bg-yellow-600 text-white">missing</Badge>
+                )}
+              </div>
+            )}
+            {server.env_secrets.length > 0 && (
+              <div className="flex flex-col gap-1">
+                {server.env_secrets.map((s) => (
+                  <div key={s.name} className="flex items-center gap-2 text-sm">
+                    <code className="rounded bg-muted px-1.5 py-0.5">{s.name}</code>
+                    {s.status === "set" ? (
+                      <Badge className="bg-green-600 text-white">set</Badge>
+                    ) : (
+                      <Badge variant="secondary" className="bg-yellow-600 text-white">missing</Badge>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Tools */}
+          <div>
+            <div className="mb-2 text-xs font-medium text-muted-foreground">
+              Tools ({server.tools.filter((t) => t.approved).length}/{server.tools.length} approved)
+            </div>
+            {!server.connected && server.tools.length === 0 ? (
+              <div className="text-sm text-muted-foreground">
+                Connect to this server to discover available tools.
+              </div>
+            ) : server.tools.length === 0 ? (
+              <div className="text-sm text-muted-foreground">
+                No tools discovered. Click "Refresh" to re-discover.
+              </div>
+            ) : (
+              <div className="flex flex-col gap-1">
+                {server.tools.map((tool) => (
+                  <div
+                    key={tool.name}
+                    className="group flex items-center gap-3 rounded-md px-3 py-2 hover:bg-accent"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <code className="text-sm font-medium">{tool.name}</code>
+                        {tool.approved ? (
+                          <Badge className="bg-green-600 text-white">approved</Badge>
+                        ) : (
+                          <Badge variant="secondary" className="bg-yellow-600 text-white">pending</Badge>
+                        )}
+                      </div>
+                      <div className="truncate text-xs text-muted-foreground">{tool.description}</div>
+                    </div>
+                    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100">
+                      {!tool.approved && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          onClick={() => handleApproveTool(tool.name)}
+                        >
+                          <Check className="h-3.5 w-3.5 text-green-500" />
+                        </Button>
+                      )}
+                      {tool.approved && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          onClick={() => handleRevokeTool(tool.name)}
+                        >
+                          <X className="h-3.5 w-3.5 text-yellow-500" />
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/web/src/components/mcp/MCPView.tsx
+++ b/web/src/components/mcp/MCPView.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { Plus, Trash2, Plug } from "lucide-react";
+import { api, ApiError } from "@/lib/api";
+import type { MCPServerSummary } from "@/lib/types";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+
+export function MCPView() {
+  const navigate = useNavigate();
+  const [servers, setServers] = useState<MCPServerSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showAdd, setShowAdd] = useState(false);
+
+  // form state
+  const [name, setName] = useState("");
+  const [transport, setTransport] = useState<"sse" | "stdio">("sse");
+  const [url, setUrl] = useState("");
+  const [command, setCommand] = useState("");
+  const [args, setArgs] = useState("");
+  const [authTokenSecret, setAuthTokenSecret] = useState("");
+  const [envSecrets, setEnvSecrets] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState("");
+
+  const refresh = useCallback(async () => {
+    try {
+      setServers(await api.listMCPServers());
+    } catch (e) {
+      console.error("Failed to load MCP servers:", e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleCreate = async () => {
+    setCreating(true);
+    setError("");
+    try {
+      await api.createMCPServer({
+        name,
+        transport,
+        url: transport === "sse" ? url || undefined : undefined,
+        command: transport === "stdio" ? command || undefined : undefined,
+        args: transport === "stdio" && args ? args.split(/\s+/) : [],
+        auth_token_secret: authTokenSecret || undefined,
+        env_secrets: transport === "stdio" && envSecrets ? envSecrets.split(",").map((s) => s.trim()).filter(Boolean) : [],
+        enabled: true,
+      });
+      setShowAdd(false);
+      setName("");
+      setUrl("");
+      setCommand("");
+      setArgs("");
+      setAuthTokenSecret("");
+      setEnvSecrets("");
+      await refresh();
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(e.message);
+      } else {
+        setError("Failed to create server");
+      }
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDelete = async (e: React.MouseEvent, name: string) => {
+    e.stopPropagation();
+    if (!confirm(`Delete MCP server "${name}"?`)) return;
+    try {
+      await api.deleteMCPServer(name);
+      await refresh();
+    } catch (e) {
+      console.error("Failed to delete:", e);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-3 px-6 py-3">
+        <h2 className="text-lg font-semibold">MCP Servers</h2>
+        <Button size="sm" variant="outline" onClick={() => setShowAdd(true)}>
+          <Plus className="mr-1 h-4 w-4" /> Add Server
+        </Button>
+      </div>
+      <ScrollArea className="flex-1">
+        <div className="px-3 pb-4">
+          {loading ? (
+            <div className="px-3 py-8 text-center text-muted-foreground">Loading…</div>
+          ) : servers.length === 0 ? (
+            <div className="px-3 py-8 text-center text-muted-foreground">
+              No MCP servers configured. Click "Add Server" to connect to an external MCP server.
+            </div>
+          ) : (
+            <div className="flex flex-col gap-1">
+              {servers.map((s) => (
+                <div
+                  key={s.name}
+                  onClick={() => navigate(`/mcp/${s.name}`)}
+                  className="group flex cursor-pointer items-center gap-3 rounded-md px-3 py-2.5 hover:bg-accent"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium">{s.name}</span>
+                      <Badge variant="outline">{s.transport}</Badge>
+                      {s.connected ? (
+                        <Badge className="bg-green-600 text-white">connected</Badge>
+                      ) : (
+                        <Badge variant="secondary" className="bg-zinc-500 text-white">disconnected</Badge>
+                      )}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {s.tools_approved}/{s.tools_total} tools approved
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100">
+                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={(e) => handleDelete(e, s.name)}>
+                      <Trash2 className="h-3.5 w-3.5 text-red-500" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+
+      <Dialog open={showAdd} onOpenChange={setShowAdd}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add MCP Server</DialogTitle>
+            <DialogDescription>
+              Connect to an external MCP server. Tools are discovered and individually approved.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-3">
+            <div>
+              <label className="text-sm font-medium">Name</label>
+              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. fastmail" />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Transport</label>
+              <div className="flex gap-2 mt-1">
+                <Button
+                  size="sm"
+                  variant={transport === "sse" ? "default" : "outline"}
+                  onClick={() => setTransport("sse")}
+                >
+                  SSE (HTTP)
+                </Button>
+                <Button
+                  size="sm"
+                  variant={transport === "stdio" ? "default" : "outline"}
+                  onClick={() => setTransport("stdio")}
+                >
+                  stdio
+                </Button>
+              </div>
+            </div>
+            {transport === "sse" ? (
+              <div>
+                <label className="text-sm font-medium">URL</label>
+                <Input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://api.example.com/mcp" />
+              </div>
+            ) : (
+              <>
+                <div>
+                  <label className="text-sm font-medium">Command</label>
+                  <Input value={command} onChange={(e) => setCommand(e.target.value)} placeholder="e.g. npx" />
+                </div>
+                <div>
+                  <label className="text-sm font-medium">Args (space-separated)</label>
+                  <Input value={args} onChange={(e) => setArgs(e.target.value)} placeholder="-y @some/mcp-server" />
+                </div>
+              </>
+            )}
+            <div>
+              <label className="text-sm font-medium">Auth Token Secret Name (optional)</label>
+              <Input
+                value={authTokenSecret}
+                onChange={(e) => setAuthTokenSecret(e.target.value)}
+                placeholder="e.g. FASTMAIL_API_TOKEN"
+              />
+              <p className="text-xs text-muted-foreground mt-1">Resolved from the Secrets store at connection time.</p>
+            </div>
+            {transport === "stdio" && (
+              <div>
+                <label className="text-sm font-medium">Env Secret Names (comma-separated, optional)</label>
+                <Input
+                  value={envSecrets}
+                  onChange={(e) => setEnvSecrets(e.target.value)}
+                  placeholder="API_KEY, DATABASE_URL"
+                />
+              </div>
+            )}
+            {error && <div className="text-sm text-red-500">{error}</div>}
+            <Button onClick={handleCreate} disabled={creating || !name}>
+              {creating ? "Creating…" : "Create Server"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,6 @@
 import type {
+  MCPServerDetail,
+  MCPServerSummary,
   MessageList,
   Schedule,
   Secret,
@@ -162,4 +164,49 @@ export const api = {
   // -- system prompt --
 
   getSystemPrompt: () => fetchJSON<SystemPrompt>(`${API_BASE}/system-prompt`),
+
+  // -- MCP --
+
+  listMCPServers: () => fetchJSON<MCPServerSummary[]>(`${API_BASE}/mcp/servers`),
+  createMCPServer: (config: {
+    name: string;
+    transport: string;
+    url?: string;
+    command?: string;
+    args?: string[];
+    auth_token_secret?: string;
+    env_secrets?: string[];
+    enabled?: boolean;
+  }) =>
+    fetchJSON<MCPServerSummary>(`${API_BASE}/mcp/servers`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(config),
+    }),
+  getMCPServer: (name: string) =>
+    fetchJSON<MCPServerDetail>(`${API_BASE}/mcp/servers/${enc(name)}`),
+  deleteMCPServer: (name: string) =>
+    fetchJSON<void>(`${API_BASE}/mcp/servers/${enc(name)}`, { method: "DELETE" }),
+  connectMCPServer: (name: string) =>
+    fetchJSON<MCPServerDetail>(`${API_BASE}/mcp/servers/${enc(name)}/connect`, {
+      method: "POST",
+    }),
+  disconnectMCPServer: (name: string) =>
+    fetchJSON<MCPServerDetail>(`${API_BASE}/mcp/servers/${enc(name)}/disconnect`, {
+      method: "POST",
+    }),
+  refreshMCPServer: (name: string) =>
+    fetchJSON<MCPServerDetail>(`${API_BASE}/mcp/servers/${enc(name)}/refresh`, {
+      method: "POST",
+    }),
+  approveMCPTool: (serverName: string, toolName: string) =>
+    fetchJSON<{ message: string }>(
+      `${API_BASE}/mcp/servers/${enc(serverName)}/tools/${enc(toolName)}/approve`,
+      { method: "POST" },
+    ),
+  revokeMCPTool: (serverName: string, toolName: string) =>
+    fetchJSON<{ message: string }>(
+      `${API_BASE}/mcp/servers/${enc(serverName)}/tools/${enc(toolName)}/revoke`,
+      { method: "POST" },
+    ),
 };

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -201,12 +201,20 @@ export const api = {
     }),
   approveMCPTool: (serverName: string, toolName: string) =>
     fetchJSON<{ message: string }>(
-      `${API_BASE}/mcp/servers/${enc(serverName)}/tools/${enc(toolName)}/approve`,
-      { method: "POST" },
+      `${API_BASE}/mcp/servers/${enc(serverName)}/tools/approve`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tool_name: toolName }),
+      },
     ),
   revokeMCPTool: (serverName: string, toolName: string) =>
     fetchJSON<{ message: string }>(
-      `${API_BASE}/mcp/servers/${enc(serverName)}/tools/${enc(toolName)}/revoke`,
-      { method: "POST" },
+      `${API_BASE}/mcp/servers/${enc(serverName)}/tools/revoke`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tool_name: toolName }),
+      },
     ),
 };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -71,6 +71,37 @@ export interface SystemPrompt {
   token_estimate: number;
 }
 
+// -- MCP types --
+
+export interface MCPServerSummary {
+  name: string;
+  transport: string;
+  enabled: boolean;
+  connected: boolean;
+  tools_total: number;
+  tools_approved: number;
+}
+
+export interface MCPToolSummary {
+  name: string;
+  description: string;
+  approved: boolean;
+}
+
+export interface MCPServerDetail {
+  name: string;
+  transport: string;
+  url: string | null;
+  command: string | null;
+  args: string[];
+  auth_token_secret: string | null;
+  auth_token_status: string;
+  env_secrets: { name: string; status: string }[];
+  enabled: boolean;
+  connected: boolean;
+  tools: MCPToolSummary[];
+}
+
 // -- SSE event types --
 
 export interface ChatSSEEvent {


### PR DESCRIPTION
## Summary

Adds configurable MCP (Model Context Protocol) client support to Victrola, allowing the operator to connect to external MCP servers (starting with Fastmail), discover their tools, approve individual tools via the web UI, and have approved tools become callable by the agent through the existing execute_code pipeline.

## Architecture

MCP tools are dynamically registered in TOOL_REGISTRY as Tool objects with namespaced names (server_name.tool_name). TS stubs and system prompt docs are auto-generated. The agent calls them as tools.fastmail.search_mail(...) inside execute_code. No changes to the agent loop were needed.

Config storage uses SQLite DocumentStore with mcpserver: prefix — same pattern as custom tools.

## Changes

**New files:**
- src/tools/mcp.py — MCPManager, MCPConnection, MCPServerConfig, MCPTool
- src/web/routers/mcp.py — CRUD + approval + connect/disconnect/refresh endpoints
- web/src/components/mcp/MCPView.tsx — server list + add form
- web/src/components/mcp/MCPServerDetail.tsx — server detail + tool approval UI
- tests/test_mcp.py — 36 tests

**Modified files:**
- src/tools/registry.py — unregister(), mcp_manager property, TS injection sanitization, markdown sanitization
- src/tools/executor.py — initialize/close MCPManager, mcp_manager property
- src/agent/prompt.py — MCP_TOOLS_TEMPLATE section
- main.py — wire MCP servers list into system prompt
- src/web/schemas.py — MCP request/response models
- src/web/app.py — register MCP router
- src/web/routers/status.py — MCP server/tool counts
- web/src/lib/types.ts, api.ts, App.tsx, Layout.tsx — frontend wiring
- pyproject.toml — mcp>=1.28.0 dependency

## Security

Went through 2 cycles of adversarial code review. All findings were fixed:
- TS code injection via */ in tool descriptions sanitized
- Invalid TS identifiers in server/tool/param names validated and sanitized
- Reserved word collisions rejected for server names, suffixed for tool/param names
- Tool name and param name collisions detected and disambiguated
- Connection leaks on failed connect/discovery cleanup with try/except BaseException
- Markdown injection in prompt docs sanitized
- Concurrent operations protected with per-server asyncio.Lock
- Union types and boolean schemas handled defensively

## Test Plan

- [x] 36 unit tests in tests/test_mcp.py all pass
- [x] 149 total tests pass (no regressions)
- [ ] Manual: Add Fastmail MCP server, connect, discover, approve, and call a tool from chat