### PR TITLE
fix: unwrap single-object tool calls even when first param name is absent

### DIFF
--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -155,17 +155,18 @@ class ToolRegistry:
             # positional slot, unwrap it. To distinguish a real envelope from
             # a legitimate object-typed first parameter, only unwrap when the
             # first param is NOT object-typed — a dict value for a scalar param
-            # is clearly an envelope, not the intended value. Additionally
-            # require the outer key itself to appear inside the nested dict.
-            # Extra keys the model invented are silently dropped so the
-            # downstream tool never sees them.
+            # is clearly an envelope, not the intended value. Require at least
+            # one key in the nested object to match a declared param so we
+            # don't unwrap a dict that happens to be a legitimate scalar value
+            # (e.g. a JSON object stored as a string and parsed). Extra keys
+            # the model invented are silently dropped so the downstream tool
+            # never sees them.
             first_param = tool.parameters[0] if tool.parameters else None
             first_is_object = first_param is not None and first_param.type == "object"
             if (
                 isinstance(val, dict)
                 and param_names
                 and not first_is_object
-                and outer_key in val
                 and set(val.keys()) & param_names
             ):
                 params = {k: v for k, v in val.items() if k in param_names}

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -278,6 +278,49 @@ async def test_execute_does_not_unwrap_object_param_self_referential():
     assert received == {"filter": {"filter": {"nested": True}, "limit": 5, "status": "open"}}
 
 
+@pytest.mark.asyncio
+async def test_execute_unwraps_single_object_without_first_param_name():
+    """When the agent passes a single object that doesn't contain the first
+    param's name, the unwrap should still fire as long as at least one key
+    matches a declared param.
+
+    This is the fastmail search_email regression: the schema has params
+    (limit, query, position) — all scalar, all optional. The agent calls
+    search_email({ query: "is:unread" }), which lands in the first positional
+    slot ("position"). The object contains "query" but not "position", so the
+    old outer_key check blocked the unwrap and the MCP server received
+    {'position': {'query': 'is:unread'}} — a dict where an integer was
+    expected — and returned empty results.
+    """
+    reg = ToolRegistry()
+    received = {}
+
+    async def handler(ctx, **kw):
+        received.update(kw)
+        return "ok"
+
+    reg.register(
+        Tool(
+            name="fastmail.search_email",
+            description="search email",
+            parameters=[
+                ToolParameter(name="limit", type="number", description="limit", required=False),
+                ToolParameter(name="query", type="string", description="query", required=False),
+                ToolParameter(name="position", type="number", description="position", required=False),
+            ],
+            handler=handler,
+        )
+    )
+
+    # The agent's { query: "is:unread" } lands in the "position" slot.
+    # "query" matches a declared param, so unwrap even though "position"
+    # does not appear inside the nested object.
+    await reg.execute(None, "fastmail.search_email", {"position": {"query": "is:unread"}})
+
+    assert received == {"query": "is:unread"}
+    assert "position" not in received
+
+
 # ---------------------------------------------------------------------------
 # Dataclass serialization tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

The agent was getting empty results from `fastmail.search_email` — and concluded there was a "connection issue" when the inbox actually had unread emails.

When the agent calls `search_email({ query: "is:unread" })`, the single object argument lands in the first positional slot (`position`). The unwrap logic in `ToolRegistry.execute()` (added in #38) required the first param's name to also appear as a key inside the nested object:

```python
if (
    isinstance(val, dict)
    and param_names
    and not first_is_object
    and outer_key in val          # ← "position" not in {"query": "..."}
    and set(val.keys()) & param_names
):
```

The object `{ query: "is:unread" }` doesn't contain `"position"`, so the unwrap silently didn't fire. The MCP server received `{'position': {'query': 'is:unread'}}` — a dict where an integer was expected — and returned empty results.

This affected **any** tool with all-scalar optional params where the agent passes a single object that doesn't happen to contain the first param's name.

## Fix

Remove the `outer_key in val` condition. It was meant to prevent false-positive unwraps for object-typed first params, but commit 23e0e0a already added a stricter guard for that exact case (`not first_is_object`). The `outer_key` check was redundant with the object-type guard and harmful for the common calling pattern.

The remaining guards are sufficient:
- `not first_is_object` — prevents corrupting legitimate object-typed params
- `set(val.keys()) & param_names` — ensures at least one key matches a declared param before unwrapping

## Test

Added `test_execute_unwraps_single_object_without_first_param_name` — reproduces the exact fastmail scenario (scalar params `limit`, `query`, `position`) and verifies the unwrap fires correctly. Confirmed the test fails on the old code and passes with the fix.

All 76 existing tests still pass.
