### PR TITLE
Let agent decide whether to notify on scheduled task runs

### DIFF
--- a/main.py
+++ b/main.py
@@ -110,13 +110,27 @@ def _wire_scheduler(executor: ToolExecutor, agent: Agent) -> None:
     if executor.scheduler is not None:
 
         async def on_schedule_fire(task_name: str, prompt: str) -> str:
-            response = await agent.chat(
-                f"[Scheduled task: {task_name}] {prompt}", conversation=[]
-            )
-            if response:
-                await _send_default_notification(
-                    executor, response, title=f"Scheduled: {task_name}"
+            try:
+                response = await agent.chat(
+                    f"[Scheduled task: {task_name}] {prompt}", conversation=[]
                 )
+            except Exception:
+                logger.exception("Scheduled task '%s' raised an exception", task_name)
+                await _send_default_notification(
+                    executor,
+                    f"Scheduled task '{task_name}' raised an exception. "
+                    "Check victrola.log for details.",
+                    title=f"Error: {task_name}",
+                )
+                raise
+
+            if not response:
+                await _send_default_notification(
+                    executor,
+                    f"Scheduled task '{task_name}' returned an empty response.",
+                    title=f"Error: {task_name}",
+                )
+
             return response
 
         executor.scheduler._on_fire = on_schedule_fire
@@ -141,7 +155,11 @@ def _wire_scheduler(executor: ToolExecutor, agent: Agent) -> None:
 async def _send_default_notification(
     executor: ToolExecutor, content: str, title: str = ""
 ) -> None:
-    """Send a notification to the default channel (Signal if configured, else Discord).
+    """Send an error notification to the default channel (Signal if configured, else Discord).
+
+    Only called as a safety net when a scheduled task raises an exception or
+    returns an empty response. Normal scheduled results are the agent's
+    responsibility — it decides whether to notify via `notify.send`.
 
     Uses executor.ctx.http_client for HTTP calls. Logs errors but does not
     raise — scheduled task results should not crash the scheduler.

--- a/src/agent/prompt.py
+++ b/src/agent/prompt.py
@@ -42,6 +42,7 @@ Every tool invocation goes through a real `execute_code` function call, every ti
 - When presenting data, use tables or structured formats
 - Cite specific data points from your tool results
 - Use `notify.send` for notifications to the operator (routes to Signal if configured, else Discord)
+- When you are running outside a live session (e.g. a scheduled task), the operator is not reading your output. `notify.send` is your only channel to reach them — use it only when you have something worth saying
 
 ## Memory Discipline
 
@@ -84,6 +85,15 @@ When a tool call fails, read the error carefully before retrying. Adjust your ap
 ## Scheduled Tasks and Triggers
 
 Scheduled tasks fire a prompt on a recurring schedule (daily summaries, periodic checks, etc.). When a schedule fires, you run the prompt in a fresh conversation with no prior history — so the prompt must be self-contained.
+
+### Notifications when outside a session
+
+When a scheduled task fires, you are running **outside a live session** — the operator is not watching your output. You decide whether the result is worth sending to them.
+
+- **Do notify** when you found something actionable, completed a meaningful task, hit an unexpected issue, or the operator explicitly asked to be informed.
+- **Do not notify** when the run turned up nothing interesting, a periodic check found no changes, or the result is routine noise.
+- Use `notify.send` to reach the operator (routes to Signal if configured, else Discord).
+- The harness will notify the operator on your behalf only if you crash or return an empty response — so you don't need to handle those cases yourself.
 
 ### Triggers (conditional schedules)
 


### PR DESCRIPTION
## What

Scheduled tasks currently auto-send **every** response to Signal/Discord via `_send_default_notification`. This means the operator gets pinged even when a periodic check turns up nothing interesting.

This changes the model: the agent now decides whether a scheduled result is worth sending to the operator via `notify.send`, and the harness stays quiet on normal completions.

## Changes

**`main.py`** — `on_schedule_fire` no longer auto-notifies on success:
- Normal completion: no auto-notification. The agent decides via `notify.send`.
- Exception: harness sends a fallback notification and re-raises (scheduler retry logic still works).
- Empty response: harness sends a fallback notification (usually indicates a problem).

**`src/agent/prompt.py`** — two prompt additions:
1. Communication Guidelines: one-liner that `notify.send` is the out-of-band channel when outside a live session.
2. Scheduled Tasks section: new "Notifications when outside a session" subsection with do/don't guidance.

## Safety net

The harness still notifies the operator when:
- The agent raises an exception (then re-raises for the scheduler retry logic)
- The agent returns an empty response

So silent failures are still surfaced.

## Tests

All 210 tests pass.