### PR TITLE
fix: unwrap single-object tool calls with unknown keys instead of failing

### DIFF
--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -147,15 +147,23 @@ class ToolRegistry:
 
         if len(params) == 1:
             param_names = {p.name for p in tool.parameters}
+            outer_key = next(iter(params))
             val = next(iter(params.values()))
             # The generated TypeScript stubs use positional parameters, but
             # LLM agents frequently call tools with a single object argument
             # (the natural MCP pattern). When that object lands in the first
-            # positional slot, unwrap it. Accept the object as long as at
-            # least one key matches a declared parameter — extra keys the
-            # model invented are silently dropped so the downstream tool
-            # never sees them.
-            if isinstance(val, dict) and param_names and set(val.keys()) & param_names:
+            # positional slot, unwrap it. To distinguish a real envelope from
+            # a legitimate object-typed first parameter, require the outer key
+            # itself to appear inside the nested dict — the agent specifies
+            # the first param's name as a key when building the object.
+            # Extra keys the model invented are silently dropped so the
+            # downstream tool never sees them.
+            if (
+                isinstance(val, dict)
+                and param_names
+                and outer_key in val
+                and set(val.keys()) & param_names
+            ):
                 params = {k: v for k, v in val.items() if k in param_names}
 
         return await tool.handler(ctx, **params)

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -148,8 +148,15 @@ class ToolRegistry:
         if len(params) == 1:
             param_names = {p.name for p in tool.parameters}
             val = next(iter(params.values()))
-            if isinstance(val, dict) and set(val.keys()) <= param_names:  # ignore: type
-                params = val  # type: ignore
+            # The generated TypeScript stubs use positional parameters, but
+            # LLM agents frequently call tools with a single object argument
+            # (the natural MCP pattern). When that object lands in the first
+            # positional slot, unwrap it. Accept the object as long as at
+            # least one key matches a declared parameter — extra keys the
+            # model invented are silently dropped so the downstream tool
+            # never sees them.
+            if isinstance(val, dict) and param_names and set(val.keys()) & param_names:
+                params = {k: v for k, v in val.items() if k in param_names}
 
         return await tool.handler(ctx, **params)
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -202,6 +202,46 @@ async def test_execute_does_not_unwrap_when_tool_has_no_params():
     assert received == {"data": {"x": 1}}
 
 
+@pytest.mark.asyncio
+async def test_execute_does_not_unwrap_object_param_with_overlapping_keys():
+    """When the first param is an object type and its value contains a key
+    that matches a sibling param name, the unwrap should NOT fire — the
+    object is a legitimate parameter value, not an argument envelope.
+
+    Example: tool has params (filter: object, limit: number). The agent
+    calls with filter={"status": "open", "limit": 5}. The wire message is
+    {"filter": {"status": "open", "limit": 5}}. Without the outer_key check,
+    "limit" in the nested dict would trigger unwrap and silently discard the
+    filter object, leaving only {"limit": 5}.
+    """
+    reg = ToolRegistry()
+    received = {}
+
+    async def handler(ctx, **kw):
+        received.update(kw)
+        return "ok"
+
+    reg.register(
+        Tool(
+            name="test.tool",
+            description="test",
+            parameters=[
+                ToolParameter(name="filter", type="object", description="filter", required=True),
+                ToolParameter(name="limit", type="number", description="limit", required=False),
+            ],
+            handler=handler,
+        )
+    )
+
+    # "filter" is NOT a key inside the nested dict, so this is a legitimate
+    # object value — don't unwrap
+    await reg.execute(
+        None, "test.tool", {"filter": {"status": "open", "limit": 5}}
+    )
+
+    assert received == {"filter": {"status": "open", "limit": 5}}
+
+
 # ---------------------------------------------------------------------------
 # Dataclass serialization tests
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -39,6 +39,170 @@ def test_unregister_returns_false_for_missing():
 
 
 # ---------------------------------------------------------------------------
