### PR TITLE
Add schedule editing and run-now trigger

### DIFF
--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -369,6 +369,21 @@ class Scheduler:
         await self._save_task(task)
         return f"Schedule '{name}' condition code approval revoked."
 
+    async def run_now(self, name: str) -> str:
+        """Fire a scheduled task immediately on operator demand.
+
+        Goes through the full ``_fire`` path (condition evaluation if present
+        and approved, agent wake, ``last_run`` advancement) so it behaves
+        exactly like a real scheduled tick. The ``enabled`` flag is ignored —
+        the operator is explicitly requesting this fire.
+        """
+        task = self._tasks.get(name)
+        if task is None:
+            return f"Schedule '{name}' not found."
+        now = datetime.now(timezone.utc)
+        await self._fire(task, now)
+        return f"Schedule '{name}' fired."
+
     async def run(self) -> None:
         """Main scheduler loop. Run as a background asyncio task."""
         self._running = True

--- a/src/web/routers/schedules.py
+++ b/src/web/routers/schedules.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 from typing import Any
 
@@ -9,7 +10,11 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from src.tools.executor import ToolExecutor
 from src.web.dependencies import get_executor
-from src.web.schemas import CreateScheduleRequest, ScheduleResponse
+from src.web.schemas import (
+    CreateScheduleRequest,
+    ScheduleResponse,
+    UpdateScheduleRequest,
+)
 
 router = APIRouter()
 
