### PR TITLE
fix: exclude MCP tokens, server configs, and scheduler configs from memory migration

### DIFF
--- a/src/memory/migration.py
+++ b/src/memory/migration.py
@@ -1,8 +1,10 @@
 """One-time migration: agent_documents → memory_entries.
 
 Non-destructive — original rows are left in `agent_documents` as inert
-orphans. Only `customtool:*` entries are skipped (they stay in
-`agent_documents` for `CustomToolManager`).
+orphans. Entries with `customtool:`, `mcptoken:`, and `mcpserver:`
+prefixes are skipped: `customtool:*` are managed by `CustomToolManager`,
+and `mcptoken:*` / `mcpserver:*` hold MCP OAuth tokens and server
+configs that must never surface in the searchable memory store.
 """
 
 import json
@@ -49,8 +51,10 @@ async def migrate_documents_to_memory(
 
     migrated = 0
     for rkey, content in docs:
-        # Skip custom tool entries — they stay in agent_documents
+        # Skip entries that belong to other subsystems
         if rkey.startswith("customtool:"):
+            continue
+        if rkey.startswith("mcptoken:") or rkey.startswith("mcpserver:"):
             continue
 
         # Skip already-migrated rkeys (prevents re-importing stale content

--- a/src/memory/migration.py
+++ b/src/memory/migration.py
@@ -1,10 +1,11 @@
 """One-time migration: agent_documents → memory_entries.
 
 Non-destructive — original rows are left in `agent_documents` as inert
-orphans. Entries with `customtool:`, `mcptoken:`, and `mcpserver:`
-prefixes are skipped: `customtool:*` are managed by `CustomToolManager`,
-and `mcptoken:*` / `mcpserver:*` hold MCP OAuth tokens and server
-configs that must never surface in the searchable memory store.
+orphans. Entries with `customtool:`, `mcptoken:`, `mcpserver:`,
+and `schedule:` prefixes are skipped: `customtool:*` are managed by
+`CustomToolManager`, `mcptoken:*` / `mcpserver:*` hold MCP OAuth tokens
+and server configs, and `schedule:*` holds scheduler task configs — all
+must never surface in the searchable memory store.
 """
 
 import json
@@ -55,6 +56,8 @@ async def migrate_documents_to_memory(
         if rkey.startswith("customtool:"):
             continue
         if rkey.startswith("mcptoken:") or rkey.startswith("mcpserver:"):
+            continue
+        if rkey.startswith("schedule:"):
             continue
 
         # Skip already-migrated rkeys (prevents re-importing stale content

--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -300,7 +300,7 @@ class MCPOAuthTokenStorage:
 
     Implements the MCP SDK's TokenStorage protocol so it can be passed
     to OAuthClientProvider. Tokens are stored as JSON documents with
-    the rkey prefix 'mcpoauth:'.
+    the rkey prefix 'mcptoken:'.
     """
 
     def __init__(self, store: Store, server_name: str) -> None:

--- a/tests/test_migration_skip.py
+++ b/tests/test_migration_skip.py
@@ -81,12 +81,29 @@ async def test_customtool_still_skipped(store):
 
 
 @pytest.mark.asyncio
+async def test_schedule_not_migrated(store):
+    """schedule: docs must not appear in memory_entries."""
+    await _seed_docs(store, {
+        "schedule:daily-check": '{"prompt": "check stuff", "secrets": ["API_KEY"]}',
+        "operator": "Operator is Hailey.",
+    })
+
+    migrated = await migrate_documents_to_memory(store, embedding_client=None)
+    assert migrated == 1
+
+    scopes = await _entry_scopes(store)
+    assert "schedule:daily-check" not in scopes
+    assert "operator" in scopes
+
+
+@pytest.mark.asyncio
 async def test_normal_docs_still_migrated(store):
     """Normal docs (skill, task, free-form) still migrate alongside skipped ones."""
     await _seed_docs(store, {
         "mcptoken:fastmail": '{"access_token": "secret"}',
         "mcpserver:github": '{"transport": "stdio"}',
         "customtool:mytool": '{"definition": "stuff"}',
+        "schedule:daily-check": '{"prompt": "check stuff"}',
         "skill:deploy": "How to deploy the app.",
         "operator": "Operator is Hailey.",
         "self": "I am the agent.",
@@ -99,6 +116,7 @@ async def test_normal_docs_still_migrated(store):
     assert "mcptoken:fastmail" not in scopes
     assert "mcpserver:github" not in scopes
     assert "customtool:mytool" not in scopes
+    assert "schedule:daily-check" not in scopes
     assert "skill:deploy" in scopes
     assert "operator" in scopes
     assert "self" in scopes

--- a/tests/test_migration_skip.py
+++ b/tests/test_migration_skip.py
@@ -1,0 +1,104 @@
+"""Tests for the agent_documents → memory_entries migration skip list.
+
+MCP OAuth tokens (``mcptoken:*``) and MCP server configs (``mcpserver:*``)
+must never be migrated into ``memory_entries`` — doing so exposes them to
+the agent via ``memory.search`` and RAG recall.
+"""
+
+import pytest
+
+from src.memory.migration import migrate_documents_to_memory
+
+
+@pytest.fixture
+async def store(tmp_path):
+    from src.store.store import Store
+
+    s = Store(path=tmp_path / "test.db")
+    await s.initialize()
+    yield s
+    await s.close()
+
+
+async def _seed_docs(store, entries: dict[str, str]) -> None:
+    """Insert rkey→content pairs into agent_documents."""
+    for rkey, content in entries.items():
+        await store.documents.create(rkey, content)
+
+
+async def _entry_scopes(store) -> set[str]:
+    """Return the set of all scopes currently in memory_entries."""
+    result = await store.memory.list_entries(limit=500)
+    return {e["scope"] for e in result["entries"]}
+
+
+@pytest.mark.asyncio
+async def test_mcptoken_not_migrated(store):
+    """mcptoken: docs must not appear in memory_entries."""
+    await _seed_docs(store, {
+        "mcptoken:fastmail": '{"access_token": "secret-abc", "refresh_token": "refresh-xyz"}',
+        "operator": "Operator is Hailey.",
+    })
+
+    migrated = await migrate_documents_to_memory(store, embedding_client=None)
+    assert migrated == 1  # only 'operator' migrated
+
+    scopes = await _entry_scopes(store)
+    assert "mcptoken:fastmail" not in scopes
+    assert "operator" in scopes
+
+
+@pytest.mark.asyncio
+async def test_mcpserver_not_migrated(store):
+    """mcpserver: docs must not appear in memory_entries."""
+    await _seed_docs(store, {
+        "mcpserver:github": '{"transport": "stdio", "command": "npx"}',
+        "operator": "Operator is Hailey.",
+    })
+
+    migrated = await migrate_documents_to_memory(store, embedding_client=None)
+    assert migrated == 1
+
+    scopes = await _entry_scopes(store)
+    assert "mcpserver:github" not in scopes
+    assert "operator" in scopes
+
+
+@pytest.mark.asyncio
+async def test_customtool_still_skipped(store):
+    """customtool: docs are still skipped (pre-existing behavior)."""
+    await _seed_docs(store, {
+        "customtool:mytool": '{"definition": "stuff"}',
+        "operator": "Operator is Hailey.",
+    })
+
+    migrated = await migrate_documents_to_memory(store, embedding_client=None)
+    assert migrated == 1
+
+    scopes = await _entry_scopes(store)
+    assert "customtool:mytool" not in scopes
+    assert "operator" in scopes
+
+
+@pytest.mark.asyncio
+async def test_normal_docs_still_migrated(store):
+    """Normal docs (skill, task, free-form) still migrate alongside skipped ones."""
+    await _seed_docs(store, {
+        "mcptoken:fastmail": '{"access_token": "secret"}',
+        "mcpserver:github": '{"transport": "stdio"}',
+        "customtool:mytool": '{"definition": "stuff"}',
+        "skill:deploy": "How to deploy the app.",
+        "operator": "Operator is Hailey.",
+        "self": "I am the agent.",
+    })
+
+    migrated = await migrate_documents_to_memory(store, embedding_client=None)
+    assert migrated == 3  # skill:deploy, operator, self
+
+    scopes = await _entry_scopes(store)
+    assert "mcptoken:fastmail" not in scopes
+    assert "mcpserver:github" not in scopes
+    assert "customtool:mytool" not in scopes
+    assert "skill:deploy" in scopes
+    assert "operator" in scopes
+    assert "self" in scopes


### PR DESCRIPTION
## Problem

The `agent_documents → memory_entries` migration (`migrate_documents_to_memory` in `src/memory/migration.py`) runs at every startup. It copies documents from the flat key-value store into the searchable memory store. Previously only `customtool:` was skipped.

MCP OAuth tokens (`mcptoken:*`), MCP server configs (`mcpserver:*`), and scheduler task configs (`schedule:*`) fell through `_classify_document` and were inserted into `memory_entries` as `factual` entries. Once there they were:

- **Visible** in the web memory viewer (`/memory` reads `memory_entries`)
- **Searchable** by the agent via `memory.search` (FTS5 + vector search)
- **Auto-injectable** into the agent context via RAG recall (per-turn semantic search)

This exposed OAuth tokens, server transport configs, and scheduler prompts/condition code/secret names to the agent.

## Fix

- Added `mcptoken:`, `mcpserver:`, and `schedule:` to the migration skip list alongside the existing `customtool:` skip
- Fixed stale docstring in `MCPOAuthTokenStorage` (said `mcpoauth:`, actual prefix is `mcptoken:`)
- Added 5 regression tests verifying each prefix is skipped and normal docs still migrate

## Out of scope

Cleanup of entries already leaked into `memory_entries` by prior migrations is handled separately.

## Review

Two-reviewer code review (standard + adversarial, gpt-5.5 high) ran for two cycles. Cycle 1 found the `schedule:` prefix leak, which was fixed. Cycle 2 returned clean — no blockers or high findings. Both reviewers recommended a follow-up to switch from a denylist to an allowlist approach, tracked separately.