### PR TITLE
feat: auto-reconnect OAuth MCP servers with stored tokens on startup

### DIFF
--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -456,10 +456,10 @@ class MCPManager:
 
     # -- connection lifecycle --
 
-    async def connect_server(self, name: str) -> None:
+    async def connect_server(self, name: str, *, auto: bool = False) -> None:
         """Connect to a server, discover tools, and register approved tools."""
         async with self._get_lock(name):
-            await self._connect_server_impl(name)
+            await self._connect_server_impl(name, auto=auto)
         self.start_health_monitor(float(CONFIG.mcp_health_check_interval_seconds))
 
     async def _connect_server_impl(self, name: str, *, auto: bool = False) -> None:
@@ -651,14 +651,29 @@ class MCPManager:
         for name, config in list(self._servers.items()):
             if not config.enabled:
                 continue
-            # Skip OAuth servers — they need manual authorization via the web UI.
-            # Even if tokens are stored, they may be expired and the refresh flow
-            # can block for minutes waiting for a callback that won't come during startup.
             if config.auth_type == "oauth":
-                logger.info(
-                    "Skipping OAuth MCP server '%s' on startup — "
-                    "connect manually via the web UI", name
-                )
+                # Only attempt OAuth servers that have stored tokens.
+                # Servers without tokens need initial authorization via the web UI.
+                status = await self.get_oauth_status_async(name)
+                if status != "authorized":
+                    logger.info(
+                        "Skipping OAuth MCP server '%s' on startup — "
+                        "no stored tokens, authorize via the web UI", name
+                    )
+                    continue
+                # Use auto=True so the callback handler fails fast (5s) if
+                # tokens are expired and can't be refreshed, rather than
+                # blocking startup waiting for an operator paste-back.
+                try:
+                    await asyncio.wait_for(
+                        self.connect_server(name, auto=True),
+                        timeout=_CONNECT_TIMEOUT,
+                    )
+                except (asyncio.TimeoutError, Exception) as e:
+                    logger.warning(
+                        "Failed to auto-connect OAuth MCP server '%s': %s. "
+                        "Connect manually via the web UI.", name, e
+                    )
                 continue
             try:
                 await asyncio.wait_for(self.connect_server(name), timeout=_CONNECT_TIMEOUT)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2031,3 +2031,90 @@ async def test_load_servers_skips_reserved_namespace(tmp_path):
     await manager.load_servers()
     assert "system" not in manager._servers
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_connect_all_auto_connects_oauth_with_tokens(tmp_path):
+    """connect_all auto-connects OAuth servers that have stored tokens,
+    using the short 5s callback timeout."""
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(
+        name="fastmail",
+        transport="streamable_http",
+        url="https://api.fastmail.com/mcp",
+        auth_type="oauth",
+        enabled=True,
+    )
+    await manager.create_server(config)
+
+    # Store a token so get_oauth_status_async returns "authorized"
+    await store.documents.create(
+        "mcptoken:fastmail",
+        json.dumps({"access_token": "tok", "token_type": "Bearer"}),
+    )
+
+    mock_tool = MagicMock()
+    mock_tool.name = "search"
+    mock_tool.description = "Search"
+    mock_tool.inputSchema = {"type": "object", "properties": {"q": {"type": "string"}}}
+
+    mock_conn = MagicMock()
+    mock_conn.is_connected = True
+    mock_conn.connect = AsyncMock()
+    mock_conn.list_tools = AsyncMock(return_value=[mock_tool])
+    mock_conn.disconnect = AsyncMock()
+
+    captured_kwargs = {}
+    original_create = manager._create_oauth_provider
+
+    def spy_create(server_name, server_url, *, callback_timeout=300.0):
+        captured_kwargs["callback_timeout"] = callback_timeout
+        return original_create(server_name, server_url, callback_timeout=callback_timeout)
+
+    with patch.object(manager, "_create_oauth_provider", side_effect=spy_create):
+        with patch("src.tools.mcp.MCPConnection", return_value=mock_conn):
+            await manager.connect_all()
+
+    # Server should be connected
+    assert "fastmail" in manager._connections
+    # Auto-connect path should use the short callback timeout
+    assert captured_kwargs.get("callback_timeout") == 5.0
+
+    await manager.stop_health_monitor()
+    await manager.disconnect_server("fastmail")
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_connect_all_oauth_failure_does_not_block(tmp_path):
+    """connect_all does not raise when an OAuth server's auto-connect fails."""
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(
+        name="fastmail",
+        transport="streamable_http",
+        url="https://api.fastmail.com/mcp",
+        auth_type="oauth",
+        enabled=True,
+    )
+    await manager.create_server(config)
+
+    # Store a token so get_oauth_status_async returns "authorized"
+    await store.documents.create(
+        "mcptoken:fastmail",
+        json.dumps({"access_token": "tok", "token_type": "Bearer"}),
+    )
+
+    mock_conn = MagicMock()
+    mock_conn.is_connected = False
+    mock_conn.connect = AsyncMock(side_effect=ConnectionRefusedError("server down"))
+    mock_conn.disconnect = AsyncMock()
+
+    with patch("src.tools.mcp.MCPConnection", return_value=mock_conn):
+        # Should not raise
+        await manager.connect_all()
+
+    # Server should not be connected
+    assert "fastmail" not in manager._connections
+
+    await manager.stop_health_monitor()
+    await store.close()


### PR DESCRIPTION
## Summary

On Victrola restart, OAuth MCP servers with stored tokens now automatically attempt to reconnect instead of being blanket-skipped — no more clicking "Connect" after every restart.

## Changes

- **`src/tools/mcp.py` — `connect_server`**: Added keyword-only `auto: bool = False` param that passes through to `_connect_server_impl`. Default `auto=False` preserves the manual connect flow (300s callback timeout).

- **`src/tools/mcp.py` — `connect_all`**: Replaced the blanket OAuth skip with a token check:
  - OAuth servers **without** stored tokens → still skipped (initial authorization via web UI)
  - OAuth servers **with** stored tokens → auto-connect attempted with `auto=True` (5s callback timeout, 30s overall bound)
  - Non-OAuth servers → unchanged
  - All failures are non-fatal — logged as warnings, operator can use the manual connect flow

- **`tests/test_mcp.py`**: Added two tests:
  - `test_connect_all_auto_connects_oauth_with_tokens` — stores tokens, mocks `MCPConnection`, spies on `_create_oauth_provider` to assert `callback_timeout == 5.0`, asserts server connects
  - `test_connect_all_oauth_failure_does_not_block` — mocks connect to raise, asserts `connect_all` returns without raising and server stays unconnected

## How it works

The MCP SDK's `OAuthClientProvider` handles three token states:
1. **Valid tokens** → used directly, no operator interaction
2. **Expired but refreshable** → refreshed silently via the refresh token
3. **Expired and not refreshable** → falls back to the consent flow

Only case 3 needs operator interaction. The `auto=True` path sets a 5s callback timeout so case 3 fails fast instead of blocking startup. The existing health-check reconnect path already relies on this same mechanism.

## Testing

```
uv run python -m pytest tests/test_mcp.py -v
# 78 passed
```

Two-reviewer code review (standard + adversarial, gpt-5.5) returned clean — no blockers or actionable findings.