@@ -98,6 +103,51 @@ async def create_schedule(
             raise HTTPException(409, result)
         raise HTTPException(400, result)
     return _to_response(task)
+
+
+@router.put("/schedules/{name}", response_model=ScheduleResponse)
+async def update_schedule(
+    name: str,
+    body: UpdateScheduleRequest,
+    executor: ToolExecutor = Depends(get_executor),
+) -> ScheduleResponse:
+    scheduler = _get_scheduler(executor)
+    task = scheduler.get_task(name)
+    if task is None:
+        raise HTTPException(404, f"Schedule '{name}' not found")
+
+    # validate schedule expression before updating
+    if body.schedule is not None:
+        from src.scheduler.schedule import parse_schedule
+
+        try:
+            parse_schedule(body.schedule)
+        except ValueError as e:
+            raise HTTPException(400, f"Invalid schedule expression: {e}")
+
+    # Build update fields, normalizing empty condition_code to None so it
+    # can be cleared. update_task skips None-valued fields, so only send
+    # keys that were explicitly provided in the request body.
+    fields: dict[str, Any] = {}
+    if body.schedule is not None:
+        fields["schedule"] = body.schedule
+    if body.prompt is not None:
+        fields["prompt"] = body.prompt
+    if body.condition_code is not None:
+        cc = body.condition_code.strip()
+        fields["condition_code"] = cc if cc else None
+    if body.requires_net is not None:
+        fields["requires_net"] = body.requires_net
+    if body.secrets is not None:
+        fields["secrets"] = list(body.secrets)
+
+    if not fields:
+        raise HTTPException(400, "No fields to update")
+
+    result = await scheduler.update_task(name, **fields)
+    if result.startswith("Error:"):
+        raise HTTPException(400, result)
+    return _to_response(scheduler.get_task(name))
 
 
 @router.post("/schedules/{name}/enable", response_model=ScheduleResponse)
@@ -197,6 +247,22 @@ async def test_schedule(
         allow_net=task.requires_net,
     )
     return result
+
+
+@router.post("/schedules/{name}/run-now")
+async def run_now_schedule(
+    name: str,
+    executor: ToolExecutor = Depends(get_executor),
+) -> dict[str, Any]:
+    scheduler = _get_scheduler(executor)
+    task = scheduler.get_task(name)
+    if task is None:
+        raise HTTPException(404, f"Schedule '{name}' not found")
+
+    # Fire in the background — _fire may take minutes (full agent chat)
+    # and results are delivered through notification channels.
+    asyncio.create_task(scheduler.run_now(name))
+    return {"fired": True, "name": name}
 
 
 @router.delete("/schedules/{name}", status_code=204)

--- a/src/web/schemas.py
+++ b/src/web/schemas.py
@@ -33,6 +33,14 @@ class CreateScheduleRequest(BaseModel):
     secrets: list[str] = []
 
 
+class UpdateScheduleRequest(BaseModel):
+    schedule: str | None = None
+    prompt: str | None = None
+    condition_code: str | None = None
+    requires_net: bool | None = None
+    secrets: list[str] | None = None
+
+
 class TestCodeRequest(BaseModel):
     params: dict = {}
 

--- a/web/src/components/schedules/SchedulesView.tsx
+++ b/web/src/components/schedules/SchedulesView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
-import { Plus, Trash2, Power, PowerOff, FlaskConical, Check, X } from "lucide-react";
+import { Plus, Trash2, Power, PowerOff, FlaskConical, Check, X, Pencil, Play } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import type { Schedule } from "@/lib/types";
 import { Button } from "@/components/ui/button";
@@ -28,6 +28,15 @@ export function SchedulesView() {
   const [testResult, setTestResult] = useState<Record<string, unknown> | null>(null);
   const [testingName, setTestingName] = useState<string | null>(null);
   const [approveError, setApproveError] = useState<string | null>(null);
+  const [showEdit, setShowEdit] = useState(false);
+  const [editName, setEditName] = useState("");
+  const [editSchedule, setEditSchedule] = useState("");
+  const [editPrompt, setEditPrompt] = useState("");
+  const [editConditionCode, setEditConditionCode] = useState("");
+  const [editRequiresNet, setEditRequiresNet] = useState(false);
+  const [editSecretsInput, setEditSecretsInput] = useState("");
+  const [editError, setEditError] = useState("");
+  const [runningName, setRunningName] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -139,6 +148,54 @@ export function SchedulesView() {
     }
   };
 
+  const handleEdit = (s: Schedule) => {
+    setEditName(s.name);
+    setEditSchedule(s.schedule);
+    setEditPrompt(s.prompt);
+    setEditConditionCode(s.condition_code ?? "");
+    setEditRequiresNet(s.requires_net);
+    setEditSecretsInput((s.secrets ?? []).join(", "));
+    setEditError("");
+    setShowEdit(true);
+  };
+
+  const handleEditSave = async () => {
+    setEditError("");
+    if (!editSchedule || !editPrompt) {
+      setEditError("Schedule and prompt are required");
+      return;
+    }
+    try {
+      const secrets = editSecretsInput
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      await api.updateSchedule(editName, {
+        schedule: editSchedule,
+        prompt: editPrompt,
+        condition_code: editConditionCode || undefined,
+        requires_net: editRequiresNet,
+        secrets,
+      });
+      setShowEdit(false);
+      await refresh();
+    } catch (e) {
+      setEditError(e instanceof Error ? e.message : "Failed to update schedule");
+    }
+  };
+
+  const handleRunNow = async (s: Schedule) => {
+    setRunningName(s.name);
+    try {
+      await api.runScheduleNow(s.name);
+      await refresh();
+    } catch (e) {
+      console.error("Failed to run schedule:", e);
+    } finally {
+      setRunningName(null);
+    }
+  };
+
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between px-6 py-3">
@@ -237,6 +294,25 @@ export function SchedulesView() {
                         )}
                       </>
                     )}
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      title="Run now"
+                      disabled={runningName === s.name}
+                      onClick={() => handleRunNow(s)}
+                    >
+                      <Play className="h-3.5 w-3.5 text-green-500" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      title="Edit"
+                      onClick={() => handleEdit(s)}
+                    >
+                      <Pencil className="h-3.5 w-3.5 text-blue-500" />
+                    </Button>
                     <Button
                       variant="ghost"
                       size="icon"
@@ -345,6 +421,71 @@ export function SchedulesView() {
           <pre className="overflow-x-auto rounded-md bg-zinc-900 p-3 text-xs text-zinc-100">
             <code>{JSON.stringify(testResult, null, 2)}</code>
           </pre>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showEdit} onOpenChange={setShowEdit}>
