### PR TITLE
Add MCP connection resilience: health monitor, auto-reconnect, SSE timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,11 @@ WEB_ALLOWED_HOSTS=
 # Character limit before the conversation is auto-compacted (~4 chars/token).
 # Default: 240000 (~60k tokens).
 # COMPACT_THRESHOLD_CHARS=240000
+
+# MCP connections (optional)
+# Seconds between background health-check pings to MCP servers. 0 disables.
+# Default: 120 (2 minutes)
+# MCP_HEALTH_CHECK_INTERVAL_SECONDS=120
+# SSE read timeout for streamable_http transports, in seconds.
+# Default: 1800 (30 minutes)
+# MCP_SSE_READ_TIMEOUT_SECONDS=1800

--- a/src/config.py
+++ b/src/config.py
@@ -77,6 +77,13 @@ class Config(BaseSettings):
     embedding_dimensions: int = 768
     """dimensionality of the embedding model"""
 
+    # mcp
+    mcp_health_check_interval_seconds: int = 120
+    """seconds between background MCP connection health checks (0 disables)"""
+
+    mcp_sse_read_timeout_seconds: int = 1800
+    """SSE read timeout for streamable_http transports, in seconds"""
+
     # web ui
     web_host: str = "127.0.0.1"
     """host interface the web ui binds to. set to 0.0.0.0 to expose on the LAN."""

--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -534,10 +534,19 @@ class MCPManager:
         """Disconnect and reconnect a server under its lock.
         Uses auto=True (short OAuth callback timeout). Returns True on success.
 
-        The entire disconnect+connect sequence is bounded by _RECONNECT_TIMEOUT
-        so a hanging stack-close or hung OAuth round-trip can't stall the caller.
+        The entire disconnect+connect sequence is bounded by _RECONNECT_TIMEOUT.
+        On timeout, the connection is popped from _connections without awaiting
+        cleanup — the cancelled task's cleanup runs independently and the stale
+        connection is left for GC.
         """
         async with self._get_lock(name):
+            # Guard: a manual disconnect or delete may have already removed
+            # the connection between the health check failure and here.
+            if name not in self._connections:
+                return False
+            config = self._servers.get(name)
+            if config is None or not config.enabled:
+                return False
             try:
                 await asyncio.wait_for(
                     self._reconnect_server_impl(name),
@@ -546,8 +555,12 @@ class MCPManager:
                 return True
             except asyncio.TimeoutError:
                 logger.warning("Auto-reconnect timed out for '%s'", name)
-                if name in self._connections:
-                    await self._disconnect_server_impl(name)
+                # Pop without awaiting cleanup — the wait_for cancellation may
+                # still be in progress and awaiting disconnect again could hang.
+                conn = self._connections.pop(name, None)
+                if conn:
+                    conn._session = None
+                    conn._stack = None
                 return False
             except Exception as e:
                 logger.warning("Auto-reconnect failed for '%s': %s", name, e)
@@ -556,9 +569,17 @@ class MCPManager:
                 return False
 
     async def _reconnect_server_impl(self, name: str) -> None:
-        """Disconnect and reconnect. Caller must hold the per-server lock."""
-        if name in self._connections:
-            await self._disconnect_server_impl(name)
+        """Disconnect and reconnect. Caller must hold the per-server lock.
+
+        The disconnect is done by popping the connection and nulling its
+        session/stack without awaiting conn.disconnect() — this prevents a
+        hung transport close from blocking the reconnect. The stale
+        connection is left for GC.
+        """
+        conn = self._connections.pop(name, None)
+        if conn:
+            conn._session = None
+            conn._stack = None
         await self._connect_server_impl(name, auto=True)
 
     async def connect_all(self) -> None:
@@ -757,8 +778,13 @@ class MCPManager:
                         timeout=_RECONNECT_TIMEOUT,
                     )
                 except asyncio.TimeoutError:
-                    if server_name in self._connections:
-                        await self._disconnect_server_impl(server_name)
+                    # Pop without awaiting cleanup — the wait_for cancellation
+                    # may still be in progress and awaiting disconnect again
+                    # could hang on a dead transport.
+                    conn = self._connections.pop(server_name, None)
+                    if conn:
+                        conn._session = None
+                        conn._stack = None
                     return {"error": f"MCP tool call failed: {e}. Auto-reconnect timed out."}
                 except Exception as reconnect_err:
                     if server_name in self._connections:

--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -483,8 +483,29 @@ class MCPManager:
         except BaseException:
             # Clean up the connection if discovery or registration failed
             # so we don't leave a live session with no tools registered.
-            await self._disconnect_server_impl(name)
+            # Use detached cleanup so a hung transport close can't block
+            # the caller (same pattern as auto-reconnect).
+            self._cleanup_connection(name)
             raise
+
+    def _cleanup_connection(self, name: str) -> None:
+        """Unregister tools, pop connection, and schedule background cleanup.
+
+        Synchronous tool unregistration + non-blocking transport close.
+        Caller must hold the per-server lock (or be in a context where no
+        other task can touch this server).
+        """
+        config = self._servers.get(name)
+        if config:
+            for tool in config.tools:
+                if tool.approved:
+                    self._registry.unregister(
+                        f"{name}.{self._sanitize_tool_name(tool.name)}"
+                    )
+        conn = self._connections.pop(name, None)
+        if conn:
+            conn._session = None
+            asyncio.create_task(_detached_disconnect(conn))
 
     async def disconnect_server(self, name: str) -> None:
         """Disconnect a server and unregister its tools."""

--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import AnyUrl
 
+from src.config import CONFIG
 from src.tools.registry import Tool, ToolParameter
 
 if TYPE_CHECKING:
@@ -60,6 +61,10 @@ _CONNECT_TIMEOUT = 30.0
 
 # Bounded timeout for individual tool calls and list_tools
 _CALL_TIMEOUT = 60.0
+
+# Bounded timeout for auto-reconnection (disconnect + reconnect).
+# Bounds the full OAuth flow (client registration, token exchange, callback).
+_RECONNECT_TIMEOUT = 20.0
 
 
 @dataclass
@@ -197,6 +202,7 @@ class MCPConnection:
                         headers=headers or None,
                         auth=auth,
                         timeout=30.0,
+                        sse_read_timeout=float(CONFIG.mcp_sse_read_timeout_seconds),
                     )
                 )
                 # streamablehttp_client returns (read, write, get_session_id)
@@ -255,6 +261,13 @@ class MCPConnection:
             self._session.list_tools(), timeout=_CALL_TIMEOUT
         )
         return result.tools
+
+    async def send_ping(self) -> None:
+        """Send a health-check ping. Raises if the connection is dead."""
+        session = self._session
+        if session is None:
+            raise RuntimeError("Not connected")
+        await asyncio.wait_for(session.send_ping(), timeout=15.0)
 
     async def call_tool(self, name: str, params: dict[str, Any]) -> Any:
         """Call a tool on the MCP server and convert the result."""
@@ -356,6 +369,7 @@ class MCPManager:
         self._servers: dict[str, MCPServerConfig] = {}
         self._connections: dict[str, MCPConnection] = {}
         self._locks: dict[str, asyncio.Lock] = {}
+        self._health_task: asyncio.Task | None = None
 
     def _get_lock(self, name: str) -> asyncio.Lock:
         """Get or create a per-server lock for serializing operations."""
@@ -403,8 +417,9 @@ class MCPManager:
         """Connect to a server, discover tools, and register approved tools."""
         async with self._get_lock(name):
             await self._connect_server_impl(name)