+# Registry execute() — single-object unwrap tests
+# ---------------------------------------------------------------------------
+
+# The generated TypeScript stubs use positional parameters, but LLM agents
+# frequently call tools with a single object argument. When that object lands
+# in the first positional slot, registry.execute() must unwrap it. These tests
+# cover the unwrap logic in ToolRegistry.execute().
+
+
+@pytest.mark.asyncio
+async def test_execute_unwraps_single_object_with_matching_keys():
+    """When the agent passes a single object whose keys all match declared
+    params, execute() should unwrap it and pass each key as a kwarg."""
+    reg = ToolRegistry()
+    received = {}
+
+    async def handler(ctx, **kw):
+        received.update(kw)
+        return "ok"
+
+    reg.register(
+        Tool(
+            name="test.echo",
+            description="echo",
+            parameters=[
+                ToolParameter(name="msg", type="string", description="msg", required=True),
+                ToolParameter(name="count", type="number", description="count", required=False),
+            ],
+            handler=handler,
+        )
+    )
+
+    # Simulate what the TS stub sends when the agent calls
+    # tools.test.echo({ msg: "hi", count: 3 })
+    # — the object lands in the "msg" positional slot
+    await reg.execute(None, "test.echo", {"msg": {"msg": "hi", "count": 3}})
+
+    assert received == {"msg": "hi", "count": 3}
+
+
+@pytest.mark.asyncio
+async def test_execute_unwraps_single_object_with_extra_keys():
+    """When the agent passes a single object with keys that don't match any
+    declared param (e.g. the model invented params), execute() should unwrap
+    the known keys and silently drop the unknown ones rather than failing."""
+    reg = ToolRegistry()
+    received = {}
+
+    async def handler(ctx, **kw):
+        received.update(kw)
+        return "ok"
+
+    reg.register(
+        Tool(
+            name="ubereats.add_to_cart",
+            description="add to cart",
+            parameters=[
+                ToolParameter(name="item_name", type="string", description="item name", required=False),
+                ToolParameter(name="quantity", type="number", description="qty", required=False),
+                ToolParameter(name="restaurant_url", type="string", description="url", required=False),
+            ],
+            handler=handler,
+        )
+    )
+
+    # The agent passed item_uuid and item_options which don't exist in the
+    # tool's schema. The unwrap should still work — drop the unknown keys.
+    nested = {
+        "item_name": "Breakfast Bagels",
+        "item_uuid": "a14c419e-...",  # not in schema
+        "restaurant_url": "house-of-bagels-colma/abc",
+        "item_options": [{"group_uuid": "..."}],  # not in schema
+    }
+    await reg.execute(None, "ubereats.add_to_cart", {"item_name": nested})
+
+    assert received == {
+        "item_name": "Breakfast Bagels",
+        "restaurant_url": "house-of-bagels-colma/abc",
+    }
+    assert "item_uuid" not in received
+    assert "item_options" not in received
+
+
+@pytest.mark.asyncio
+async def test_execute_unwraps_single_object_partial_overlap():
+    """When only some keys in the nested object match declared params, unwrap
+    and pass only the matching keys."""
+    reg = ToolRegistry()
+    received = {}
+
+    async def handler(ctx, **kw):
+        received.update(kw)
+        return "ok"
+
+    reg.register(
+        Tool(
+            name="test.tool",
+            description="test",
+            parameters=[
+                ToolParameter(name="a", type="string", description="a", required=True),
+            ],
+            handler=handler,
+        )
+    )
+
+    # Only "a" matches; "b" and "c" are unknown
+    await reg.execute(None, "test.tool", {"a": {"a": 1, "b": 2, "c": 3}})
+
+    assert received == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_execute_does_not_unwrap_when_no_keys_match():
+    """If the single object has no keys matching declared params, it should
+    be passed through as-is to the first parameter (not unwrapped)."""
+    reg = ToolRegistry()
+    received = {}
+
+    async def handler(ctx, **kw):
+        received.update(kw)
+        return "ok"
+
+    reg.register(
+        Tool(
+            name="test.tool",
+            description="test",
+            parameters=[
+                ToolParameter(name="a", type="string", description="a", required=True),
+            ],
+            handler=handler,
+        )
+    )
+
+    # "x" and "y" don't match param "a" — pass through as-is
+    await reg.execute(None, "test.tool", {"a": {"x": 1, "y": 2}})
+
+    assert received == {"a": {"x": 1, "y": 2}}
+
+
+@pytest.mark.asyncio
+async def test_execute_does_not_unwrap_when_tool_has_no_params():
+    """If the tool has no declared parameters, don't try to unwrap."""
+    reg = ToolRegistry()
+    received = {}
+
+    async def handler(ctx, **kw):
+        received.update(kw)
+        return "ok"
+
+    reg.register(
+        Tool(
+            name="test.tool",
+            description="test",
+            parameters=[],
+            handler=handler,
+        )
+    )
+
+    await reg.execute(None, "test.tool", {"data": {"x": 1}})
+
+    assert received == {"data": {"x": 1}}
+
+
+# ---------------------------------------------------------------------------
 # Dataclass serialization tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Fix: MCP tool calls fail when agent passes a single object with unknown keys