+        <DialogContent className="max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Edit Schedule{editName ? `: ${editName}` : ""}</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-3">
+            {editError && <div className="text-sm text-red-500">{editError}</div>}
+            <div>
+              <label className="text-sm font-medium">Schedule expression</label>
+              <Input
+                value={editSchedule}
+                onChange={(e) => setEditSchedule(e.target.value)}
+                placeholder='e.g. "30m", "daily@9:00", "weekly@monday"'
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Prompt</label>
+              <Textarea
+                value={editPrompt}
+                onChange={(e) => setEditPrompt(e.target.value)}
+                placeholder="Instruction for the agent…"
+              />
+            </div>
+            <div className="border-t pt-3">
+              <div className="text-sm font-medium mb-1">
+                Condition script (optional)
+              </div>
+              <p className="text-xs text-muted-foreground mb-2">
+                TypeScript that runs on schedule before waking the agent. Call
+                <code className="mx-1 px-1 bg-muted rounded">output(&#123; wake: true &#125;)</code>
+                to wake, or
+                <code className="mx-1 px-1 bg-muted rounded">output(&#123; wake: false &#125;)</code>
+                to skip. Requires operator approval.
+              </p>
+              <Textarea
+                value={editConditionCode}
+                onChange={(e) => setEditConditionCode(e.target.value)}
+                placeholder="// Optional: TypeScript condition script"
+                className="font-mono text-xs"
+                rows={5}
+              />
+              <div className="flex items-center gap-4 mt-2">
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={editRequiresNet}
+                    onChange={(e) => setEditRequiresNet(e.target.checked)}
+                  />
+                  Requires network
+                </label>
+              </div>
+              <div className="mt-2">
+                <label className="text-sm font-medium">Secrets (comma-separated)</label>
+                <Input
+                  value={editSecretsInput}
+                  onChange={(e) => setEditSecretsInput(e.target.value)}
+                  placeholder="API_KEY, CALENDAR_URL"
+                />
+              </div>
+            </div>
+            <Button onClick={handleEditSave}>Save</Button>
+          </div>
         </DialogContent>
       </Dialog>
     </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -188,6 +188,26 @@ export const api = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
     }),
+  updateSchedule: (
+    name: string,
+    fields: {
+      schedule?: string;
+      prompt?: string;
+      condition_code?: string;
+      requires_net?: boolean;
+      secrets?: string[];
+    },
+  ) =>
+    fetchJSON<Schedule>(`${API_BASE}/schedules/${enc(name)}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(fields),
+    }),
+  runScheduleNow: (name: string) =>
+    fetchJSON<{ fired: boolean; name: string }>(
+      `${API_BASE}/schedules/${enc(name)}/run-now`,
+      { method: "POST" },
+    ),
   testTool: (name: string, params: Record<string, unknown> = {}) =>
     fetchJSON<Record<string, unknown>>(`${API_BASE}/tools/${enc(name)}/test`, {
       method: "POST",


### PR DESCRIPTION
## Changes

Two features for the schedules system:

### 1. Editable schedules
- PUT /schedules/{name} endpoint wraps the existing scheduler.update_task() with schedule-expression validation
- UpdateScheduleRequest schema
- Edit dialog in SchedulesView pre-populated with current values (schedule, prompt, condition code, requires_net, secrets)
- Name is immutable (it's the key)
- The existing approval-reset logic carries through: changing condition code, broadening net access, or adding secrets resets approval to pending

### 2. Run now
- Scheduler.run_now(name) fires a task immediately via the full _fire path — condition evaluation (if present and approved), agent wake, and last_run advancement. Ignores the enabled flag since it's an explicit operator trigger.
- POST /schedules/{name}/run-now fires in the background (fire-and-forget) since agent chat can take minutes. Results are delivered through normal notification channels.
- Play button in the schedule action row

### Known limitation
Clearing a condition code entirely via edit doesn't work — update_task treats None as "skip this field." Delete and recreate to remove a condition script.