+        self.start_health_monitor(float(CONFIG.mcp_health_check_interval_seconds))
 
-    async def _connect_server_impl(self, name: str) -> None:
+    async def _connect_server_impl(self, name: str, *, auto: bool = False) -> None:
         config = self._servers.get(name)
         if config is None:
             raise ValueError(f"MCP server '{name}' not found")
@@ -416,7 +431,10 @@ class MCPManager:
         # build OAuth provider if needed
         oauth_provider = None
         if config.auth_type == "oauth" and config.url:
-            oauth_provider = self._create_oauth_provider(name, config.url)
+            callback_timeout = 5.0 if auto else 300.0
+            oauth_provider = self._create_oauth_provider(
+                name, config.url, callback_timeout=callback_timeout
+            )
 
         conn = MCPConnection(config, self._secret_manager, oauth_provider=oauth_provider)
         await conn.connect()
@@ -453,6 +471,84 @@ class MCPManager:
         if conn:
             await conn.disconnect()
 
+    def start_health_monitor(self, interval: float) -> None:
+        """Start the background health check loop. Safe to call if already running."""
+        if self._health_task is not None and not self._health_task.done():
+            return
+        if interval <= 0:
+            return
+        self._health_task = asyncio.create_task(self._health_check_loop(interval))
+
+    async def stop_health_monitor(self) -> None:
+        """Cancel the health check loop and await its completion."""
+        if self._health_task is not None:
+            self._health_task.cancel()
+            try:
+                await self._health_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.warning("Health monitor task raised on cancel", exc_info=True)
+        self._health_task = None
+
+    async def _health_check_loop(self, interval: float) -> None:
+        """Periodically ping each connected server and reconnect dead ones."""
+        while True:
+            await asyncio.sleep(interval)
+            # Top-level guard: a single iteration failure must not kill the loop.
+            try:
+                for name in list(self._connections.keys()):
+                    try:
+                        await asyncio.wait_for(
+                            self._health_check_server(name), timeout=20.0
+                        )
+                    except Exception as e:
+                        logger.warning("MCP health check failed for '%s': %s", name, e)
+                        await self._reconnect_server(name)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning("Unexpected error in health check loop", exc_info=True)
+
+    async def _health_check_server(self, name: str) -> None:
+        """Ping a single server to verify the connection is alive.
+
+        Holds the per-server lock so the ping is serialized against
+        disconnect/reconnect from call_tool or disconnect_all.
+        """
+        async with self._get_lock(name):
+            conn = self._connections.get(name)
+            if conn is None or not conn.is_connected:
+                return
+            await conn.send_ping()
+
+    async def _reconnect_server(self, name: str) -> bool:
+        """Disconnect and reconnect a server under its lock.
+        Uses auto=True (short OAuth callback timeout). Returns True on success.
+
+        Both the disconnect and the connect are bounded by an outer timeout so a
+        hanging stack-close or hung OAuth round-trip can't stall the health monitor.
+        The 5s callback_timeout alone does NOT bound the entire flow, since the SDK
+        issues additional HTTP requests before/after the callback.
+        """
+        async with self._get_lock(name):
+            if name in self._connections:
+                await self._disconnect_server_impl(name)
+            try:
+                await asyncio.wait_for(
+                    self._connect_server_impl(name, auto=True),
+                    timeout=_RECONNECT_TIMEOUT,
+                )
+                return True
+            except asyncio.TimeoutError:
+                logger.warning("Auto-reconnect timed out for '%s'", name)
+                if name in self._connections:
+                    await self._disconnect_server_impl(name)
+                return False
+            except Exception as e:
+                logger.warning("Auto-reconnect failed for '%s': %s", name, e)
+                return False
+
     async def connect_all(self) -> None:
         """Connect to all enabled servers. Non-fatal on failure."""
         for name, config in list(self._servers.items()):
@@ -473,9 +569,11 @@ class MCPManager:
                 logger.warning(
                     "Failed to connect to MCP server '%s': %s", name, e
                 )
+        self.start_health_monitor(float(CONFIG.mcp_health_check_interval_seconds))
 
     async def disconnect_all(self) -> None:
         """Disconnect all connected servers."""
+        await self.stop_health_monitor()
         for name in list(self._connections.keys()):
             await self.disconnect_server(name)
 
@@ -632,7 +730,38 @@ class MCPManager:
             return await conn.call_tool(tool_name, params)
         except Exception as e:
             logger.warning("MCP tool call failed: %s.%s: %s", server_name, tool_name, e)
-            return {"error": f"MCP tool call failed: {e}"}
+            # Attempt one reconnection + retry under the per-server lock.
+            # The full connect (including OAuth round-trips) is bounded by a 20s
+            # timeout so the agent isn't blocked indefinitely on a hung server.
+            async with self._get_lock(server_name):
+                # Health monitor may have already reconnected — check first
+                conn = self._connections.get(server_name)
+                if conn is not None and conn.is_connected:
+                    try:
+                        return await conn.call_tool(tool_name, params)
+                    except Exception:
+                        pass  # still failing, proceed to full reconnect
+                # Full disconnect + reconnect (bounded)
+                if server_name in self._connections:
+                    await self._disconnect_server_impl(server_name)
+                try:
+                    await asyncio.wait_for(
+                        self._connect_server_impl(server_name, auto=True),
+                        timeout=_RECONNECT_TIMEOUT,
+                    )
+                except asyncio.TimeoutError:
+                    if server_name in self._connections:
+                        await self._disconnect_server_impl(server_name)
+                    return {"error": f"MCP tool call failed: {e}. Auto-reconnect timed out."}
+                except Exception as reconnect_err:
+                    return {"error": f"MCP tool call failed: {e}. Reconnect failed: {reconnect_err}"}
+                conn = self._connections.get(server_name)
+                if conn is None or not conn.is_connected:
+                    return {"error": f"MCP tool call failed: {e}. Reconnect produced no active connection."}
+                try:
+                    return await conn.call_tool(tool_name, params)
+                except Exception as retry_err:
+                    return {"error": f"MCP tool call failed: {e}. Reconnected but retry also failed: {retry_err}"}
 
     # -- server CRUD --
 
@@ -822,7 +951,9 @@ class MCPManager:
 
     # -- internals --
 
-    def _create_oauth_provider(self, server_name: str, server_url: str) -> Any:
+    def _create_oauth_provider(
+        self, server_name: str, server_url: str, *, callback_timeout: float = 300.0
+    ) -> Any:
         """Create an OAuthClientProvider for a server.
 
         Uses a paste-back flow instead of a local callback server so it works
@@ -868,11 +999,13 @@ class MCPManager:
             logger.info("Waiting for OAuth callback paste for '%s'...", server_name)
 
             try:
-                # Wait up to 5 minutes for the operator to complete the flow
-                callback_url = await asyncio.wait_for(future, timeout=300.0)
+                # Wait up to callback_timeout for the operator to complete the flow
+                callback_url = await asyncio.wait_for(future, timeout=callback_timeout)
             except asyncio.TimeoutError:
                 self._oauth_state[server_name]["pending_callback"] = None
-                raise RuntimeError("OAuth callback timed out — no response within 5 minutes")
+                raise RuntimeError(
+                    f"OAuth callback timed out — no response within {callback_timeout}s"
+                )
 
             self._oauth_state[server_name]["pending_callback"] = None
 

--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -513,30 +513,34 @@ class MCPManager:
     async def _health_check_server(self, name: str) -> None:
         """Ping a single server to verify the connection is alive.
 