### The problem

When the agent calls an MCP tool with a single object argument (the natural MCP pattern), the tool call fails with a confusing Pydantic validation error like:

```
1 validation error for uber_eats_add_to_cartArguments
item_name
  Input should be a valid string [type=string_type, input_value={'item_name': 'Breakfast Bagels', ...}, input_type=dict]
```

This happened every time the agent tried to add a customized item to an Uber Eats cart this morning — ~30 failed attempts over 4 minutes before the agent gave up.

### Root cause

The generated TypeScript stubs use **positional parameters**:

```typescript
uber_eats_add_to_cart: (item_name?: string, quantity?: number, restaurant_url?: string, ...): Promise<unknown> =>
  callTool("ubereats.uber_eats_add_to_cart", { item_name, quantity, restaurant_url, ... }),
```

But LLM agents call tools with a **single object argument**:

```typescript
tools.ubereats.uber_eats_add_to_cart({
  item_name: "Breakfast Bagels",
  item_uuid: "a14c419e-...",        // not in schema (schema has menu_item_uuid)
  restaurant_url: "house-of-bagels-colma/abc",
  item_options: [...]               // not in schema at all
})
```

JavaScript binds the entire object to the first positional parameter (`item_name`), so the wire message arrives as `{"item_name": {the whole object}}`.

The registry's unwrap logic in `ToolRegistry.execute()` tried to handle this, but it was too strict — it required **every** key in the nested object to match a declared parameter name:

```python
if isinstance(val, dict) and set(val.keys()) <= param_names:  # subset check
    params = val
```

If the agent included even one unknown key (which LLMs do frequently — conflating `item_uuid` with `menu_item_uuid`, or inventing `item_options` based on tool response data), the unwrap silently failed and the entire nested dict was passed to the MCP server as `item_name`, causing the validation error.

### The fix

Change the unwrap condition from "all keys must match" to "at least one key must match", and silently drop unknown keys:

```python
if isinstance(val, dict) and param_names and set(val.keys()) & param_names:
    params = {k: v for k, v in val.items() if k in param_names}
```

This means:
- If the agent passes `item_name`, `item_uuid`, `restaurant_url`, `item_options` and only `item_name` and `restaurant_url` are in the schema → unwrap and pass only those two, drop the rest.
- If the agent passes a single object with no matching keys at all → don't unwrap (pass through as-is, which is the pre-existing behavior).
- If the tool has no declared parameters → don't unwrap.

### Tests

Added 5 tests covering:
1. All keys match → unwraps correctly (existing behavior, now tested)
2. Extra unknown keys → unwraps and drops unknowns (the bug fix)
3. Partial overlap → unwraps only matching keys
4. No keys match → passes through as-is (no false positive unwrap)
5. Tool has no params → doesn't unwrap

All 283 existing tests still pass.

### Evidence from production logs

This bug was observed in `victrola.log` on June 26, 2026, 08:53–08:57 AM PT. The agent made ~30 attempts to call `uber_eats_add_to_cart` with customizations (asiago bagel, sausage omelet, extra bacon). Every single attempt failed with the identical `item_name Input should be a valid string` error because the agent passed `item_uuid` and `item_options` which weren't in the tool's schema, causing the unwrap to fail.

The same bug also affected Wingstop and Taqueria Guadalajara orders the night before — the agent misdiagnosed it as "the tool doesn't support customizations" when it was actually this bridge serialization issue.