-        Holds the per-server lock so the ping is serialized against
-        disconnect/reconnect from call_tool or disconnect_all.
+        Uses a short try-acquire on the per-server lock so a long-running
+        tool call doesn't block the health check — it just skips this iteration.
         """
-        async with self._get_lock(name):
+        lock = self._get_lock(name)
+        try:
+            await asyncio.wait_for(lock.acquire(), timeout=1.0)
+        except asyncio.TimeoutError:
+            logger.debug("Skipping health check for '%s' — lock held by active call", name)
+            return
+        try:
             conn = self._connections.get(name)
             if conn is None or not conn.is_connected:
                 return
             await conn.send_ping()
+        finally:
+            lock.release()
 
     async def _reconnect_server(self, name: str) -> bool:
         """Disconnect and reconnect a server under its lock.
         Uses auto=True (short OAuth callback timeout). Returns True on success.
 
-        Both the disconnect and the connect are bounded by an outer timeout so a
-        hanging stack-close or hung OAuth round-trip can't stall the health monitor.
-        The 5s callback_timeout alone does NOT bound the entire flow, since the SDK
-        issues additional HTTP requests before/after the callback.
+        The entire disconnect+connect sequence is bounded by _RECONNECT_TIMEOUT
+        so a hanging stack-close or hung OAuth round-trip can't stall the caller.
         """
         async with self._get_lock(name):
-            if name in self._connections:
-                await self._disconnect_server_impl(name)
             try:
                 await asyncio.wait_for(
-                    self._connect_server_impl(name, auto=True),
+                    self._reconnect_server_impl(name),
                     timeout=_RECONNECT_TIMEOUT,
                 )
                 return True
@@ -547,7 +551,15 @@ class MCPManager:
                 return False
             except Exception as e:
                 logger.warning("Auto-reconnect failed for '%s': %s", name, e)
+                if name in self._connections:
+                    await self._disconnect_server_impl(name)
                 return False
+
+    async def _reconnect_server_impl(self, name: str) -> None:
+        """Disconnect and reconnect. Caller must hold the per-server lock."""
+        if name in self._connections:
+            await self._disconnect_server_impl(name)
+        await self._connect_server_impl(name, auto=True)
 
     async def connect_all(self) -> None:
         """Connect to all enabled servers. Non-fatal on failure."""
@@ -719,34 +731,29 @@ class MCPManager:
     async def call_tool(
         self, server_name: str, tool_name: str, params: dict[str, Any]
     ) -> Any:
-        """Proxy a tool call to the MCP server."""
-        conn = self._connections.get(server_name)
-        if conn is None or not conn.is_connected:
-            return {
-                "error": f"MCP server '{server_name}' is not connected. "
-                "The operator can reconnect it via the web UI."
-            }
-        try:
-            return await conn.call_tool(tool_name, params)
-        except Exception as e:
-            logger.warning("MCP tool call failed: %s.%s: %s", server_name, tool_name, e)
-            # Attempt one reconnection + retry under the per-server lock.
-            # The full connect (including OAuth round-trips) is bounded by a 20s
-            # timeout so the agent isn't blocked indefinitely on a hung server.
-            async with self._get_lock(server_name):
-                # Health monitor may have already reconnected — check first
-                conn = self._connections.get(server_name)
-                if conn is not None and conn.is_connected:
-                    try:
-                        return await conn.call_tool(tool_name, params)
-                    except Exception:
-                        pass  # still failing, proceed to full reconnect
-                # Full disconnect + reconnect (bounded)
-                if server_name in self._connections:
-                    await self._disconnect_server_impl(server_name)
+        """Proxy a tool call to the MCP server.
+
+        Holds the per-server lock for the entire call so the health monitor
+        can't tear down the session mid-call. If the call fails, attempts one
+        bounded reconnection and retries.
+        """
+        async with self._get_lock(server_name):
+            conn = self._connections.get(server_name)
+            if conn is None or not conn.is_connected:
+                return {
+                    "error": f"MCP server '{server_name}' is not connected. "
+                    "The operator can reconnect it via the web UI."
+                }
+            try:
+                return await conn.call_tool(tool_name, params)
+            except Exception as e:
+                logger.warning("MCP tool call failed: %s.%s: %s", server_name, tool_name, e)
+                # Attempt one bounded reconnection + retry. The full disconnect
+                # + connect (including OAuth round-trips) is bounded by
+                # _RECONNECT_TIMEOUT so the agent isn't blocked indefinitely.
                 try:
                     await asyncio.wait_for(
-                        self._connect_server_impl(server_name, auto=True),
+                        self._reconnect_server_impl(server_name),
                         timeout=_RECONNECT_TIMEOUT,
                     )
                 except asyncio.TimeoutError:
@@ -754,6 +761,8 @@ class MCPManager:
                         await self._disconnect_server_impl(server_name)
                     return {"error": f"MCP tool call failed: {e}. Auto-reconnect timed out."}
                 except Exception as reconnect_err:
+                    if server_name in self._connections:
+                        await self._disconnect_server_impl(server_name)
                     return {"error": f"MCP tool call failed: {e}. Reconnect failed: {reconnect_err}"}
                 conn = self._connections.get(server_name)
                 if conn is None or not conn.is_connected:

--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -257,7 +257,22 @@ class MCPConnection:
         except BaseException:
             # Clean up the exit stack if any step failed — otherwise
             # transports/subprocesses entered into the stack would leak.
-            await self.disconnect()
+            # Bound the cleanup so a hung transport close can't block the
+            # caller indefinitely (e.g. during wait_for cancellation in
+            # auto-reconnect). If the transport's aclose() is truly
+            # cancellation-resistant, the wait_for itself may delay — this
+            # is an asyncio limitation. The session/stack are nulled
+            # regardless so the connection is marked dead.
+            try:
+                await asyncio.wait_for(
+                    self.disconnect(), timeout=_DETACHED_DISCONNECT_TIMEOUT
+                )
+            except asyncio.TimeoutError:
+                logger.warning("disconnect() timed out during connect cleanup — abandoning transport")
+                self._session = None
+                self._stack = None
+            except Exception:
+                logger.warning("Error during connect cleanup disconnect", exc_info=True)
             raise
 
     async def disconnect(self) -> None:

--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -66,6 +66,23 @@ _CALL_TIMEOUT = 60.0
 # Bounds the full OAuth flow (client registration, token exchange, callback).
 _RECONNECT_TIMEOUT = 20.0
 
+# Best-effort timeout for closing an old transport during reconnect.
+# If cleanup doesn't finish in this time, the background task is abandoned.
+_DETACHED_DISCONNECT_TIMEOUT = 10.0
+
+
+async def _detached_disconnect(conn: "MCPConnection") -> None:
+    """Close a connection in the background with a best-effort timeout.
+
+    Prevents a hung transport close (cancellation-resistant aclose) from
+    blocking the caller. If the close doesn't finish in time, the task
+    is abandoned — the stale connection leaks but the caller proceeds.
+    """
+    try:
+        await asyncio.wait_for(conn.disconnect(), timeout=_DETACHED_DISCONNECT_TIMEOUT)
+    except Exception:
+        logger.warning("Detached disconnect failed (abandoned)", exc_info=True)
+
 
 @dataclass
 class MCPTool:
@@ -555,12 +572,12 @@ class MCPManager:
                 return True
             except asyncio.TimeoutError:
                 logger.warning("Auto-reconnect timed out for '%s'", name)
-                # Pop without awaiting cleanup — the wait_for cancellation may
-                # still be in progress and awaiting disconnect again could hang.
+                # Pop and schedule background cleanup. The wait_for cancellation
+                # may still be in progress; don't await disconnect synchronously.
                 conn = self._connections.pop(name, None)
                 if conn:
                     conn._session = None
-                    conn._stack = None
+                    asyncio.create_task(_detached_disconnect(conn))
                 return False
             except Exception as e:
                 logger.warning("Auto-reconnect failed for '%s': %s", name, e)
@@ -571,15 +588,15 @@ class MCPManager:
     async def _reconnect_server_impl(self, name: str) -> None:
         """Disconnect and reconnect. Caller must hold the per-server lock.
 
-        The disconnect is done by popping the connection and nulling its
-        session/stack without awaiting conn.disconnect() — this prevents a
-        hung transport close from blocking the reconnect. The stale
-        connection is left for GC.
+        The old connection is popped immediately and its cleanup is scheduled
+        as a background task with a best-effort timeout. This prevents a hung
+        transport close from blocking the reconnect while still attempting
+        proper resource cleanup.
         """
         conn = self._connections.pop(name, None)
         if conn:
             conn._session = None
-            conn._stack = None
+            asyncio.create_task(_detached_disconnect(conn))
         await self._connect_server_impl(name, auto=True)
 
     async def connect_all(self) -> None:
@@ -778,13 +795,13 @@ class MCPManager:
                         timeout=_RECONNECT_TIMEOUT,
                     )
                 except asyncio.TimeoutError:
-                    # Pop without awaiting cleanup — the wait_for cancellation
-                    # may still be in progress and awaiting disconnect again
-                    # could hang on a dead transport.
+                    # Pop and schedule background cleanup. The wait_for
+                    # cancellation may still be in progress; don't await
+                    # disconnect synchronously.
                     conn = self._connections.pop(server_name, None)
                     if conn:
                         conn._session = None
-                        conn._stack = None
+                        asyncio.create_task(_detached_disconnect(conn))
                     return {"error": f"MCP tool call failed: {e}. Auto-reconnect timed out."}
                 except Exception as reconnect_err:
                     if server_name in self._connections:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1166,8 +1166,9 @@ async def test_health_check_reconnects_dead_connection(tmp_path):
     assert result is True
     assert "srv" in manager._connections
     assert manager._connections["srv"] is healthy_conn
-    # dead_conn should have been disconnected
-    dead_conn.disconnect.assert_awaited()
+    # dead_conn should have been popped (non-blocking disconnect — no await)
+    assert dead_conn._session is None
+    assert dead_conn._stack is None
 
     await manager.stop_health_monitor()
     await manager.disconnect_server("srv")
@@ -1517,13 +1518,17 @@ async def test_call_tool_auto_reconnect_does_not_block(tmp_path):
     config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
     await manager.create_server(config)
 
-    # First connection: disconnect hangs forever, call_tool fails
+    # First connection: disconnect hangs and resists cancellation, call_tool fails
     mock_conn = MagicMock()
     mock_conn.is_connected = True
     mock_conn.connect = AsyncMock()
 
     async def hang_disconnect():
-        await asyncio.sleep(9999)
+        try:
+            await asyncio.sleep(9999)
+        except asyncio.CancelledError:
+            # Simulate a transport that doesn't respond to cancellation
+            await asyncio.sleep(9999)
 
     mock_conn.disconnect = AsyncMock(side_effect=hang_disconnect)
     mock_conn.list_tools = AsyncMock(return_value=[])

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1091,3 +1091,562 @@ async def test_web_oauth_deauthorize(tmp_path):
     status = await manager.get_oauth_status_async("fastmail")
     assert status == "not_authorized"
     await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Resilience tests: health monitor, auto-reconnect, sse_read_timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_ping_succeeds_on_healthy_connection(tmp_path):
+    """send_ping on a healthy connection completes without error."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+
+    mock_conn = MagicMock()
+    mock_conn.is_connected = True
+    mock_conn.connect = AsyncMock()
+    mock_conn.disconnect = AsyncMock()
+    mock_conn.send_ping = AsyncMock()
+    mock_conn.list_tools = AsyncMock(return_value=[])
+
+    with patch("src.tools.mcp.MCPConnection", return_value=mock_conn):
+        await manager.connect_server("srv")
+
+    # Directly invoke the connection's send_ping — should not raise
+    await mock_conn.send_ping()
+    mock_conn.send_ping.assert_called()
+
+    await manager.stop_health_monitor()
+    await manager.disconnect_server("srv")
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_health_check_reconnects_dead_connection(tmp_path):
+    """When send_ping raises, the health check disconnects and reconnects."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+
+    # First connection: ping raises
+    dead_conn = MagicMock()
+    dead_conn.is_connected = True
+    dead_conn.connect = AsyncMock()
+    dead_conn.disconnect = AsyncMock()
+    dead_conn.send_ping = AsyncMock(side_effect=RuntimeError("connection dead"))
+    dead_conn.list_tools = AsyncMock(return_value=[])
+
+    # Second connection (after reconnect): ping succeeds
+    healthy_conn = MagicMock()
+    healthy_conn.is_connected = True
+    healthy_conn.connect = AsyncMock()
+    healthy_conn.disconnect = AsyncMock()
+    healthy_conn.send_ping = AsyncMock()
+    healthy_conn.list_tools = AsyncMock(return_value=[])
+
+    call_count = 0
+
+    def conn_factory(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return dead_conn if call_count == 1 else healthy_conn
+
+    with patch("src.tools.mcp.MCPConnection", side_effect=conn_factory):
+        await manager.connect_server("srv")
+        # Simulate a health check failure + reconnect
+        result = await manager._reconnect_server("srv")
+
+    assert result is True
+    assert "srv" in manager._connections
+    assert manager._connections["srv"] is healthy_conn
+    # dead_conn should have been disconnected
+    dead_conn.disconnect.assert_awaited()
+
+    await manager.stop_health_monitor()
+    await manager.disconnect_server("srv")
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_auto_reconnects_on_failure(tmp_path):
+    """call_tool reconnects and retries when the first call fails."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+
+    # First connection: call_tool raises once
+    fail_conn = MagicMock()
+    fail_conn.is_connected = True
+    fail_conn.connect = AsyncMock()
+    fail_conn.disconnect = AsyncMock()
+    fail_conn.list_tools = AsyncMock(return_value=[])
+    fail_conn.call_tool = AsyncMock(side_effect=RuntimeError("transport dead"))
+
+    # Second connection (after reconnect): call_tool succeeds
+    good_conn = MagicMock()
+    good_conn.is_connected = True
+    good_conn.connect = AsyncMock()
+    good_conn.disconnect = AsyncMock()
+    good_conn.list_tools = AsyncMock(return_value=[])
+    good_conn.call_tool = AsyncMock(return_value="result")
+
+    call_count = 0
+
+    def conn_factory(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return fail_conn if call_count == 1 else good_conn
+
+    with patch("src.tools.mcp.MCPConnection", side_effect=conn_factory):
+        await manager.connect_server("srv")
+        result = await manager.call_tool("srv", "search", {"q": "test"})
+
+    assert result == "result"
+    # fail_conn.call_tool called twice: initial failure + check-first retry
+    assert fail_conn.call_tool.await_count == 2
+    # good_conn.call_tool should have been called once (the retry after reconnect)
+    good_conn.call_tool.assert_awaited_once()
+
+    await manager.stop_health_monitor()
+    await manager.disconnect_server("srv")
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_returns_error_when_reconnect_fails(tmp_path):
+    """call_tool returns an error dict when both the call and reconnect fail."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+
+    mock_conn = MagicMock()
+    mock_conn.is_connected = True
+    mock_conn.connect = AsyncMock()
+    mock_conn.disconnect = AsyncMock()
+    mock_conn.list_tools = AsyncMock(return_value=[])
+    mock_conn.call_tool = AsyncMock(side_effect=RuntimeError("transport dead"))
+
+    # _connect_server_impl will also fail (connect raises)
+    fail_conn = MagicMock()
+    fail_conn.is_connected = False
+    fail_conn.connect = AsyncMock(side_effect=RuntimeError("server down"))
+    fail_conn.disconnect = AsyncMock()
+    fail_conn.list_tools = AsyncMock(return_value=[])
+
+    call_count = 0
+
+    def conn_factory(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return mock_conn if call_count == 1 else fail_conn
+
+    with patch("src.tools.mcp.MCPConnection", side_effect=conn_factory):
+        await manager.connect_server("srv")
+        result = await manager.call_tool("srv", "search", {"q": "test"})
+
+    assert isinstance(result, dict)
+    assert "error" in result
+    assert "MCP tool call failed" in result["error"]
+
+    await manager.stop_health_monitor()
+    await manager.disconnect_server("srv")
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_oauth_auto_connect_uses_short_callback_timeout(tmp_path):
+    """_connect_server_impl(auto=True) passes callback_timeout=5.0 to _create_oauth_provider."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(
+        name="fastmail",
+        transport="streamable_http",
+        url="https://api.fastmail.com/mcp",
+        auth_type="oauth",
+    )
+    await manager.create_server(config)
+
+    mock_conn = MagicMock()
+    mock_conn.is_connected = True
+    mock_conn.connect = AsyncMock()
+    mock_conn.disconnect = AsyncMock()
+    mock_conn.list_tools = AsyncMock(return_value=[])
+
+    captured_kwargs = {}
+
+    original_create = manager._create_oauth_provider
+
+    def spy_create(server_name, server_url, *, callback_timeout=300.0):
+        captured_kwargs["callback_timeout"] = callback_timeout
+        return original_create(server_name, server_url, callback_timeout=callback_timeout)
+
+    with patch.object(manager, "_create_oauth_provider", side_effect=spy_create):
+        with patch("src.tools.mcp.MCPConnection", return_value=mock_conn):
+            # auto=True path
+            await manager._connect_server_impl("fastmail", auto=True)
+
+    assert captured_kwargs.get("callback_timeout") == 5.0
+
+    # Verify manual path uses 300.0
+    captured_kwargs.clear()
+    # Need to disconnect first
+    await manager._disconnect_server_impl("fastmail")
+    with patch.object(manager, "_create_oauth_provider", side_effect=spy_create):
+        with patch("src.tools.mcp.MCPConnection", return_value=mock_conn):
+            await manager._connect_server_impl("fastmail", auto=False)
+
+    assert captured_kwargs.get("callback_timeout") == 300.0
+
+    await manager.stop_health_monitor()
+    await manager.disconnect_server("fastmail")
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_health_monitor_start_stop(tmp_path):
+    """start_health_monitor creates a task; stop_health_monitor cancels it."""
+    import asyncio
+
+    manager, store = await _make_manager(tmp_path)
+
+    # No task initially
+    assert manager._health_task is None
+
+    # Start with a long interval so the loop doesn't iterate during the test
+    manager.start_health_monitor(9999.0)
+    assert manager._health_task is not None
+    assert not manager._health_task.done()
+
+    # Starting again is a no-op
+    first_task = manager._health_task
+    manager.start_health_monitor(9999.0)
+    assert manager._health_task is first_task
+
+    # Stop cancels and clears the task
+    await manager.stop_health_monitor()
+    assert manager._health_task is None
+    assert first_task.done()
+
+    # Stopping again is a no-op
+    await manager.stop_health_monitor()
+
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_sse_read_timeout_passed_to_transport(tmp_path):
+    """MCPConnection.connect passes sse_read_timeout from CONFIG to streamablehttp_client."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.config import CONFIG
+
+    # Save original value
+    original = CONFIG.mcp_sse_read_timeout_seconds
+    CONFIG.mcp_sse_read_timeout_seconds = 1234
+    try:
+        captured_kwargs = {}
+
+        # We need to mock the streamablehttp_client at the import site
+        mock_read = MagicMock()
+        mock_write = MagicMock()
+        mock_get_session_id = MagicMock()
+
+        class FakeAsyncCtx:
+            async def __aenter__(self):
+                return (mock_read, mock_write, mock_get_session_id)
+
+            async def __aexit__(self, *args):
+                pass
+
+        def fake_streamablehttp_client(url, **kwargs):
+            captured_kwargs.update(kwargs)
+            return FakeAsyncCtx()
+
+        # Mock ClientSession.initialize
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+
+        def fake_client_session(read, write):
+            class SessionCtx:
+                async def __aenter__(self_inner):
+                    return mock_session
+
+                async def __aexit__(self_inner, *args):
+                    pass
+
+            return SessionCtx()
+
+        config = MCPServerConfig(
+            name="srv",
+            transport="streamable_http",
+            url="https://example.com/mcp",
+        )
+        conn = MCPConnection(config, secret_manager=None)
+
+        with patch("mcp.client.streamable_http.streamablehttp_client", side_effect=fake_streamablehttp_client):
+            with patch("mcp.client.session.ClientSession", side_effect=fake_client_session):
+                await conn.connect()
+
+        assert "sse_read_timeout" in captured_kwargs
+        assert captured_kwargs["sse_read_timeout"] == 1234.0
+
+        await conn.disconnect()
+    finally:
+        CONFIG.mcp_sse_read_timeout_seconds = original
+
+
+@pytest.mark.asyncio
+async def test_call_tool_succeeds_after_health_monitor_reconnected(tmp_path):
+    """call_tool uses the 'check first' path when the health monitor already reconnected."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+
+    # Initial connection — call_tool will fail
+    fail_conn = MagicMock()
+    fail_conn.is_connected = True
+    fail_conn.connect = AsyncMock()
+    fail_conn.disconnect = AsyncMock()
+    fail_conn.list_tools = AsyncMock(return_value=[])
+    fail_conn.call_tool = AsyncMock(side_effect=RuntimeError("transport dead"))
+
+    # After the initial failure, we simulate the health monitor having already
+    # reconnected by replacing the connection in _connections with a healthy one
+    # before call_tool acquires the lock. We do this by having the initial
+    # call_tool's side_effect swap the connection.
+    healthy_conn = MagicMock()
+    healthy_conn.is_connected = True
+    healthy_conn.connect = AsyncMock()
+    healthy_conn.disconnect = AsyncMock()
+    healthy_conn.list_tools = AsyncMock(return_value=[])
+    healthy_conn.call_tool = AsyncMock(return_value="recovered_result")
+
+    def fail_then_swap(*args, **kwargs):
+        # Swap the connection so the check-first path finds a healthy one
+        manager._connections["srv"] = healthy_conn
+        raise RuntimeError("transport dead")
+
+    fail_conn.call_tool = AsyncMock(side_effect=fail_then_swap)
+
+    disconnect_spy = AsyncMock(wraps=manager._disconnect_server_impl)
+
+    with patch("src.tools.mcp.MCPConnection", return_value=fail_conn):
+        await manager.connect_server("srv")
+        with patch.object(manager, "_disconnect_server_impl", disconnect_spy):
+            result = await manager.call_tool("srv", "search", {"q": "test"})
+
+    # Should have succeeded via the check-first path
+    assert result == "recovered_result"
+    # _disconnect_server_impl should NOT have been called (no full reconnect)
+    disconnect_spy.assert_not_awaited()
+    # healthy_conn.call_tool should have been called (the retry)
+    healthy_conn.call_tool.assert_awaited_once()
+
+    await manager.stop_health_monitor()
+    await manager.disconnect_server("srv")
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_retries_after_checkfirst_failure(tmp_path):
+    """When check-first also fails, full reconnect happens and retry succeeds."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+
+    # Initial connection — both call_tool attempts fail
+    fail_conn = MagicMock()
+    fail_conn.is_connected = True
+    fail_conn.connect = AsyncMock()
+    fail_conn.disconnect = AsyncMock()
+    fail_conn.list_tools = AsyncMock(return_value=[])
+    fail_conn.call_tool = AsyncMock(side_effect=RuntimeError("transport dead"))
+
+    # Reconnected connection — call_tool succeeds
+    good_conn = MagicMock()
+    good_conn.is_connected = True
+    good_conn.connect = AsyncMock()
+    good_conn.disconnect = AsyncMock()
+    good_conn.list_tools = AsyncMock(return_value=[])
+    good_conn.call_tool = AsyncMock(return_value="retry_success")
+
+    call_count = 0
+
+    def conn_factory(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return fail_conn if call_count == 1 else good_conn
+
+    with patch("src.tools.mcp.MCPConnection", side_effect=conn_factory):
+        await manager.connect_server("srv")
+        result = await manager.call_tool("srv", "search", {"q": "test"})
+
+    # Should have succeeded after full reconnect
+    assert result == "retry_success"
+    # fail_conn.call_tool called twice: initial + check-first
+    assert fail_conn.call_tool.await_count == 2
+    # good_conn.call_tool called once: the retry after reconnect
+    good_conn.call_tool.assert_awaited_once()
+
+    await manager.stop_health_monitor()
+    await manager.disconnect_server("srv")
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_auto_reconnect_does_not_block(tmp_path):
+    """call_tool returns within bounded time even if _connect_server_impl hangs."""
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock
+
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+
+    mock_conn = MagicMock()
+    mock_conn.is_connected = True
+    mock_conn.connect = AsyncMock()
+    mock_conn.disconnect = AsyncMock()
+    mock_conn.list_tools = AsyncMock(return_value=[])
+    mock_conn.call_tool = AsyncMock(side_effect=RuntimeError("transport dead"))
+
+    # Second connection: connect hangs forever
+    hang_conn = MagicMock()
+    hang_conn.is_connected = False
+
+    async def hang_forever():
+        await asyncio.sleep(9999)
+
+    hang_conn.connect = AsyncMock(side_effect=hang_forever)
+    hang_conn.disconnect = AsyncMock()
+    hang_conn.list_tools = AsyncMock(return_value=[])
+
+    call_count = 0
+
+    def conn_factory(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return mock_conn if call_count == 1 else hang_conn
+
+    # Monkeypatch _RECONNECT_TIMEOUT to a small value so the test is fast
+    import src.tools.mcp as mcp_mod
+
+    original_timeout = mcp_mod._RECONNECT_TIMEOUT
+    mcp_mod._RECONNECT_TIMEOUT = 0.5
+    try:
+        with patch("src.tools.mcp.MCPConnection", side_effect=conn_factory):
+            await manager.connect_server("srv")
+            result = await manager.call_tool("srv", "search", {"q": "test"})
+    finally:
+        mcp_mod._RECONNECT_TIMEOUT = original_timeout
+
+    assert isinstance(result, dict)
+    assert "error" in result
+    assert "timed out" in result["error"].lower()
+
+    await manager.stop_health_monitor()
+    await manager.disconnect_server("srv")
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ping_and_disconnect(tmp_path):
+    """_health_check_server and disconnect_server run concurrently without exceptions."""
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock
+
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+
+    ping_event = asyncio.Event()
+
+    mock_conn = MagicMock()
+    mock_conn.is_connected = True
+    mock_conn.connect = AsyncMock()
+    mock_conn.disconnect = AsyncMock()
+
+    async def slow_ping():
+        await ping_event.wait()
+        raise RuntimeError("ping failed after disconnect")
+
+    mock_conn.send_ping = AsyncMock(side_effect=slow_ping)
+    mock_conn.list_tools = AsyncMock(return_value=[])
+
+    with patch("src.tools.mcp.MCPConnection", return_value=mock_conn):
+        await manager.connect_server("srv")
+
+        # Run health_check_server and disconnect_server concurrently
+        async def do_health_check():
+            try:
+                await manager._health_check_server("srv")
+            except Exception:
+                pass  # ping failure is expected
+
+        async def do_disconnect():
+            # Let the ping start first (it holds the lock, waiting on ping_event)
+            await asyncio.sleep(0.01)
+            # Release the ping so the health check completes and releases the lock
+            ping_event.set()
+            # Now disconnect can acquire the lock
+            await manager.disconnect_server("srv")
+
+        await asyncio.gather(do_health_check(), do_disconnect())
+
+    # Connection should be cleanly removed
+    assert "srv" not in manager._connections
+    await manager.stop_health_monitor()
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_all_awaits_health_monitor_during_teardown(tmp_path):
+    """disconnect_all stops the health monitor before tearing down connections."""
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock
+
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+
+    mock_conn = MagicMock()
+    mock_conn.is_connected = True
+    mock_conn.connect = AsyncMock()
+    mock_conn.disconnect = AsyncMock()
+    mock_conn.list_tools = AsyncMock(return_value=[])
+
+    reconnect_called = False
+
+    with patch("src.tools.mcp.MCPConnection", return_value=mock_conn):
+        await manager.connect_server("srv")
+
+        # Start the health monitor with a short interval
+        manager.start_health_monitor(0.05)
+
+        # Let one health check iteration run
+        await asyncio.sleep(0.06)
+
+        # Now call disconnect_all — should stop the monitor first
+        await manager.disconnect_all()
+
+    # Health task should be cancelled
+    assert manager._health_task is None
+    # Connections should be empty
+    assert len(manager._connections) == 0
+    await store.close()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1211,8 +1211,8 @@ async def test_call_tool_auto_reconnects_on_failure(tmp_path):
         result = await manager.call_tool("srv", "search", {"q": "test"})
 
     assert result == "result"
-    # fail_conn.call_tool called twice: initial failure + check-first retry
-    assert fail_conn.call_tool.await_count == 2
+    # fail_conn.call_tool called once (the initial failure)
+    fail_conn.call_tool.assert_awaited_once()
     # good_conn.call_tool should have been called once (the retry after reconnect)
     good_conn.call_tool.assert_awaited_once()
 
@@ -1408,53 +1408,53 @@ async def test_sse_read_timeout_passed_to_transport(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_call_tool_succeeds_after_health_monitor_reconnected(tmp_path):
-    """call_tool uses the 'check first' path when the health monitor already reconnected."""
+async def test_call_tool_serializes_with_health_monitor(tmp_path):
+    """call_tool holds the per-server lock; health check skips while a call is in progress."""
+    import asyncio
     from unittest.mock import AsyncMock, MagicMock
 
     manager, store = await _make_manager(tmp_path)
     config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
     await manager.create_server(config)
 
-    # Initial connection — call_tool will fail
-    fail_conn = MagicMock()
-    fail_conn.is_connected = True
-    fail_conn.connect = AsyncMock()
-    fail_conn.disconnect = AsyncMock()
-    fail_conn.list_tools = AsyncMock(return_value=[])
-    fail_conn.call_tool = AsyncMock(side_effect=RuntimeError("transport dead"))
+    call_started = asyncio.Event()
+    call_can_finish = asyncio.Event()
 
-    # After the initial failure, we simulate the health monitor having already
-    # reconnected by replacing the connection in _connections with a healthy one
-    # before call_tool acquires the lock. We do this by having the initial
-    # call_tool's side_effect swap the connection.
-    healthy_conn = MagicMock()
-    healthy_conn.is_connected = True
-    healthy_conn.connect = AsyncMock()
-    healthy_conn.disconnect = AsyncMock()
-    healthy_conn.list_tools = AsyncMock(return_value=[])
-    healthy_conn.call_tool = AsyncMock(return_value="recovered_result")
+    mock_conn = MagicMock()
+    mock_conn.is_connected = True
+    mock_conn.connect = AsyncMock()
+    mock_conn.disconnect = AsyncMock()
+    mock_conn.list_tools = AsyncMock(return_value=[])
 
-    def fail_then_swap(*args, **kwargs):
-        # Swap the connection so the check-first path finds a healthy one
-        manager._connections["srv"] = healthy_conn
-        raise RuntimeError("transport dead")
+    async def slow_call_tool(*args, **kwargs):
+        call_started.set()
+        await call_can_finish.wait()
+        return "slow_result"
 
-    fail_conn.call_tool = AsyncMock(side_effect=fail_then_swap)
+    mock_conn.call_tool = AsyncMock(side_effect=slow_call_tool)
+    mock_conn.send_ping = AsyncMock()
 
-    disconnect_spy = AsyncMock(wraps=manager._disconnect_server_impl)
-
-    with patch("src.tools.mcp.MCPConnection", return_value=fail_conn):
+    with patch("src.tools.mcp.MCPConnection", return_value=mock_conn):
         await manager.connect_server("srv")
-        with patch.object(manager, "_disconnect_server_impl", disconnect_spy):
-            result = await manager.call_tool("srv", "search", {"q": "test"})
 
-    # Should have succeeded via the check-first path
-    assert result == "recovered_result"
-    # _disconnect_server_impl should NOT have been called (no full reconnect)
-    disconnect_spy.assert_not_awaited()
-    # healthy_conn.call_tool should have been called (the retry)
-    healthy_conn.call_tool.assert_awaited_once()
+        # Run call_tool and _health_check_server concurrently
+        async def do_call():
+            return await manager.call_tool("srv", "search", {"q": "test"})
+
+        async def do_health_check():
+            await call_started.wait()
+            # Health check should skip (lock held by do_call), not block
+            await asyncio.wait_for(
+                manager._health_check_server("srv"), timeout=5.0
+            )
+            # Now let the call finish
+            call_can_finish.set()
+
+        results = await asyncio.gather(do_call(), do_health_check())
+
+    assert results[0] == "slow_result"
+    # send_ping should NOT have been called (health check skipped)
+    mock_conn.send_ping.assert_not_awaited()
 
     await manager.stop_health_monitor()
     await manager.disconnect_server("srv")
@@ -1462,15 +1462,15 @@ async def test_call_tool_succeeds_after_health_monitor_reconnected(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_call_tool_retries_after_checkfirst_failure(tmp_path):
-    """When check-first also fails, full reconnect happens and retry succeeds."""
+async def test_call_tool_retry_fails_after_reconnect(tmp_path):
+    """When retry also fails after a successful reconnect, call_tool returns a clear error."""
     from unittest.mock import AsyncMock, MagicMock
 
     manager, store = await _make_manager(tmp_path)
     config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
     await manager.create_server(config)
 
-    # Initial connection — both call_tool attempts fail
+    # Initial connection — call_tool fails
     fail_conn = MagicMock()
     fail_conn.is_connected = True
     fail_conn.connect = AsyncMock()
@@ -1478,31 +1478,29 @@ async def test_call_tool_retries_after_checkfirst_failure(tmp_path):
     fail_conn.list_tools = AsyncMock(return_value=[])
     fail_conn.call_tool = AsyncMock(side_effect=RuntimeError("transport dead"))
 
-    # Reconnected connection — call_tool succeeds
-    good_conn = MagicMock()
-    good_conn.is_connected = True
-    good_conn.connect = AsyncMock()
-    good_conn.disconnect = AsyncMock()
-    good_conn.list_tools = AsyncMock(return_value=[])
-    good_conn.call_tool = AsyncMock(return_value="retry_success")
+    # Reconnected connection — call_tool also fails (different error)
+    still_bad_conn = MagicMock()
+    still_bad_conn.is_connected = True
+    still_bad_conn.connect = AsyncMock()
+    still_bad_conn.disconnect = AsyncMock()
+    still_bad_conn.list_tools = AsyncMock(return_value=[])
+    still_bad_conn.call_tool = AsyncMock(side_effect=RuntimeError("server error after reconnect"))
 
     call_count = 0
 
     def conn_factory(*args, **kwargs):
         nonlocal call_count
         call_count += 1
-        return fail_conn if call_count == 1 else good_conn
+        return fail_conn if call_count == 1 else still_bad_conn
 
     with patch("src.tools.mcp.MCPConnection", side_effect=conn_factory):
         await manager.connect_server("srv")
         result = await manager.call_tool("srv", "search", {"q": "test"})
 
-    # Should have succeeded after full reconnect
-    assert result == "retry_success"
-    # fail_conn.call_tool called twice: initial + check-first
-    assert fail_conn.call_tool.await_count == 2
-    # good_conn.call_tool called once: the retry after reconnect
-    good_conn.call_tool.assert_awaited_once()
+    assert isinstance(result, dict)
+    assert "error" in result
+    assert "Reconnected but retry also failed" in result["error"]
+    assert "server error after reconnect" in result["error"]
 
     await manager.stop_health_monitor()
     await manager.disconnect_server("srv")
@@ -1511,7 +1509,7 @@ async def test_call_tool_retries_after_checkfirst_failure(tmp_path):
 
 @pytest.mark.asyncio
 async def test_call_tool_auto_reconnect_does_not_block(tmp_path):
-    """call_tool returns within bounded time even if _connect_server_impl hangs."""
+    """call_tool returns within bounded time even if disconnect or connect hangs."""
     import asyncio
     from unittest.mock import AsyncMock, MagicMock
 
@@ -1519,14 +1517,19 @@ async def test_call_tool_auto_reconnect_does_not_block(tmp_path):
     config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
     await manager.create_server(config)
 
+    # First connection: disconnect hangs forever, call_tool fails
     mock_conn = MagicMock()
     mock_conn.is_connected = True
     mock_conn.connect = AsyncMock()
-    mock_conn.disconnect = AsyncMock()
+
+    async def hang_disconnect():
+        await asyncio.sleep(9999)
+
+    mock_conn.disconnect = AsyncMock(side_effect=hang_disconnect)
     mock_conn.list_tools = AsyncMock(return_value=[])
     mock_conn.call_tool = AsyncMock(side_effect=RuntimeError("transport dead"))
 
-    # Second connection: connect hangs forever
+    # Second connection: connect also hangs forever
     hang_conn = MagicMock()
     hang_conn.is_connected = False
 
@@ -1561,13 +1564,15 @@ async def test_call_tool_auto_reconnect_does_not_block(tmp_path):
     assert "timed out" in result["error"].lower()
 
     await manager.stop_health_monitor()
-    await manager.disconnect_server("srv")
+    # Clean up — use the impl directly since disconnect_server would try to
+    # disconnect the hanging connection again
+    manager._connections.pop("srv", None)
     await store.close()
 
 
 @pytest.mark.asyncio
 async def test_concurrent_ping_and_disconnect(tmp_path):
-    """_health_check_server and disconnect_server run concurrently without exceptions."""
+    """_health_check_server and disconnect_server run concurrently without deadlocking."""
     import asyncio
     from unittest.mock import AsyncMock, MagicMock
 
@@ -1575,7 +1580,8 @@ async def test_concurrent_ping_and_disconnect(tmp_path):
     config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
     await manager.create_server(config)
 
-    ping_event = asyncio.Event()
+    ping_started = asyncio.Event()
+    ping_can_finish = asyncio.Event()
 
     mock_conn = MagicMock()
     mock_conn.is_connected = True
@@ -1583,8 +1589,8 @@ async def test_concurrent_ping_and_disconnect(tmp_path):
     mock_conn.disconnect = AsyncMock()
 
     async def slow_ping():
-        await ping_event.wait()
-        raise RuntimeError("ping failed after disconnect")
+        ping_started.set()
+        await ping_can_finish.wait()
 
     mock_conn.send_ping = AsyncMock(side_effect=slow_ping)
     mock_conn.list_tools = AsyncMock(return_value=[])
@@ -1592,22 +1598,28 @@ async def test_concurrent_ping_and_disconnect(tmp_path):
     with patch("src.tools.mcp.MCPConnection", return_value=mock_conn):
         await manager.connect_server("srv")
 
-        # Run health_check_server and disconnect_server concurrently
+        # Run health_check_server and disconnect_server concurrently.
+        # The health check acquires the lock and holds it during the slow ping.
+        # disconnect_server blocks on the lock until the ping finishes.
         async def do_health_check():
             try:
                 await manager._health_check_server("srv")
             except Exception:
-                pass  # ping failure is expected
+                pass
 
         async def do_disconnect():
-            # Let the ping start first (it holds the lock, waiting on ping_event)
-            await asyncio.sleep(0.01)
+            # Let the ping start (it holds the lock)
+            await ping_started.wait()
             # Release the ping so the health check completes and releases the lock
-            ping_event.set()
-            # Now disconnect can acquire the lock
+            ping_can_finish.set()
+            # Now disconnect_server can acquire the lock
             await manager.disconnect_server("srv")
 
-        await asyncio.gather(do_health_check(), do_disconnect())
+        # Wrap in a timeout so the test fails fast if there's a deadlock
+        await asyncio.wait_for(
+            asyncio.gather(do_health_check(), do_disconnect()),
+            timeout=10.0,
+        )
 
     # Connection should be cleanly removed
     assert "srv" not in manager._connections

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1166,9 +1166,11 @@ async def test_health_check_reconnects_dead_connection(tmp_path):
     assert result is True
     assert "srv" in manager._connections
     assert manager._connections["srv"] is healthy_conn
-    # dead_conn should have been popped (non-blocking disconnect — no await)
-    assert dead_conn._session is None
-    assert dead_conn._stack is None
+    # dead_conn.disconnect should be called by the background cleanup task
+    # Yield to let the background task run
+    import asyncio
+    await asyncio.sleep(0)
+    dead_conn.disconnect.assert_awaited()
 
     await manager.stop_health_monitor()
     await manager.disconnect_server("srv")
@@ -1556,13 +1558,16 @@ async def test_call_tool_auto_reconnect_does_not_block(tmp_path):
     import src.tools.mcp as mcp_mod
 
     original_timeout = mcp_mod._RECONNECT_TIMEOUT
+    original_detach_timeout = mcp_mod._DETACHED_DISCONNECT_TIMEOUT
     mcp_mod._RECONNECT_TIMEOUT = 0.5
+    mcp_mod._DETACHED_DISCONNECT_TIMEOUT = 0.5
     try:
         with patch("src.tools.mcp.MCPConnection", side_effect=conn_factory):
             await manager.connect_server("srv")
             result = await manager.call_tool("srv", "search", {"q": "test"})
     finally:
         mcp_mod._RECONNECT_TIMEOUT = original_timeout
+        mcp_mod._DETACHED_DISCONNECT_TIMEOUT = original_detach_timeout
 
     assert isinstance(result, dict)
     assert "error" in result


### PR DESCRIPTION
## Summary

MCP connections die silently after a few hours because the SDK's `sse_read_timeout` defaults to 5 minutes, there's no health checking, and no reconnection — once the transport dies, the dead session lingers and every subsequent tool call fails permanently.

This adds three resilience layers:

1. **Transport tuning** — passes `sse_read_timeout` (default 30 min) to `streamablehttp_client`, up from the SDK's 5-minute default
2. **Background health monitor** — a periodic `send_ping()` task that keeps connections alive and detects dead ones. Dead connections are disconnected and reconnected automatically with a bounded 20s timeout
3. **Auto-reconnect on `call_tool` failure** — when a tool call raises, attempts one bounded reconnection (with a short 5s OAuth callback timeout so interactive flows don't block) and retries the call

## Key design decisions

- **`call_tool` holds the per-server lock for its entire operation** (initial call + reconnect + retry), preventing the health monitor from tearing down a session mid-call
- **Non-blocking reconnect**: old connections are popped immediately and their `disconnect()` is scheduled as a background task with a 10s best-effort timeout — prevents hung transport closes from blocking the reconnect while still attempting cleanup
- **Health check try-acquire**: uses a 1s lock acquisition timeout so long-running tool calls cause the health check to skip rather than block
- **Stale server guard**: `_reconnect_server` re-checks that the server is still connected/enabled before reconnecting, preventing reconnection of a server the operator just disconnected
- **No frontend changes** — existing connected/disconnected badges already reflect state; the web UI's manual "Connect" button remains the fallback when auto-reconnect fails (e.g. OAuth refresh_token expired)

## Config changes

Two new fields in `src/config.py`, documented in `.env.example`:

| Field | Default | Description |
|-------|---------|-------------|
| `MCP_HEALTH_CHECK_INTERVAL_SECONDS` | 120 (2 min) | Seconds between background health-check pings (0 disables) |
| `MCP_SSE_READ_TIMEOUT_SECONDS` | 1800 (30 min) | SSE read timeout for streamable_http transports |

## Testing

12 new tests added to `tests/test_mcp.py` (64 total, all passing):
- Health check ping on healthy/dead connections
- Auto-reconnect on `call_tool` failure (success + failure paths)
- Bounded reconnect timeout (cancellation-resistant disconnect)
- Lock serialization between `call_tool` and health monitor
- `sse_read_timeout` passed to transport
- OAuth `auto=True` uses 5s callback timeout
- Health monitor start/stop lifecycle
- `disconnect_all` stops health monitor before teardown
- Concurrent ping and disconnect

## Review history

Reviewed through 5 cycles of two-reviewer (standard + adversarial) code review. Key findings addressed:
- Disconnect was outside `_RECONNECT_TIMEOUT` `wait_for` → moved inside
- `call_tool` didn't hold lock during initial call → now holds for entire operation
- `wait_for` cancellation could hang on unbounded `disconnect()` → bounded with `_detached_disconnect` background task
- `connect()`'s `except BaseException` awaited unbounded `disconnect()` → bounded with `wait_for`
- Non-blocking disconnect leaked transport resources → scheduled background cleanup task
