### PR TITLE
feat: add persistent workspace directory for agent file operations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,14 @@ jobs:
         with:
           python-version: "3.12"
 
+      # The workspace permission tests spawn real `deno` subprocesses, so the
+      # runner needs Deno on PATH. Pinned to the version the suite is validated
+      # against locally; bump deliberately after re-validating.
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v1.42.4
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,9 @@ web/node_modules/
 web/*.tsbuildinfo
 web/dist-tsconfig/
 
+# Planning docs (personal scratch, never committed)
+docs/design-plans/
+docs/implementation-plans/
+docs/test-plans/
+
 .worktrees/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Victrola supports Anthropic, OpenAI, or any OpenAPI compatible endpoint like Oll
 
 The agent interacts with its tools via a single `execute_code` primitive. It writes TypeScript that calls `tools.namespace.method(...)`, which round-trips to Python handlers. This lets the agent chain multiple tool calls in one turn instead of paying a round trip per call (see [Cloudflare's "code mode" post](https://blog.cloudflare.com/code-mode/) for the rationale).
 
-Deno runs with the bare minimum of permissions: no filesystem writes, no network, no env access, 256 MB V8 heap, 60 s timeout, max 25 inner tool calls per execution. All actual network / storage work happens in Python.
+Deno runs with the bare minimum of permissions: scoped filesystem access limited to the workspace directory, no network, no env access (except explicitly declared secrets in custom tools), 256 MB V8 heap, 60 s timeout, max 25 inner tool calls per execution. All actual network / storage work happens in Python.
 
 ## Built-in tools
 
@@ -117,12 +117,34 @@ Embeddings are generated via a local Ollama instance using `nomic-embed-text` (7
 
 Memory entries can also be managed through the web interface at `/memory`, which provides browse, search, create, edit, and delete alongside the `memory.*` agent tools.
 
+## Workspace
+
+The agent has a persistent workspace directory (default: `data/workspace/`) where it can read and write files using Deno's native file APIs. This lets the agent build multi-file projects, create shared libraries, test code before deploying it as a custom tool, and generate artifacts.
+
+The workspace path is injected into every `execute_code` and custom tool block as the `WORKSPACE` TypeScript constant. The agent uses `Deno.writeTextFile`, `Deno.readTextFile`, `Deno.readDir`, and other native APIs to interact with files. Modules in the workspace can be dynamically imported via `await import(WORKSPACE + "/lib/parsers.ts")`.
+
+### Security model
+
+- Workspace access is scoped via Deno's `--allow-write=<workspace>` and `--allow-read=<workspace>` — the agent cannot write outside this directory
+- Symlink creation is not permitted
+- The workspace is visible to the operator via the web interface at `/workspace`
+- No npm packages — the agent vendors TypeScript source manually if needed
+- A configurable size limit prevents disk exhaustion
+
+### Configuration
+
+```env
+WORKSPACE_DIR=data/workspace
+WORKSPACE_MAX_SIZE_MB=1024
+```
+
 ## Storage
 
 Everything persistent lives under `./data/`:
 - `store.db` — SQLite: memory entries (+ FTS5 index + embeddings), chat sessions + messages, custom tool definitions, scheduled tasks, namespaced records
 - `secrets.json` — named secrets (injected as env vars into custom tool Deno processes)
 - `schedules.json.migrated` — renamed after one-time migration to SQLite (kept as backup)
+- `workspace/` — agent file storage (read/write scoped to Deno sandbox)
 
 Nothing leaves this directory unless you wire a tool to send it somewhere.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The workspace path is injected into every `execute_code` and custom tool block a
 - Symlink creation is not permitted
 - The workspace is visible to the operator via the web interface at `/workspace`
 - No npm packages — the agent vendors TypeScript source manually if needed
-- A configurable size limit prevents disk exhaustion
+- A configurable size limit monitors for disk exhaustion (soft limit with warning)
 
 ### Configuration
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any, Literal
 
 import click
@@ -104,6 +105,15 @@ def build_services(
     )
 
     return executor, agent
+
+
+def _ensure_workspace_dir() -> None:
+    """Create the workspace directory if it doesn't exist.
+
+    Called early so the agent never sees a missing workspace.
+    """
+    workspace_path = Path(CONFIG.workspace_dir)
+    workspace_path.mkdir(parents=True, exist_ok=True)
 
 
 def _wire_scheduler(executor: ToolExecutor, agent: Agent) -> None:
@@ -408,6 +418,7 @@ def main(
     async def run():
         try:
             await executor.initialize()
+            _ensure_workspace_dir()
             _wire_scheduler(executor, agent)
             await _init_memory(executor, agent)
 
@@ -455,6 +466,7 @@ def chat(
     async def run():
         try:
             await executor.initialize()
+            _ensure_workspace_dir()
             await _init_memory(executor, agent)
 
             async def _refresh_prompt() -> str:
@@ -506,6 +518,7 @@ def serve(
     async def run():
         try:
             await executor.initialize()
+            _ensure_workspace_dir()
             _wire_scheduler(executor, agent)
             await _init_memory(executor, agent)
 

--- a/src/agent/prompt.py
+++ b/src/agent/prompt.py
@@ -82,6 +82,48 @@ Err toward writing too often rather than too rarely. Memory loss is much more ex
 
 When a tool call fails, read the error carefully before retrying. Adjust your approach based on the error message. If you emitted something other than an `execute_code` call and got an error, the fix is to wrap your intended operation in `execute_code` TypeScript.
 
+## Workspace
+
+You have a persistent workspace directory available as the `WORKSPACE` constant in every `execute_code` block. It holds an absolute path string — use Deno's native file APIs to read and write files there.
+
+### What you can do
+
+- **Read and write files** using `Deno.writeTextFile`, `Deno.readTextFile`, `Deno.readDir`, `Deno.mkdir`, `Deno.remove`, `Deno.stat`
+- **Import modules** from the workspace — use dynamic imports: `const mod = await import(WORKSPACE + "/lib/parsers.ts")`. The temp file `execute_code` runs from lives in a different directory, so static relative imports won't reach the workspace. But workspace files can import *each other* via relative imports normally.
+- **Build multi-file projects** — split logic across files, share utilities, create libraries. Write a module to the workspace, import it dynamically from `execute_code`, and have that module statically import other workspace modules.
+- **Test your code** — write a test file, run it inside `execute_code`, read results, iterate
+- **Generate artifacts** — scripts, data files, reports, configurations
+
+### Organization
+
+Suggested structure (adapt as needed):
+```
+$WORKSPACE/
+  lib/           # shared utilities imported by custom tools
+  projects/      # project-specific code and artifacts
+  tests/         # test files
+  scratch/       # temporary/experimental code
+```
+
+### Constraints
+
+- You cannot write outside `$WORKSPACE` — Deno's permission model blocks this
+- You cannot create symlinks — not permitted
+- You cannot install npm packages — `--no-npm` is enforced; vendor TypeScript source manually if needed
+- The operator can see everything you write here via the web UI file browser
+- Files persist across turns and restarts
+
+### Self-improvement workflow
+
+1. Write a utility or tool to the workspace
+2. Write a test file alongside it
+3. Run the test inside `execute_code` to validate
+4. Iterate until tests pass
+5. Propose the tool via `custom_tools.create_custom_tool` — the custom tool can import from the workspace via `await import(WORKSPACE + "/...")`
+6. The operator reviews and approves the tool
+
+This lets you build, test, and iterate before deploying — no more shipping untested single-file tools.
+
 ## Scheduled Tasks and Triggers
 
 Scheduled tasks fire a prompt on a recurring schedule (daily summaries, periodic checks, etc.). When a schedule fires, you run the prompt in a fresh conversation with no prior history — so the prompt must be self-contained.
@@ -156,7 +198,7 @@ CUSTOM_TOOLS_TEMPLATE = """
 
 You can create custom tools via `custom_tools.create_custom_tool()` from inside `execute_code`. Once approved by the operator, call them via `tools.custom_tools.call_tool({{ name: "tool_name", params: {{...}} }})` from inside `execute_code`.
 
-Approved tools run with: network access, 256MB heap, 60s timeout, no filesystem writes.
+Approved tools run with: scoped workspace read/write access, 256MB heap, 60s timeout. Network access is granted only when the tool declares `requires_net: true`.
 
 ## How secrets work — READ CAREFULLY
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,6 @@
 from typing import Literal
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -102,6 +103,19 @@ class Config(BaseSettings):
     non-loopback hostname (e.g. a Tailscale host like 'pikachu')."""
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    @field_validator("workspace_dir")
+    @classmethod
+    def _workspace_dir_no_comma(cls, v: str) -> str:
+        """Deno's --allow-read/--allow-write flags use commas as path separators.
+        A workspace path containing a comma would silently grant access to
+        extra directories, so reject it at config load time."""
+        if "," in v:
+            raise ValueError(
+                f"workspace_dir must not contain commas (Deno treats commas as "
+                f"path separators in permission flags): {v!r}"
+            )
+        return v
 
 
 CONFIG = Config()

--- a/src/config.py
+++ b/src/config.py
@@ -28,6 +28,13 @@ class Config(BaseSettings):
     data_dir: str = "data"
     """local directory for secrets, schedules, and other operator state"""
 
+    # workspace (agent file storage)
+    workspace_dir: str = "data/workspace"
+    """directory the agent can read and write files to (Deno-scoped)"""
+
+    workspace_max_size_mb: int = 1024
+    """soft limit for workspace size in MB; logged as a warning when exceeded"""
+
     # display
     context_limit: int = 200_000
     """approximate context window of the main model; used for the web UI context bar"""

--- a/src/config.py
+++ b/src/config.py
@@ -34,7 +34,10 @@ class Config(BaseSettings):
     """directory the agent can read and write files to (Deno-scoped)"""
 
     workspace_max_size_mb: int = 1024
-    """soft limit for workspace size in MB; logged as a warning when exceeded"""
+    """workspace size limit in MB. Enforced as a pre-run refusal: the agent
+    cannot start code that writes to the workspace while it is already over
+    this size (and the web UI surfaces it). Not a live per-write cap — a single
+    permitted run can still write past the limit before the next run is blocked."""
 
     # display
     context_limit: int = 200_000

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -83,6 +83,21 @@ def _scan_workspace_or_raise(workspace: str) -> None:
             it = os.scandir(current)
         except FileNotFoundError:
             continue
+        except PermissionError:
+            # The agent has write scope and can chmod its OWN workspace dirs
+            # unreadable (e.g. Deno.chmod(dir, 0)), which would otherwise
+            # permanently fail the guard and brick all future runs. Since we own
+            # the dir, restore owner access and retry once. If we don't own it
+            # (chmod fails), fall through to fail-closed — a planted dir owned by
+            # another user can't be forced open to hide a symlink/hardlink.
+            try:
+                os.chmod(current, os.stat(current).st_mode | 0o700)
+                it = os.scandir(current)
+            except OSError as exc:
+                raise WorkspaceError(
+                    f"cannot scan the workspace ({exc}); refusing to run code "
+                    "that writes to the workspace."
+                )
         except OSError as exc:
             # Fail closed: if we can't enumerate a directory we can't prove it's
             # symlink/hardlink free, so don't grant write access.

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -353,6 +353,10 @@ import {{ output, debug }} from "./runtime.ts";
         # spawn a subprocess that executes deno with minimal permissions. explicit deny flags
         # ensure these can't be escalated via dynamic imports or permission prompts.
         deno_read_path = str(DENO_DIR)
+        if "," in deno_read_path:
+            raise ValueError(
+                f"DENO_DIR must not contain commas (Deno permission separator): {deno_read_path!r}"
+            )
         workspace = _resolve_workspace()
         read_paths = [deno_read_path, workspace]
 
@@ -395,6 +399,10 @@ import {{ output, debug }} from "./runtime.ts";
         """
 
         deno_read_path = str(DENO_DIR)
+        if "," in deno_read_path:
+            raise ValueError(
+                f"DENO_DIR must not contain commas (Deno permission separator): {deno_read_path!r}"
+            )
 
         if allow_workspace:
             workspace = _resolve_workspace()

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -83,6 +83,13 @@ def _scan_workspace_or_raise(workspace: str) -> None:
             it = os.scandir(current)
         except FileNotFoundError:
             continue
+        except OSError as exc:
+            # Fail closed: if we can't enumerate a directory we can't prove it's
+            # symlink/hardlink free, so don't grant write access.
+            raise WorkspaceError(
+                f"cannot scan the workspace ({exc}); refusing to run code that "
+                "writes to the workspace."
+            )
         with it:
             for entry in it:
                 if entry.is_symlink():
@@ -99,7 +106,15 @@ def _scan_workspace_or_raise(workspace: str) -> None:
                     st = entry.stat(follow_symlinks=False)
                 except OSError:
                     continue
-                if stat.S_ISREG(st.st_mode) and st.st_nlink > 1:
+                if not stat.S_ISREG(st.st_mode):
+                    # FIFOs/sockets/device nodes are not supported workspace
+                    # artifacts and could be a planted DoS/escape vector.
+                    raise WorkspaceError(
+                        f"workspace contains a special file ({entry.path!r}); "
+                        "only regular files and directories are supported. "
+                        "Remove it and retry."
+                    )
+                if st.st_nlink > 1:
                     rec = multilink.get((st.st_dev, st.st_ino))
                     if rec is None:
                         multilink[(st.st_dev, st.st_ino)] = [st.st_nlink, 1]

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -38,6 +38,66 @@ def _resolve_workspace() -> str:
     return workspace
 
 
+class WorkspaceError(Exception):
+    """The workspace is in an unsafe state to grant to Deno.
+
+    Raised when the workspace contains a symlink (which could escape the
+    scoped write permission) or is already over its size quota.
+    """
+
+
+def _scan_workspace_or_raise(workspace: str) -> None:
+    """Pre-execution guard run before Deno is granted workspace access.
+
+    1. Reject ANY symlink in the workspace tree. Deno authorizes a read/write
+       *through* a symlink based on the link's location, not its target, so a
+       symlink inside the workspace turns ``--allow-write=<workspace>`` into a
+       write-outside primitive. The agent itself cannot create symlinks (Deno
+       denies it), but the workspace is persistent and an operator, a restored
+       backup, another local process, or a future upload path could plant one —
+       so we refuse to run rather than follow it.
+    2. Refuse when the workspace already exceeds the configured size quota,
+       bounding unbounded disk growth from agent writes.
+
+    A single ``scandir`` traversal does both; the symlink check short-circuits.
+    Cost is O(workspace entries) per execution — negligible for the expected
+    small workspaces.
+    """
+    from src.config import CONFIG
+
+    max_bytes = CONFIG.workspace_max_size_mb * 1024 * 1024
+    total = 0
+    stack = [workspace]
+    while stack:
+        current = stack.pop()
+        try:
+            it = os.scandir(current)
+        except FileNotFoundError:
+            continue
+        with it:
+            for entry in it:
+                if entry.is_symlink():
+                    raise WorkspaceError(
+                        f"workspace contains a symlink ({entry.path!r}); "
+                        "symlinks can escape the sandbox's scoped write "
+                        "permission and are not permitted. Remove it (e.g. via "
+                        "the workspace file browser) and retry."
+                    )
+                if entry.is_dir(follow_symlinks=False):
+                    stack.append(entry.path)
+                else:
+                    try:
+                        total += entry.stat(follow_symlinks=False).st_size
+                    except OSError:
+                        continue
+    if max_bytes and total > max_bytes:
+        raise WorkspaceError(
+            f"workspace is over its size limit ({total} bytes > {max_bytes} "
+            f"bytes / {CONFIG.workspace_max_size_mb} MB). Free space before "
+            "running code that writes to the workspace."
+        )
+
+
 class ToolExecutor:
     """executor that runs Typescript code in a deno subprocess"""
 
@@ -238,6 +298,8 @@ const WORKSPACE = {workspace_json};
 
         try:
             return await self._run_deno(temp_path)
+        except WorkspaceError as e:
+            return {"success": False, "error": str(e), "debug": []}
         finally:
             os.unlink(temp_path)
 
@@ -285,6 +347,8 @@ const WORKSPACE = {workspace_json};
                 allow_net=allow_net,
                 env=env or {},
             )
+        except WorkspaceError as e:
+            return {"success": False, "error": str(e), "debug": []}
         finally:
             os.unlink(temp_path)
 
@@ -358,6 +422,9 @@ import {{ output, debug }} from "./runtime.ts";
                 f"DENO_DIR must not contain commas (Deno permission separator): {deno_read_path!r}"
             )
         workspace = _resolve_workspace()
+        # Refuse to run if the workspace contains a symlink (write-scope escape)
+        # or is over quota, before granting Deno --allow-write to it.
+        _scan_workspace_or_raise(workspace)
         read_paths = [deno_read_path, workspace]
 
         process = await asyncio.create_subprocess_exec(
@@ -406,6 +473,8 @@ import {{ output, debug }} from "./runtime.ts";
 
         if allow_workspace:
             workspace = _resolve_workspace()
+            # Same pre-execution guard as _run_deno before granting write scope.
+            _scan_workspace_or_raise(workspace)
             args = [
                 "deno",
                 "run",

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -69,6 +69,15 @@ def _scan_workspace_or_raise(workspace: str) -> None:
     A single ``scandir`` traversal collects everything; the symlink check
     short-circuits. Cost is O(workspace entries) per execution — negligible for
     the expected small workspaces.
+
+    Threat model: the agent runs in Deno (``--deny-run/ffi/sys``, no net on the
+    main path) and cannot create symlinks, escaping hardlinks, or special files,
+    so it cannot defeat this guard. Two residuals are out of scope because they
+    require an *active local attacker* racing the filesystem (not the agent):
+    an intermediate path component swapped to a symlink between this scan and
+    Deno's open, and the same race on the web delete path. A single permitted
+    run can also exceed the quota before the next run is refused (availability,
+    not an escape).
     """
     from src.config import CONFIG
 

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -204,11 +204,16 @@ class ToolExecutor:
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".ts", delete=False, dir=DENO_DIR
         ) as f:
+            from src.config import CONFIG
+
+            workspace_json = json.dumps(str(Path(CONFIG.workspace_dir).resolve()))
             # start by adding all the imports that we need...
             full_code = f"""
 import {{ output, debug }} from "./runtime.ts";
 import * as tools from "./tools.ts";
 export {{ tools }};
+
+const WORKSPACE = {workspace_json};
 
 {code}
 """
@@ -239,12 +244,16 @@ export {{ tools }};
         self._write_generated_tools()
 
         params_json = json.dumps(params)
+        from src.config import CONFIG
+
+        workspace_json = json.dumps(str(Path(CONFIG.workspace_dir).resolve()))
         full_code = f"""
 import {{ output, debug }} from "./runtime.ts";
 import * as tools from "./tools.ts";
 export {{ tools }};
 
 const params = {params_json};
+const WORKSPACE = {workspace_json};
 
 // --- tool code ---
 {code}
@@ -304,6 +313,7 @@ import {{ output, debug }} from "./runtime.ts";
                 allow_net=allow_net,
                 env=env or {},
                 allow_tool_calls=False,
+                allow_workspace=False,
             )
         finally:
             os.unlink(temp_path)
@@ -328,12 +338,17 @@ import {{ output, debug }} from "./runtime.ts";
 
         # spawn a subprocess that executes deno with minimal permissions. explicit deny flags
         # ensure these can't be escalated via dynamic imports or permission prompts.
+        from src.config import CONFIG
+
         deno_read_path = str(DENO_DIR)
+        workspace = str(Path(CONFIG.workspace_dir).resolve())
+        read_paths = [deno_read_path, workspace]
+
         process = await asyncio.create_subprocess_exec(
             "deno",
             "run",
-            f"--allow-read={deno_read_path}",
-            "--deny-write",
+            f"--allow-read={','.join(read_paths)}",
+            f"--allow-write={workspace}",
             "--deny-net",
             "--deny-run",
             "--deny-env",
@@ -357,21 +372,43 @@ import {{ output, debug }} from "./runtime.ts";
         allow_net: bool = False,
         env: dict[str, str] | None = None,
         allow_tool_calls: bool = True,
+        allow_workspace: bool = True,
     ) -> dict[str, Any]:
-        """Run deno with configurable permissions for custom tools."""
+        """Run deno with configurable permissions for custom tools.
+
+        When ``allow_workspace`` is True (default, custom tools path), scoped
+        workspace read/write access is granted. When False (condition code
+        path), writes remain fully denied — condition scripts are side-effect
+        free by design.
+        """
 
         deno_read_path = str(DENO_DIR)
 
-        args = [
-            "deno",
-            "run",
-            f"--allow-read={deno_read_path}",
-            "--deny-write",
-            "--deny-run",
-            "--deny-ffi",
-            "--deny-sys",
-            "--no-prompt",
-        ]
+        if allow_workspace:
+            from src.config import CONFIG
+
+            workspace = str(Path(CONFIG.workspace_dir).resolve())
+            args = [
+                "deno",
+                "run",
+                f"--allow-read={deno_read_path},{workspace}",
+                f"--allow-write={workspace}",
+                "--deny-run",
+                "--deny-ffi",
+                "--deny-sys",
+                "--no-prompt",
+            ]
+        else:
+            args = [
+                "deno",
+                "run",
+                f"--allow-read={deno_read_path}",
+                "--deny-write",
+                "--deny-run",
+                "--deny-ffi",
+                "--deny-sys",
+                "--no-prompt",
+            ]
 
         if allow_net:
             # Allow outbound fetch() but NOT remote module loading —

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -20,6 +20,24 @@ MAX_EXECUTION_TIME = 60.0  # total wall-clock timeout in seconds
 DENO_MEMORY_LIMIT_MB = 256  # v8 heap limit
 
 
+def _resolve_workspace() -> str:
+    """Resolve the workspace directory to an absolute path.
+
+    Rejects paths containing commas — Deno's --allow-read/--allow-write flags
+    use commas as path separators, so a comma in the workspace path would
+    silently grant access to extra directories.
+    """
+    from src.config import CONFIG
+
+    workspace = str(Path(CONFIG.workspace_dir).resolve())
+    if "," in workspace:
+        raise ValueError(
+            f"workspace_dir must not contain commas (Deno treats commas as "
+            f"path separators in permission flags): {workspace!r}"
+        )
+    return workspace
+
+
 class ToolExecutor:
     """executor that runs Typescript code in a deno subprocess"""
 
@@ -204,9 +222,7 @@ class ToolExecutor:
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".ts", delete=False, dir=DENO_DIR
         ) as f:
-            from src.config import CONFIG
-
-            workspace_json = json.dumps(str(Path(CONFIG.workspace_dir).resolve()))
+            workspace_json = json.dumps(_resolve_workspace())
             # start by adding all the imports that we need...
             full_code = f"""
 import {{ output, debug }} from "./runtime.ts";
@@ -244,9 +260,7 @@ const WORKSPACE = {workspace_json};
         self._write_generated_tools()
 
         params_json = json.dumps(params)
-        from src.config import CONFIG
-
-        workspace_json = json.dumps(str(Path(CONFIG.workspace_dir).resolve()))
+        workspace_json = json.dumps(_resolve_workspace())
         full_code = f"""
 import {{ output, debug }} from "./runtime.ts";
 import * as tools from "./tools.ts";
@@ -338,10 +352,8 @@ import {{ output, debug }} from "./runtime.ts";
 
         # spawn a subprocess that executes deno with minimal permissions. explicit deny flags
         # ensure these can't be escalated via dynamic imports or permission prompts.
-        from src.config import CONFIG
-
         deno_read_path = str(DENO_DIR)
-        workspace = str(Path(CONFIG.workspace_dir).resolve())
+        workspace = _resolve_workspace()
         read_paths = [deno_read_path, workspace]
 
         process = await asyncio.create_subprocess_exec(
@@ -385,9 +397,7 @@ import {{ output, debug }} from "./runtime.ts";
         deno_read_path = str(DENO_DIR)
 
         if allow_workspace:
-            from src.config import CONFIG
-
-            workspace = str(Path(CONFIG.workspace_dir).resolve())
+            workspace = _resolve_workspace()
             args = [
                 "deno",
                 "run",

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+import stat
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -49,24 +50,32 @@ class WorkspaceError(Exception):
 def _scan_workspace_or_raise(workspace: str) -> None:
     """Pre-execution guard run before Deno is granted workspace access.
 
-    1. Reject ANY symlink in the workspace tree. Deno authorizes a read/write
-       *through* a symlink based on the link's location, not its target, so a
-       symlink inside the workspace turns ``--allow-write=<workspace>`` into a
-       write-outside primitive. The agent itself cannot create symlinks (Deno
-       denies it), but the workspace is persistent and an operator, a restored
-       backup, another local process, or a future upload path could plant one —
-       so we refuse to run rather than follow it.
-    2. Refuse when the workspace already exceeds the configured size quota,
-       bounding unbounded disk growth from agent writes.
+    Deno authorizes a read/write *through* a link based on the link's location,
+    not its target, so a link inside the workspace pointing/refers outside turns
+    ``--allow-write=<workspace>`` into a write-outside primitive. The agent
+    cannot create escaping links (Deno denies symlink creation and won't link or
+    rename across the permission boundary), but the workspace is persistent and
+    an operator, a restored backup, another local process, or a future upload
+    path could plant one — so we refuse to run rather than follow it.
 
-    A single ``scandir`` traversal does both; the symlink check short-circuits.
-    Cost is O(workspace entries) per execution — negligible for the expected
-    small workspaces.
+    1. Reject ANY symlink in the workspace tree.
+    2. Reject any hardlink whose inode also has a link OUTSIDE the workspace
+       (writing it would modify out-of-workspace data). Hardlinks that live
+       entirely inside the workspace are allowed.
+    3. Refuse to START a run while the workspace already exceeds the configured
+       size quota. This is a next-run backpressure check, not a per-run cap: a
+       single permitted run can still write past the limit.
+
+    A single ``scandir`` traversal collects everything; the symlink check
+    short-circuits. Cost is O(workspace entries) per execution — negligible for
+    the expected small workspaces.
     """
     from src.config import CONFIG
 
     max_bytes = CONFIG.workspace_max_size_mb * 1024 * 1024
     total = 0
+    # inode (st_dev, st_ino) -> [fs-wide link count, links seen inside workspace]
+    multilink: dict[tuple[int, int], list[int]] = {}
     stack = [workspace]
     while stack:
         current = stack.pop()
@@ -85,11 +94,28 @@ def _scan_workspace_or_raise(workspace: str) -> None:
                     )
                 if entry.is_dir(follow_symlinks=False):
                     stack.append(entry.path)
-                else:
-                    try:
-                        total += entry.stat(follow_symlinks=False).st_size
-                    except OSError:
-                        continue
+                    continue
+                try:
+                    st = entry.stat(follow_symlinks=False)
+                except OSError:
+                    continue
+                if stat.S_ISREG(st.st_mode) and st.st_nlink > 1:
+                    rec = multilink.get((st.st_dev, st.st_ino))
+                    if rec is None:
+                        multilink[(st.st_dev, st.st_ino)] = [st.st_nlink, 1]
+                    else:
+                        rec[1] += 1
+                total += st.st_size
+
+    for fs_links, inside_links in multilink.values():
+        if fs_links > inside_links:
+            raise WorkspaceError(
+                "workspace contains a hardlink to a file outside the workspace; "
+                "writes through it would escape the sandbox's scoped write "
+                "permission. Remove it (e.g. via the workspace file browser) "
+                "and retry."
+            )
+
     if max_bytes and total > max_bytes:
         raise WorkspaceError(
             f"workspace is over its size limit ({total} bytes > {max_bytes} "

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -21,6 +21,7 @@ from src.web.routers import (
     status,
     system_prompt,
     tools,
+    workspace,
 )
 
 # Methods that can change server state — these require Origin validation
@@ -79,6 +80,7 @@ def create_app(agent, executor, conversation_manager) -> FastAPI:
     app.include_router(mcp.router, prefix="/api")
     app.include_router(system_prompt.router, prefix="/api")
     app.include_router(memory.router, prefix="/api")
+    app.include_router(workspace.router, prefix="/api")
 
     static_dir = Path(__file__).parent / "static"
 

--- a/src/web/routers/workspace.py
+++ b/src/web/routers/workspace.py
@@ -62,7 +62,10 @@ def _compute_workspace_size(workspace: Path) -> int:
             if f.is_symlink():
                 continue
             if f.is_file():
-                total += f.stat().st_size
+                st = f.stat()
+                if st.st_nlink > 1:  # skip possible hardlink-to-outside
+                    continue
+                total += st.st_size
         except OSError:
             continue
     return total
@@ -97,6 +100,9 @@ async def list_workspace(
             continue
         try:
             st = entry.stat()
+            # Skip multi-linked regular files (possible hardlink to outside).
+            if stat.S_ISREG(st.st_mode) and st.st_nlink > 1:
+                continue
             entries.append(
                 {
                     "name": entry.name,
@@ -151,6 +157,11 @@ async def read_workspace_file(
     with os.fdopen(fd, "rb") as f:
         st = os.fstat(f.fileno())
         if not stat.S_ISREG(st.st_mode):
+            raise HTTPException(404, "File not found")
+        # Refuse multi-linked files: a hardlink can share an inode with a file
+        # outside the workspace, so reading it could disclose out-of-workspace
+        # content (O_NOFOLLOW does not catch hardlinks).
+        if st.st_nlink > 1:
             raise HTTPException(404, "File not found")
         # Read at most MAX_READ_SIZE + 1 bytes so a file growing between checks
         # can't blow up memory; truncate the response if it's larger.

--- a/src/web/routers/workspace.py
+++ b/src/web/routers/workspace.py
@@ -39,8 +39,19 @@ def _resolve_workspace_path(path: str) -> tuple[Path, Path]:
 
 
 def _compute_workspace_size(workspace: Path) -> int:
-    """Walk the workspace tree and sum file sizes."""
-    return sum(f.stat().st_size for f in workspace.rglob("*") if f.is_file())
+    """Walk the workspace tree and sum file sizes.
+
+    Catches OSError per-file so concurrent agent writes/deletes don't
+    cause a 500 on the listing endpoint.
+    """
+    total = 0
+    for f in workspace.rglob("*"):
+        try:
+            if f.is_file():
+                total += f.stat().st_size
+        except OSError:
+            continue
+    return total
 
 
 @router.get("/workspace")
@@ -116,17 +127,20 @@ async def read_workspace_file(
 
     stat = target.stat()
 
-    # Check size before reading to avoid loading huge files into memory.
-    # The cap applies to what we read, not just what we return.
-    if stat.st_size > MAX_READ_SIZE:
-        # Read only the first MAX_READ_SIZE bytes, then decode.
+    # Always read at most MAX_READ_SIZE + 1 bytes from a single open file
+    # descriptor. This avoids a TOCTOU race where the agent grows the file
+    # between a stat() size check and a subsequent read_text() call.
+    try:
         with open(target, "rb") as f:
-            raw = f.read(MAX_READ_SIZE)
-        content = raw.decode("utf-8", errors="replace") + "\n... (truncated)"
+            raw = f.read(MAX_READ_SIZE + 1)
+    except OSError:
+        raise HTTPException(500, "Failed to read file")
+
+    # If we read more than MAX_READ_SIZE, the file is large — truncate
+    if len(raw) > MAX_READ_SIZE:
+        content = raw[:MAX_READ_SIZE].decode("utf-8", errors="replace") + "\n... (truncated)"
     else:
-        content = target.read_text(errors="replace")
-        if len(content) > MAX_READ_SIZE:
-            content = content[:MAX_READ_SIZE] + "\n... (truncated)"
+        content = raw.decode("utf-8", errors="replace")
 
     return {
         "path": path,

--- a/src/web/routers/workspace.py
+++ b/src/web/routers/workspace.py
@@ -116,9 +116,17 @@ async def read_workspace_file(
 
     stat = target.stat()
 
-    content = target.read_text(errors="replace")
-    if len(content) > MAX_READ_SIZE:
-        content = content[:MAX_READ_SIZE] + "\n... (truncated)"
+    # Check size before reading to avoid loading huge files into memory.
+    # The cap applies to what we read, not just what we return.
+    if stat.st_size > MAX_READ_SIZE:
+        # Read only the first MAX_READ_SIZE bytes, then decode.
+        with open(target, "rb") as f:
+            raw = f.read(MAX_READ_SIZE)
+        content = raw.decode("utf-8", errors="replace") + "\n... (truncated)"
+    else:
+        content = target.read_text(errors="replace")
+        if len(content) > MAX_READ_SIZE:
+            content = content[:MAX_READ_SIZE] + "\n... (truncated)"
 
     return {
         "path": path,

--- a/src/web/routers/workspace.py
+++ b/src/web/routers/workspace.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import shutil
+import stat
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -28,12 +30,22 @@ def _resolve_workspace_path(path: str) -> tuple[Path, Path]:
     resolved path escapes the workspace.
     """
     workspace = Path(CONFIG.workspace_dir).resolve()
-    target = (workspace / path).resolve()
+    # Join + normalize LEXICALLY — do NOT follow symlinks during resolution.
+    target = Path(os.path.normpath(workspace / path))
 
-    try:
-        target.relative_to(workspace)
-    except ValueError:
+    # Lexical containment (catches ``..`` and absolute paths).
+    if target != workspace and workspace not in target.parents:
         raise HTTPException(403, "Path outside workspace")
+
+    # Reject any symlink component under the workspace so a planted symlink is
+    # never followed out of it. The agent cannot create symlinks, but the
+    # workspace is persistent and could be touched by other actors; the
+    # executor enforces the same no-symlink invariant before each run.
+    cur = workspace
+    for part in target.relative_to(workspace).parts:
+        cur = cur / part
+        if cur.is_symlink():
+            raise HTTPException(403, "Symlinks are not permitted in the workspace")
 
     return workspace, target
 
@@ -47,6 +59,8 @@ def _compute_workspace_size(workspace: Path) -> int:
     total = 0
     for f in workspace.rglob("*"):
         try:
+            if f.is_symlink():
+                continue
             if f.is_file():
                 total += f.stat().st_size
         except OSError:
@@ -66,26 +80,30 @@ async def list_workspace(
         raise HTTPException(404, "Path not found")
 
     if target.is_file():
-        stat = target.stat()
+        st = target.stat()
         return {
             "type": "file",
             "name": target.name,
-            "size": stat.st_size,
-            "modified": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+            "size": st.st_size,
+            "modified": datetime.fromtimestamp(st.st_mtime, tz=timezone.utc).isoformat(),
         }
 
     # List directory contents
     entries = []
     for entry in sorted(target.iterdir()):
+        # Skip symlinks: they aren't a supported workspace artifact and
+        # following one could leak metadata about files outside the workspace.
+        if entry.is_symlink():
+            continue
         try:
-            stat = entry.stat()
+            st = entry.stat()
             entries.append(
                 {
                     "name": entry.name,
                     "type": "directory" if entry.is_dir() else "file",
-                    "size": stat.st_size if entry.is_file() else None,
+                    "size": st.st_size if entry.is_file() else None,
                     "modified": datetime.fromtimestamp(
-                        stat.st_mtime, tz=timezone.utc
+                        st.st_mtime, tz=timezone.utc
                     ).isoformat(),
                 }
             )
@@ -122,21 +140,22 @@ async def read_workspace_file(
     """Read a file's contents from the workspace."""
     _, target = _resolve_workspace_path(path)
 
-    if not target.is_file():
+    # Open with O_NOFOLLOW so a final-component symlink swapped in after
+    # validation cannot redirect the read outside the workspace, then operate
+    # on the file descriptor (fstat/read) rather than re-resolving the path.
+    try:
+        fd = os.open(target, os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError:
         raise HTTPException(404, "File not found")
 
-    stat = target.stat()
+    with os.fdopen(fd, "rb") as f:
+        st = os.fstat(f.fileno())
+        if not stat.S_ISREG(st.st_mode):
+            raise HTTPException(404, "File not found")
+        # Read at most MAX_READ_SIZE + 1 bytes so a file growing between checks
+        # can't blow up memory; truncate the response if it's larger.
+        raw = f.read(MAX_READ_SIZE + 1)
 
-    # Always read at most MAX_READ_SIZE + 1 bytes from a single open file
-    # descriptor. This avoids a TOCTOU race where the agent grows the file
-    # between a stat() size check and a subsequent read_text() call.
-    try:
-        with open(target, "rb") as f:
-            raw = f.read(MAX_READ_SIZE + 1)
-    except OSError:
-        raise HTTPException(500, "Failed to read file")
-
-    # If we read more than MAX_READ_SIZE, the file is large — truncate
     if len(raw) > MAX_READ_SIZE:
         content = raw[:MAX_READ_SIZE].decode("utf-8", errors="replace") + "\n... (truncated)"
     else:
@@ -145,8 +164,8 @@ async def read_workspace_file(
     return {
         "path": path,
         "content": content,
-        "size": stat.st_size,
-        "modified": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+        "size": st.st_size,
+        "modified": datetime.fromtimestamp(st.st_mtime, tz=timezone.utc).isoformat(),
     }
 
 

--- a/src/web/routers/workspace.py
+++ b/src/web/routers/workspace.py
@@ -1,0 +1,163 @@
+"""Workspace file browsing, reading, and deletion endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from src.config import CONFIG
+from src.tools.executor import ToolExecutor
+from src.web.dependencies import get_executor
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+MAX_READ_SIZE = 256 * 1024  # 256KB cap for file content responses
+
+
+def _resolve_workspace_path(path: str) -> tuple[Path, Path]:
+    """Resolve a relative path against the workspace root.
+
+    Returns ``(workspace_root, resolved_target)``. Raises 403 if the
+    resolved path escapes the workspace.
+    """
+    workspace = Path(CONFIG.workspace_dir).resolve()
+    target = (workspace / path).resolve()
+
+    try:
+        target.relative_to(workspace)
+    except ValueError:
+        raise HTTPException(403, "Path outside workspace")
+
+    return workspace, target
+
+
+def _compute_workspace_size(workspace: Path) -> int:
+    """Walk the workspace tree and sum file sizes."""
+    return sum(f.stat().st_size for f in workspace.rglob("*") if f.is_file())
+
+
+@router.get("/workspace")
+async def list_workspace(
+    path: str = Query(default=""),
+    executor: ToolExecutor = Depends(get_executor),
+):
+    """List files and directories at a given path within the workspace."""
+    workspace, target = _resolve_workspace_path(path)
+
+    if not target.exists():
+        raise HTTPException(404, "Path not found")
+
+    if target.is_file():
+        stat = target.stat()
+        return {
+            "type": "file",
+            "name": target.name,
+            "size": stat.st_size,
+            "modified": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+        }
+
+    # List directory contents
+    entries = []
+    for entry in sorted(target.iterdir()):
+        try:
+            stat = entry.stat()
+            entries.append(
+                {
+                    "name": entry.name,
+                    "type": "directory" if entry.is_dir() else "file",
+                    "size": stat.st_size if entry.is_file() else None,
+                    "modified": datetime.fromtimestamp(
+                        stat.st_mtime, tz=timezone.utc
+                    ).isoformat(),
+                }
+            )
+        except OSError:
+            # broken symlink or permission issue — skip
+            continue
+
+    # Compute total workspace size in a threadpool to avoid blocking the event loop.
+    total_size = await asyncio.to_thread(_compute_workspace_size, workspace)
+
+    # Log a warning if workspace exceeds the soft limit
+    max_size = CONFIG.workspace_max_size_mb * 1024 * 1024
+    if total_size > max_size:
+        logger.warning(
+            "Workspace size %d bytes exceeds limit of %d bytes (%d MB)",
+            total_size,
+            max_size,
+            CONFIG.workspace_max_size_mb,
+        )
+
+    return {
+        "path": path,
+        "entries": entries,
+        "total_size_bytes": total_size,
+        "max_size_bytes": max_size,
+    }
+
+
+@router.get("/workspace/file")
+async def read_workspace_file(
+    path: str = Query(...),
+    executor: ToolExecutor = Depends(get_executor),
+):
+    """Read a file's contents from the workspace."""
+    _, target = _resolve_workspace_path(path)
+
+    if not target.is_file():
+        raise HTTPException(404, "File not found")
+
+    stat = target.stat()
+
+    content = target.read_text(errors="replace")
+    if len(content) > MAX_READ_SIZE:
+        content = content[:MAX_READ_SIZE] + "\n... (truncated)"
+
+    return {
+        "path": path,
+        "content": content,
+        "size": stat.st_size,
+        "modified": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+    }
+
+
+@router.delete("/workspace/file")
+async def delete_workspace_file(
+    path: str = Query(...),
+    executor: ToolExecutor = Depends(get_executor),
+):
+    """Delete a file or directory from the workspace."""
+    workspace, target = _resolve_workspace_path(path)
+
+    # Reject deleting the workspace root itself
+    if target == workspace:
+        raise HTTPException(400, "Cannot delete workspace root")
+
+    if not target.exists():
+        raise HTTPException(404, "File not found")
+
+    if target.is_dir():
+        shutil.rmtree(target)
+    else:
+        target.unlink()
+
+    return {"deleted": path}
+
+
+@router.post("/workspace/dir")
+async def create_workspace_dir(
+    path: str = Query(...),
+    executor: ToolExecutor = Depends(get_executor),
+):
+    """Create a directory in the workspace."""
+    _, target = _resolve_workspace_path(path)
+
+    target.mkdir(parents=True, exist_ok=True)
+    return {"created": path}

--- a/src/web/routers/workspace.py
+++ b/src/web/routers/workspace.py
@@ -84,6 +84,10 @@ async def list_workspace(
 
     if target.is_file():
         st = target.stat()
+        # Don't expose metadata for a multi-linked file either (possible
+        # hardlink to outside) — mirrors the read endpoint's policy.
+        if stat.S_ISREG(st.st_mode) and st.st_nlink > 1:
+            raise HTTPException(404, "File not found")
         return {
             "type": "file",
             "name": target.name,
@@ -186,6 +190,13 @@ async def delete_workspace_file(
     executor: ToolExecutor = Depends(get_executor),
 ):
     """Delete a file or directory from the workspace."""
+    # _resolve_workspace_path rejects any symlink path component, so a planted
+    # static symlink can't redirect the delete out of the workspace. Note: this
+    # does NOT defend against an active local actor swapping an intermediate
+    # directory for a symlink between validation and rmtree (an intermediate-
+    # component TOCTOU). That's outside the agent threat model — the agent runs
+    # in Deno with --deny-run and cannot create symlinks or spawn processes —
+    # and a same-user local attacker could mutate the target directly anyway.
     workspace, target = _resolve_workspace_path(path)
 
     # Reject deleting the workspace root itself

--- a/tests/test_workspace_permissions.py
+++ b/tests/test_workspace_permissions.py
@@ -629,3 +629,21 @@ def test_web_list_rejects_hardlink_metadata(workspace_app, temp_workspace, tmp_p
 
     resp = workspace_app.get("/api/workspace", params={"path": "hl"})
     assert resp.status_code == 404
+
+
+async def test_agent_cannot_permanently_brick_via_chmod(
+    executor_with_workspace, temp_workspace
+):
+    """The agent has workspace write scope and can chmod its own dirs 000; the
+    pre-run scan must restore owner access and auto-heal rather than fail every
+    future run (and the dir becomes scannable/deletable again)."""
+    sub = temp_workspace / "locked"
+    sub.mkdir()
+    (sub / "f.txt").write_text("x")
+    os.chmod(sub, 0o000)
+    try:
+        result = await executor_with_workspace.execute_code("output({ ok: true });")
+        assert result["success"] is True, f"scan should auto-heal, got: {result}"
+        assert os.access(sub, os.R_OK | os.X_OK), "owner access should be restored"
+    finally:
+        os.chmod(sub, 0o700)  # ensure tmp cleanup can remove the tree

--- a/tests/test_workspace_permissions.py
+++ b/tests/test_workspace_permissions.py
@@ -1,0 +1,384 @@
+"""Tests for workspace feature: Deno permissions, path injection, and web API."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import quote
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.config import CONFIG
+from src.tools.registry import ToolRegistry, ToolContext
+from src.tools.executor import ToolExecutor
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_workspace(tmp_path: Path, monkeypatch) -> Path:
+    """Create a temp workspace directory and patch CONFIG to point at it."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(CONFIG, "workspace_dir", str(workspace))
+    return workspace
+
+
+@pytest.fixture
+async def executor_with_workspace(temp_workspace: Path) -> ToolExecutor:
+    """A ToolExecutor with a temp workspace and mock context."""
+    ctx = ToolContext()
+    registry = ToolRegistry()
+    executor = ToolExecutor(registry=registry, ctx=ctx)
+    executor._tool_definition = None
+    yield executor
+
+
+@pytest.fixture
+def workspace_app(temp_workspace: Path):
+    """Create a FastAPI TestClient with the workspace router."""
+    from src.web.app import create_app
+
+    agent = MagicMock()
+    executor = MagicMock()
+    conversation_manager = MagicMock()
+    app = create_app(agent, executor, conversation_manager)
+    with TestClient(app) as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Deno security tests (actual subprocess execution)
+# ---------------------------------------------------------------------------
+
+
+async def test_deno_can_write_file_inside_workspace(executor_with_workspace, temp_workspace):
+    """Deno can write a file inside the workspace."""
+    result = await executor_with_workspace.execute_code(
+        'await Deno.writeTextFile(WORKSPACE + "/test_write.txt", "hello workspace");\noutput({ ok: true });'
+    )
+    assert result["success"], f"Expected success, got: {result}"
+    assert (temp_workspace / "test_write.txt").read_text() == "hello workspace"
+
+
+async def test_deno_can_read_file_from_workspace(executor_with_workspace, temp_workspace):
+    """Deno can read a file from the workspace."""
+    (temp_workspace / "read_test.txt").write_text("readable content")
+    result = await executor_with_workspace.execute_code(
+        'const content = await Deno.readTextFile(WORKSPACE + "/read_test.txt");\noutput({ content });'
+    )
+    assert result["success"], f"Expected success, got: {result}"
+    assert result["output"]["content"] == "readable content"
+
+
+async def test_deno_can_create_subdirectories(executor_with_workspace, temp_workspace):
+    """Deno can create subdirectories inside the workspace."""
+    result = await executor_with_workspace.execute_code(
+        'await Deno.mkdir(WORKSPACE + "/lib/sub", { recursive: true });\n'
+        'await Deno.writeTextFile(WORKSPACE + "/lib/sub/mod.ts", "export const x = 1;");\n'
+        'output({ ok: true });'
+    )
+    assert result["success"], f"Expected success, got: {result}"
+    assert (temp_workspace / "lib" / "sub" / "mod.ts").exists()
+    assert (temp_workspace / "lib" / "sub" / "mod.ts").read_text() == "export const x = 1;"
+
+
+async def test_deno_cannot_write_outside_workspace(executor_with_workspace):
+    """Deno CANNOT write outside the workspace (e.g. /tmp/)."""
+    result = await executor_with_workspace.execute_code(
+        'try {\n'
+        '  await Deno.writeTextFile("/tmp/victrola_escape_test.txt", "escaped");\n'
+        '  output({ escaped: true });\n'
+        '} catch (e) {\n'
+        '  output({ escaped: false, error: e instanceof Error ? e.message : String(e) });\n'
+        '}'
+    )
+    assert result["success"], f"Code should run, got: {result}"
+    output = result["output"]
+    assert output["escaped"] is False, "Should not be able to write to /tmp"
+    # Deno should report a permission error
+    err_lower = output["error"].lower()
+    assert "permission" in err_lower or "notcapable" in err_lower or "denied" in err_lower or "write access" in err_lower or "allow-write" in err_lower
+
+
+async def test_deno_cannot_write_via_path_traversal(executor_with_workspace, temp_workspace):
+    """Deno CANNOT write via path traversal (../../escape)."""
+    result = await executor_with_workspace.execute_code(
+        'try {\n'
+        '  await Deno.writeTextFile(WORKSPACE + "/../../escape_test.txt", "escaped");\n'
+        '  output({ escaped: true });\n'
+        '} catch (e) {\n'
+        '  output({ escaped: false, error: e instanceof Error ? e.message : String(e) });\n'
+        '}'
+    )
+    assert result["success"], f"Code should run, got: {result}"
+    output = result["output"]
+    assert output["escaped"] is False, "Should not be able to write via traversal"
+    # The file should not exist outside the workspace
+    assert not (temp_workspace.parent.parent / "escape_test.txt").exists()
+
+
+async def test_deno_cannot_create_symlinks(executor_with_workspace, temp_workspace):
+    """Deno CANNOT create symlinks inside the workspace."""
+    (temp_workspace / "target.txt").write_text("target")
+    result = await executor_with_workspace.execute_code(
+        'try {\n'
+        '  await Deno.symlink(WORKSPACE + "/target.txt", WORKSPACE + "/link.txt");\n'
+        '  output({ created: true });\n'
+        '} catch (e) {\n'
+        '  output({ created: false, error: e instanceof Error ? e.message : String(e) });\n'
+        '}'
+    )
+    assert result["success"], f"Code should run, got: {result}"
+    output = result["output"]
+    assert output["created"] is False, "Should not be able to create symlinks"
+    err_lower = output["error"].lower()
+    assert "permission" in err_lower or "notcapable" in err_lower or "denied" in err_lower or "write access" in err_lower or "allow-write" in err_lower
+    # The symlink should not have been created
+    assert not (temp_workspace / "link.txt").exists() or not (temp_workspace / "link.txt").is_symlink()
+
+
+async def test_deno_can_dynamically_import_workspace_module(executor_with_workspace, temp_workspace):
+    """Deno can dynamically import a module from the workspace."""
+    # Write a module to the workspace
+    (temp_workspace / "mathmod.ts").write_text(
+        "export function double(n: number): number {\n"
+        "  return n * 2;\n"
+        "}\n"
+    )
+    result = await executor_with_workspace.execute_code(
+        'const mod = await import(WORKSPACE + "/mathmod.ts");\n'
+        'const result = mod.double(21);\n'
+        'output({ result });'
+    )
+    assert result["success"], f"Expected success, got: {result}"
+    assert result["output"]["result"] == 42
+
+
+# ---------------------------------------------------------------------------
+# Preamble / WORKSPACE constant tests
+# ---------------------------------------------------------------------------
+
+
+async def test_workspace_constant_in_execute_code(executor_with_workspace, temp_workspace):
+    """The WORKSPACE constant is correctly set in the execute_code preamble."""
+    result = await executor_with_workspace.execute_code(
+        'output({ workspace: WORKSPACE });'
+    )
+    assert result["success"], f"Expected success, got: {result}"
+    expected = str(temp_workspace.resolve())
+    assert result["output"]["workspace"] == expected
+
+
+async def test_workspace_constant_in_custom_tool_code(executor_with_workspace, temp_workspace):
+    """The WORKSPACE constant is correctly set in the custom tool preamble."""
+    result = await executor_with_workspace.execute_custom_tool_code(
+        code='output({ workspace: WORKSPACE, params: params });',
+        params={"test": True},
+    )
+    assert result["success"], f"Expected success, got: {result}"
+    expected = str(temp_workspace.resolve())
+    assert result["output"]["workspace"] == expected
+    assert result["output"]["params"]["test"] is True
+
+
+async def test_condition_code_has_no_workspace_access(executor_with_workspace, temp_workspace):
+    """Condition code does NOT get workspace access — no WORKSPACE constant and writes fail."""
+    # The WORKSPACE constant should not be defined — referencing it should be a ReferenceError
+    result = await executor_with_workspace.execute_condition_code(
+        code='try {\n'
+        '  output({ workspace: WORKSPACE });\n'
+        '} catch (e) {\n'
+        '  output({ error: e instanceof Error ? e.message : String(e) });\n'
+        '}'
+    )
+    assert result["success"] is False or "error" in result.get("output", {}), \
+        f"Expected error or failure, got: {result}"
+
+
+async def test_condition_code_cannot_write_files(executor_with_workspace, temp_workspace):
+    """Condition code attempting Deno.writeTextFile fails with a permission error."""
+    result = await executor_with_workspace.execute_condition_code(
+        code='try {\n'
+        '  await Deno.writeTextFile("/tmp/condition_escape.txt", "data");\n'
+        '  output({ written: true });\n'
+        '} catch (e) {\n'
+        '  output({ written: false, error: e instanceof Error ? e.message : String(e) });\n'
+        '}'
+    )
+    # The code runs but the write should fail
+    output = result.get("output", {})
+    if isinstance(output, dict) and "written" in output:
+        assert output["written"] is False, "Condition code should not be able to write files"
+    else:
+        # If the process errored out entirely, that's also acceptable
+        assert not result["success"] or "error" in result, \
+            f"Expected write failure, got: {result}"
+
+
+async def test_bare_execute_code_still_runs(executor_with_workspace):
+    """A bare execute_code call (output('hi')) still runs with the new permission setup."""
+    result = await executor_with_workspace.execute_code(
+        "output('hello world');"
+    )
+    assert result["success"], f"Expected success, got: {result}"
+    assert result["output"] == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# Web API tests
+# ---------------------------------------------------------------------------
+
+
+def test_web_list_workspace_root(workspace_app, temp_workspace):
+    """Web API directory listing works at the workspace root."""
+    (temp_workspace / "file1.txt").write_text("content1")
+    (temp_workspace / "subdir").mkdir()
+
+    resp = workspace_app.get("/api/workspace")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "entries" in data
+    names = [e["name"] for e in data["entries"]]
+    assert "file1.txt" in names
+    assert "subdir" in names
+    assert data["total_size_bytes"] >= 0
+    assert data["max_size_bytes"] > 0
+
+
+def test_web_list_workspace_subdirectory(workspace_app, temp_workspace):
+    """Web API can list subdirectories."""
+    (temp_workspace / "projects").mkdir()
+    (temp_workspace / "projects" / "app.ts").write_text("export const x = 1;")
+
+    resp = workspace_app.get("/api/workspace", params={"path": "projects"})
+    assert resp.status_code == 200
+    data = resp.json()
+    names = [e["name"] for e in data["entries"]]
+    assert "app.ts" in names
+
+
+def test_web_read_workspace_file(workspace_app, temp_workspace):
+    """Web API file reading works for text files."""
+    (temp_workspace / "readable.ts").write_text("export const value = 42;")
+
+    resp = workspace_app.get("/api/workspace/file", params={"path": "readable.ts"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["content"] == "export const value = 42;"
+    assert data["size"] > 0
+
+
+def test_web_delete_workspace_file(workspace_app, temp_workspace):
+    """Web API file deletion works."""
+    (temp_workspace / "deletable.txt").write_text("delete me")
+
+    resp = workspace_app.delete("/api/workspace/file", params={"path": "deletable.txt"})
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == "deletable.txt"
+    assert not (temp_workspace / "deletable.txt").exists()
+
+
+def test_web_delete_workspace_directory(workspace_app, temp_workspace):
+    """Web API can delete directories recursively."""
+    (temp_workspace / "to-remove").mkdir()
+    (temp_workspace / "to-remove" / "inner.txt").write_text("inner")
+
+    resp = workspace_app.delete("/api/workspace/file", params={"path": "to-remove"})
+    assert resp.status_code == 200
+    assert not (temp_workspace / "to-remove").exists()
+
+
+def test_web_create_workspace_dir(workspace_app, temp_workspace):
+    """Web API directory creation works."""
+    resp = workspace_app.post("/api/workspace/dir", params={"path": "new-dir/sub"})
+    assert resp.status_code == 200
+    assert (temp_workspace / "new-dir" / "sub").is_dir()
+
+
+def test_web_rejects_path_traversal_list(workspace_app):
+    """Web API rejects path traversal on list endpoint."""
+    resp = workspace_app.get("/api/workspace", params={"path": "../../etc/passwd"})
+    assert resp.status_code == 403
+
+
+def test_web_rejects_path_traversal_read(workspace_app):
+    """Web API rejects path traversal on file read endpoint."""
+    resp = workspace_app.get("/api/workspace/file", params={"path": "../../etc/passwd"})
+    assert resp.status_code == 403
+
+
+def test_web_rejects_path_traversal_delete(workspace_app):
+    """Web API rejects path traversal on delete endpoint."""
+    resp = workspace_app.delete("/api/workspace/file", params={"path": "../../etc/passwd"})
+    assert resp.status_code == 403
+
+
+def test_web_rejects_path_traversal_mkdir(workspace_app):
+    """Web API rejects path traversal on mkdir endpoint."""
+    resp = workspace_app.post("/api/workspace/dir", params={"path": "../../etc/evil"})
+    assert resp.status_code == 403
+
+
+def test_web_rejects_deleting_workspace_root(workspace_app):
+    """Web API rejects deleting the workspace root (path='')."""
+    resp = workspace_app.delete("/api/workspace/file", params={"path": ""})
+    assert resp.status_code == 400
+
+
+def test_web_404_for_missing_path(workspace_app):
+    """Web API returns 404 for a non-existent path."""
+    resp = workspace_app.get("/api/workspace", params={"path": "nonexistent"})
+    assert resp.status_code == 404
+
+
+def test_web_csrf_protection_post(workspace_app):
+    """Cross-origin POST to /api/workspace/dir is rejected (no valid Origin)."""
+    resp = workspace_app.post(
+        "/api/workspace/dir",
+        params={"path": "csrf-test"},
+        headers={"Origin": "https://evil.com"},
+    )
+    assert resp.status_code == 403
+
+
+def test_web_csrf_protection_delete(workspace_app):
+    """Cross-origin DELETE to /api/workspace/file is rejected."""
+    resp = workspace_app.delete(
+        "/api/workspace/file",
+        params={"path": "csrf-test"},
+        headers={"Origin": "https://evil.com"},
+    )
+    assert resp.status_code == 403
+
+
+def test_web_same_origin_post_allowed(workspace_app, temp_workspace):
+    """Same-origin POST to /api/workspace/dir is allowed."""
+    resp = workspace_app.post(
+        "/api/workspace/dir",
+        params={"path": "allowed-dir"},
+        headers={"Origin": "http://localhost:8000"},
+    )
+    assert resp.status_code == 200
+    assert (temp_workspace / "allowed-dir").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+def test_config_has_workspace_fields():
+    """Config should have workspace_dir and workspace_max_size_mb fields."""
+    assert hasattr(CONFIG, "workspace_dir")
+    assert hasattr(CONFIG, "workspace_max_size_mb")
+    assert CONFIG.workspace_dir == "data/workspace"
+    assert CONFIG.workspace_max_size_mb == 1024

--- a/tests/test_workspace_permissions.py
+++ b/tests/test_workspace_permissions.py
@@ -382,3 +382,42 @@ def test_config_has_workspace_fields():
     assert hasattr(CONFIG, "workspace_max_size_mb")
     assert CONFIG.workspace_dir == "data/workspace"
     assert CONFIG.workspace_max_size_mb == 1024
+
+
+def test_config_rejects_comma_in_workspace_dir():
+    """Config validator should reject workspace_dir containing commas."""
+    from pydantic import ValidationError
+    from src.config import Config
+
+    with pytest.raises(ValidationError):
+        Config(workspace_dir="data/workspace,/tmp")
+
+
+def test_resolve_workspace_rejects_comma(tmp_path, monkeypatch):
+    """_resolve_workspace should raise on comma-containing paths (defense-in-depth)."""
+    comma_dir = tmp_path / "ws,evil"
+    comma_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(CONFIG, "workspace_dir", str(comma_dir))
+
+    from src.tools.executor import _resolve_workspace
+
+    with pytest.raises(ValueError, match="comma"):
+        _resolve_workspace()
+
+
+def test_web_read_large_file_does_not_load_full_content(workspace_app, temp_workspace):
+    """Reading a file larger than MAX_READ_SIZE should not load the full file."""
+    from src.web.routers.workspace import MAX_READ_SIZE
+
+    # Create a file larger than the read cap
+    large_content = "x" * (MAX_READ_SIZE + 4096)
+    (temp_workspace / "large.txt").write_text(large_content)
+
+    resp = workspace_app.get("/api/workspace/file", params={"path": "large.txt"})
+    assert resp.status_code == 200
+    data = resp.json()
+    # The returned content should be truncated, not the full file
+    assert "truncated" in data["content"]
+    assert len(data["content"]) < len(large_content)
+    # The reported size should be the real file size
+    assert data["size"] == len(large_content)

--- a/tests/test_workspace_permissions.py
+++ b/tests/test_workspace_permissions.py
@@ -421,3 +421,121 @@ def test_web_read_large_file_does_not_load_full_content(workspace_app, temp_work
     assert len(data["content"]) < len(large_content)
     # The reported size should be the real file size
     assert data["size"] == len(large_content)
+
+
+# ---------------------------------------------------------------------------
+# Symlink-escape regression tests
+#
+# Deno authorizes a read/write THROUGH a symlink based on the link's location,
+# not its target, so a pre-existing symlink inside the workspace would turn
+# --allow-write=<workspace> into a write-outside primitive. The agent can't
+# create symlinks (covered above), but the workspace is persistent, so the
+# executor refuses to run while one exists and the web API refuses to follow it.
+# ---------------------------------------------------------------------------
+
+
+async def test_deno_refuses_run_when_workspace_has_symlink(
+    executor_with_workspace, temp_workspace, tmp_path
+):
+    """A pre-existing symlink in the workspace blocks execute_code (would
+    otherwise let scoped writes escape the workspace)."""
+    outside = tmp_path / "outside_secret.txt"
+    outside.write_text("ORIGINAL")
+    (temp_workspace / "escape").symlink_to(outside)  # planted, points outside
+
+    result = await executor_with_workspace.execute_code(
+        'await Deno.writeTextFile(WORKSPACE + "/escape", "CLOBBERED");\n'
+        "output({ ok: true });"
+    )
+    assert result["success"] is False, f"expected refusal, got: {result}"
+    assert "symlink" in result["error"].lower()
+    # The outside file must be untouched.
+    assert outside.read_text() == "ORIGINAL"
+
+
+async def test_deno_refuses_run_for_inside_pointing_symlink(
+    executor_with_workspace, temp_workspace
+):
+    """The guard rejects ANY symlink, even one pointing inside the workspace —
+    symlinks aren't a supported artifact and are the escape vector."""
+    (temp_workspace / "real.txt").write_text("x")
+    (temp_workspace / "inside_link").symlink_to(temp_workspace / "real.txt")
+
+    result = await executor_with_workspace.execute_code("output({ ok: true });")
+    assert result["success"] is False
+    assert "symlink" in result["error"].lower()
+
+
+async def test_custom_tool_refuses_run_when_workspace_has_symlink(
+    executor_with_workspace, temp_workspace, tmp_path
+):
+    """The custom-tool path enforces the same symlink guard."""
+    outside = tmp_path / "ct_outside.txt"
+    outside.write_text("ORIG")
+    (temp_workspace / "ln").symlink_to(outside)
+
+    result = await executor_with_workspace.execute_custom_tool_code(
+        'await Deno.writeTextFile(WORKSPACE + "/ln", "X");\noutput({ ok: true });',
+        params={},
+    )
+    assert result["success"] is False
+    assert "symlink" in result["error"].lower()
+    assert outside.read_text() == "ORIG"
+
+
+async def test_condition_code_runs_despite_workspace_symlink(
+    executor_with_workspace, temp_workspace, tmp_path
+):
+    """Condition code gets no workspace access, so the symlink guard does not
+    apply and it still runs (the guard is scoped to workspace-granting paths)."""
+    (temp_workspace / "ln").symlink_to(tmp_path / "whatever")  # dangling is fine
+    result = await executor_with_workspace.execute_condition_code("output({ ok: true });")
+    assert result["success"] is True
+
+
+async def test_workspace_over_quota_refuses_execution(
+    executor_with_workspace, temp_workspace, monkeypatch
+):
+    """Execution is refused when the workspace already exceeds its size quota."""
+    monkeypatch.setattr(CONFIG, "workspace_max_size_mb", 1)  # 1 MB cap
+    (temp_workspace / "big.bin").write_bytes(b"\0" * (2 * 1024 * 1024))  # 2 MB
+
+    result = await executor_with_workspace.execute_code("output({ ok: true });")
+    assert result["success"] is False
+    assert "size limit" in result["error"].lower()
+
+
+def test_web_read_rejects_symlink(workspace_app, temp_workspace, tmp_path):
+    """The read endpoint refuses to follow a symlink out of the workspace."""
+    outside = tmp_path / "secret.txt"
+    outside.write_text("SECRET")
+    (temp_workspace / "ln").symlink_to(outside)
+
+    resp = workspace_app.get("/api/workspace/file", params={"path": "ln"})
+    assert resp.status_code == 403
+
+
+def test_web_delete_rejects_symlink(workspace_app, temp_workspace, tmp_path):
+    """The delete endpoint refuses a symlink path and leaves the target intact."""
+    outside = tmp_path / "secret2.txt"
+    outside.write_text("SECRET")
+    (temp_workspace / "ln2").symlink_to(outside)
+
+    resp = workspace_app.delete("/api/workspace/file", params={"path": "ln2"})
+    assert resp.status_code == 403
+    assert outside.read_text() == "SECRET"  # untouched
+
+
+def test_web_list_skips_symlinks(workspace_app, temp_workspace, tmp_path):
+    """Listing skips symlink entries so it can't leak metadata about files
+    outside the workspace."""
+    outside = tmp_path / "exists.txt"
+    outside.write_text("data")
+    (temp_workspace / "real.txt").write_text("hi")
+    (temp_workspace / "ln3").symlink_to(outside)  # points at an existing outside file
+
+    resp = workspace_app.get("/api/workspace", params={"path": ""})
+    assert resp.status_code == 200
+    names = [e["name"] for e in resp.json()["entries"]]
+    assert "real.txt" in names
+    assert "ln3" not in names

--- a/tests/test_workspace_permissions.py
+++ b/tests/test_workspace_permissions.py
@@ -609,3 +609,23 @@ def test_web_read_rejects_hardlink(workspace_app, temp_workspace, tmp_path):
     resp = workspace_app.get("/api/workspace/file", params={"path": "hl"})
     assert resp.status_code == 404
     assert outside.read_text() == "SECRET"
+
+
+async def test_deno_refuses_run_with_special_file(executor_with_workspace, temp_workspace):
+    """A planted special file (FIFO/device/socket) blocks execution — only
+    regular files and directories are supported workspace artifacts."""
+    os.mkfifo(temp_workspace / "pipe")
+    result = await executor_with_workspace.execute_code("output({ ok: true });")
+    assert result["success"] is False
+    assert "special file" in result["error"].lower()
+
+
+def test_web_list_rejects_hardlink_metadata(workspace_app, temp_workspace, tmp_path):
+    """Requesting a multi-linked file directly via list must not leak its
+    metadata (mirrors the read endpoint)."""
+    outside = tmp_path / "hl_meta.txt"
+    outside.write_text("SECRET")
+    os.link(outside, temp_workspace / "hl")
+
+    resp = workspace_app.get("/api/workspace", params={"path": "hl"})
+    assert resp.status_code == 404

--- a/tests/test_workspace_permissions.py
+++ b/tests/test_workspace_permissions.py
@@ -539,3 +539,73 @@ def test_web_list_skips_symlinks(workspace_app, temp_workspace, tmp_path):
     names = [e["name"] for e in resp.json()["entries"]]
     assert "real.txt" in names
     assert "ln3" not in names
+
+
+# ---------------------------------------------------------------------------
+# Hardlink-escape regression tests
+#
+# A hardlink is a regular file (no symlink, O_NOFOLLOW doesn't help). If its
+# inode also has a link OUTSIDE the workspace, writing it modifies / reading it
+# discloses out-of-workspace data. The agent cannot create such a link (Deno
+# denies it), but a pre-existing one (operator/backup/other process) must be
+# rejected — symmetric with the symlink guard.
+# ---------------------------------------------------------------------------
+
+
+async def test_deno_refuses_run_with_external_hardlink(
+    executor_with_workspace, temp_workspace, tmp_path
+):
+    """A hardlink to an outside file blocks execution."""
+    outside = tmp_path / "hl_outside.txt"
+    outside.write_text("ORIGINAL")
+    os.link(outside, temp_workspace / "hl")  # hardlink into the workspace
+
+    result = await executor_with_workspace.execute_code(
+        'await Deno.writeTextFile(WORKSPACE + "/hl", "CLOBBERED");\noutput({ ok: true });'
+    )
+    assert result["success"] is False, f"expected refusal, got: {result}"
+    assert "hardlink" in result["error"].lower()
+    assert outside.read_text() == "ORIGINAL"
+
+
+async def test_deno_allows_internal_hardlink(executor_with_workspace, temp_workspace):
+    """A hardlink whose links are all INSIDE the workspace is fine — the guard
+    must not brick the agent on a self-created internal hardlink."""
+    (temp_workspace / "a.txt").write_text("data")
+    os.link(temp_workspace / "a.txt", temp_workspace / "b.txt")  # both inside
+
+    result = await executor_with_workspace.execute_code("output({ ok: true });")
+    assert result["success"] is True, f"internal hardlink should be allowed: {result}"
+
+
+async def test_deno_cannot_create_escaping_hardlink(
+    executor_with_workspace, temp_workspace, tmp_path
+):
+    """The agent itself cannot Deno.link an outside file into the workspace
+    (Deno denies read on the outside source) — locks in the runtime behavior."""
+    src = tmp_path / "link_src.txt"
+    src.write_text("x")
+    code = (
+        "try {\n"
+        f"  await Deno.link({json.dumps(str(src))}, WORKSPACE + \"/x\");\n"
+        "  output({ created: true });\n"
+        "} catch (e) {\n"
+        "  output({ created: false, error: e instanceof Error ? e.message : String(e) });\n"
+        "}"
+    )
+    result = await executor_with_workspace.execute_code(code)
+    assert result["success"], f"code should run, got: {result}"
+    assert result["output"]["created"] is False
+    err = result["output"]["error"].lower()
+    assert any(k in err for k in ("permission", "notcapable", "denied", "read access", "allow-read"))
+
+
+def test_web_read_rejects_hardlink(workspace_app, temp_workspace, tmp_path):
+    """The read endpoint refuses a multi-linked file (possible hardlink-out)."""
+    outside = tmp_path / "hl_secret.txt"
+    outside.write_text("SECRET")
+    os.link(outside, temp_workspace / "hl")
+
+    resp = workspace_app.get("/api/workspace/file", params={"path": "hl"})
+    assert resp.status_code == 404
+    assert outside.read_text() == "SECRET"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import { SystemPromptView } from "./components/system-prompt/SystemPromptView";
 import { MCPView } from "./components/mcp/MCPView";
 import { MCPServerDetail } from "./components/mcp/MCPServerDetail";
 import { MemoryView } from "./components/memory/MemoryView";
+import { WorkspaceView } from "./components/workspace/WorkspaceView";
 
 export default function App() {
   return (
@@ -27,6 +28,7 @@ export default function App() {
           <Route path="/mcp/:name" element={<MCPServerDetail />} />
           <Route path="/system-prompt" element={<SystemPromptView />} />
           <Route path="/memory" element={<MemoryView />} />
+          <Route path="/workspace" element={<WorkspaceView />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,11 +1,12 @@
 import { Outlet, Link, useLocation } from "react-router-dom";
-import { MessageSquare, Wrench, Key, Clock, FileText, Plug, Brain } from "lucide-react";
+import { MessageSquare, Wrench, Key, Clock, FileText, Plug, Brain, FolderOpen } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const navItems = [
   { to: "/sessions", label: "Sessions", icon: MessageSquare },
   { to: "/tools", label: "Tools", icon: Wrench },
   { to: "/mcp", label: "MCP", icon: Plug },
+  { to: "/workspace", label: "Workspace", icon: FolderOpen },
   { to: "/secrets", label: "Secrets", icon: Key },
   { to: "/schedules", label: "Schedules", icon: Clock },
   { to: "/system-prompt", label: "Prompt", icon: FileText },

--- a/web/src/components/workspace/WorkspaceView.tsx
+++ b/web/src/components/workspace/WorkspaceView.tsx
@@ -1,0 +1,321 @@
+import { useEffect, useState, useCallback } from "react";
+import {
+  Folder,
+  File as FileIcon,
+  Trash2,
+  ChevronRight,
+  FolderPlus,
+  HardDrive,
+} from "lucide-react";
+import { api } from "@/lib/api";
+import type { WorkspaceEntry, WorkspaceFile } from "@/lib/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+function formatSize(bytes: number | null): string {
+  if (bytes === null) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatRelative(iso: string): string {
+  if (!iso) return "";
+  try {
+    const d = new Date(iso);
+    const now = new Date();
+    const diff = now.getTime() - d.getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return "just now";
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days < 7) return `${days}d ago`;
+    return d.toLocaleDateString();
+  } catch {
+    return "";
+  }
+}
+
+export function WorkspaceView() {
+  const [currentPath, setCurrentPath] = useState("");
+  const [entries, setEntries] = useState<WorkspaceEntry[]>([]);
+  const [totalSize, setTotalSize] = useState(0);
+  const [maxSize, setMaxSize] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [fileContent, setFileContent] = useState<WorkspaceFile | null>(null);
+  const [fileLoading, setFileLoading] = useState(false);
+  const [showNewDir, setShowNewDir] = useState(false);
+  const [newDirName, setNewDirName] = useState("");
+
+  const refresh = useCallback(async (path: string) => {
+    setError("");
+    try {
+      const result = await api.listWorkspace(path);
+      setEntries(result.entries);
+      setTotalSize(result.total_size_bytes);
+      setMaxSize(result.max_size_bytes);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load workspace");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    setLoading(true);
+    setFileContent(null);
+    refresh(currentPath);
+  }, [currentPath, refresh]);
+
+  const navigateTo = (path: string) => {
+    setCurrentPath(path);
+  };
+
+  const navigateUp = () => {
+    const parts = currentPath.split("/").filter(Boolean);
+    parts.pop();
+    setCurrentPath(parts.join("/"));
+  };
+
+  const breadcrumbs = currentPath
+    ? currentPath.split("/").filter(Boolean)
+    : [];
+
+  const handleClick = async (entry: WorkspaceEntry) => {
+    const fullPath = currentPath
+      ? `${currentPath}/${entry.name}`
+      : entry.name;
+
+    if (entry.type === "directory") {
+      navigateTo(fullPath);
+      return;
+    }
+
+    // File — load content
+    setFileLoading(true);
+    setFileContent(null);
+    try {
+      const result = await api.readWorkspaceFile(fullPath);
+      setFileContent(result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to read file");
+    } finally {
+      setFileLoading(false);
+    }
+  };
+
+  const handleDelete = async (entry: WorkspaceEntry) => {
+    const fullPath = currentPath
+      ? `${currentPath}/${entry.name}`
+      : entry.name;
+    if (!confirm(`Delete "${entry.name}"?${entry.type === "directory" ? " This will remove the directory and all its contents." : ""}`)) return;
+    try {
+      await api.deleteWorkspaceFile(fullPath);
+      setFileContent(null);
+      await refresh(currentPath);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to delete");
+    }
+  };
+
+  const handleCreateDir = async () => {
+    if (!newDirName.trim()) return;
+    const fullPath = currentPath
+      ? `${currentPath}/${newDirName.trim()}`
+      : newDirName.trim();
+    try {
+      await api.createWorkspaceDir(fullPath);
+      setNewDirName("");
+      setShowNewDir(false);
+      await refresh(currentPath);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create directory");
+    }
+  };
+
+  const sizePercent = maxSize > 0 ? Math.min(100, (totalSize / maxSize) * 100) : 0;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between px-6 py-3">
+        <h2 className="text-lg font-semibold">Workspace</h2>
+        <Button size="sm" onClick={() => setShowNewDir(true)}>
+          <FolderPlus className="mr-1 h-4 w-4" /> New Dir
+        </Button>
+      </div>
+
+      {/* Size indicator */}
+      <div className="flex items-center gap-2 px-6 pb-2">
+        <HardDrive className="h-4 w-4 text-muted-foreground" />
+        <div className="flex-1 h-2 rounded-full bg-muted overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all ${
+              sizePercent > 90 ? "bg-red-500" : "bg-blue-500"
+            }`}
+            style={{ width: `${sizePercent}%` }}
+          />
+        </div>
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          {formatSize(totalSize)} / {formatSize(maxSize)}
+        </span>
+      </div>
+
+      {/* Breadcrumbs */}
+      <div className="flex items-center gap-1 px-6 pb-2 text-sm">
+        <button
+          className="text-muted-foreground hover:text-foreground"
+          onClick={() => navigateTo("")}
+        >
+          workspace
+        </button>
+        {breadcrumbs.map((part, i) => {
+          const path = breadcrumbs.slice(0, i + 1).join("/");
+          const isLast = i === breadcrumbs.length - 1;
+          return (
+            <span key={path} className="flex items-center gap-1">
+              <ChevronRight className="h-3 w-3 text-muted-foreground" />
+              {isLast ? (
+                <span className="font-medium">{part}</span>
+              ) : (
+                <button
+                  className="text-muted-foreground hover:text-foreground"
+                  onClick={() => navigateTo(path)}
+                >
+                  {part}
+                </button>
+              )}
+            </span>
+          );
+        })}
+        {currentPath && (
+          <button
+            className="ml-2 text-xs text-muted-foreground hover:text-foreground"
+            onClick={navigateUp}
+          >
+            ↑ up
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="px-6 pb-2 text-sm text-red-500">{error}</div>
+      )}
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* File list */}
+        <ScrollArea className="flex-1">
+          <div className="px-3 pb-4">
+            {loading ? (
+              <div className="px-3 py-8 text-center text-muted-foreground">Loading…</div>
+            ) : entries.length === 0 ? (
+              <div className="px-3 py-8 text-center text-muted-foreground">
+                Empty directory. The agent hasn't written any files here yet.
+              </div>
+            ) : (
+              <div className="flex flex-col gap-0.5">
+                {entries.map((entry) => (
+                  <div
+                    key={entry.name}
+                    className="group flex items-center gap-2 rounded-md px-3 py-2 hover:bg-accent cursor-pointer"
+                    onClick={() => handleClick(entry)}
+                  >
+                    {entry.type === "directory" ? (
+                      <Folder className="h-4 w-4 text-blue-500 flex-shrink-0" />
+                    ) : (
+                      <FileIcon className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                    )}
+                    <span className="text-sm truncate flex-1">{entry.name}</span>
+                    {entry.size !== null && (
+                      <span className="text-xs text-muted-foreground">
+                        {formatSize(entry.size)}
+                      </span>
+                    )}
+                    <span className="text-xs text-muted-foreground">
+                      {formatRelative(entry.modified)}
+                    </span>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 opacity-0 group-hover:opacity-100"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDelete(entry);
+                      }}
+                    >
+                      <Trash2 className="h-3.5 w-3.5 text-red-500" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+
+        {/* File content panel */}
+        {(fileContent || fileLoading) && (
+          <div className="w-1/2 border-l border-border flex flex-col">
+            <div className="flex items-center justify-between px-4 py-2 border-b border-border">
+              <span className="text-sm font-medium truncate">
+                {fileContent?.path ?? "Loading…"}
+              </span>
+              {fileContent && (
+                <span className="text-xs text-muted-foreground ml-2">
+                  {formatSize(fileContent.size)}
+                </span>
+              )}
+            </div>
+            <ScrollArea className="flex-1">
+              <div className="p-4">
+                {fileLoading ? (
+                  <div className="text-center text-muted-foreground">Loading…</div>
+                ) : fileContent ? (
+                  <pre className="whitespace-pre-wrap text-sm font-mono">
+                    {fileContent.content}
+                  </pre>
+                ) : null}
+              </div>
+            </ScrollArea>
+          </div>
+        )}
+      </div>
+
+      {/* New directory dialog */}
+      <Dialog open={showNewDir} onOpenChange={setShowNewDir}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Directory</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-3">
+            {error && <div className="text-sm text-red-500">{error}</div>}
+            <div>
+              <label className="text-sm font-medium">
+                {currentPath ? `in ${currentPath}/` : "in workspace root"}
+              </label>
+              <Input
+                value={newDirName}
+                onChange={(e) => setNewDirName(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleCreateDir()}
+                placeholder="directory name"
+                autoFocus
+              />
+            </div>
+            <Button onClick={handleCreateDir} disabled={!newDirName.trim()}>
+              Create
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -13,6 +13,8 @@ import type {
   SystemPrompt,
   ToolDetail,
   ToolSummary,
+  WorkspaceFile,
+  WorkspaceListing,
 } from "./types";
 
 const API_BASE = "/api";
@@ -325,5 +327,25 @@ export const api = {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ redirect_url: redirectUrl }),
       },
+    ),
+
+  // -- workspace --
+
+  listWorkspace: (path = "") =>
+    fetchJSON<WorkspaceListing>(`${API_BASE}/workspace?path=${enc(path)}`),
+
+  readWorkspaceFile: (path: string) =>
+    fetchJSON<WorkspaceFile>(`${API_BASE}/workspace/file?path=${enc(path)}`),
+
+  deleteWorkspaceFile: (path: string) =>
+    fetchJSON<{ deleted: string }>(
+      `${API_BASE}/workspace/file?path=${enc(path)}`,
+      { method: "DELETE" },
+    ),
+
+  createWorkspaceDir: (path: string) =>
+    fetchJSON<{ created: string }>(
+      `${API_BASE}/workspace/dir?path=${enc(path)}`,
+      { method: "POST" },
     ),
 };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -151,3 +151,26 @@ export interface MemorySearchResult {
 export interface MemorySearchResponse {
   results: MemorySearchResult[];
 }
+
+// -- workspace --
+
+export interface WorkspaceEntry {
+  name: string;
+  type: "file" | "directory";
+  size: number | null;
+  modified: string;
+}
+
+export interface WorkspaceListing {
+  path: string;
+  entries: WorkspaceEntry[];
+  total_size_bytes: number;
+  max_size_bytes: number;
+}
+
+export interface WorkspaceFile {
+  path: string;
+  content: string;
+  size: number;
+  modified: string;
+}


### PR DESCRIPTION
## Summary

Give the agent a persistent, operator-granted workspace directory where it can read and write files using Deno's native file APIs. This unlocks multi-file projects, shared libraries, self-testing, and artifact generation — the foundation for agent self-improvement through tool development.

## What changed

### Backend (Deno sandbox)
- **`src/config.py`** — added `workspace_dir` (default `data/workspace`) and `workspace_max_size_mb` (default 1024) config fields
- **`src/tools/executor.py`** — core security change:
  - `_run_deno` (execute_code path): `--deny-write` replaced with scoped `--allow-write=<workspace>`, workspace added to `--allow-read` allow-list
  - `_run_deno_with_permissions` (custom tools path): new `allow_workspace` parameter (default `True`); when `True`, grants scoped workspace read/write; when `False` (condition code), keeps `--deny-write` unchanged
  - `WORKSPACE` TypeScript constant injected into `execute_code` and `execute_custom_tool_code` preambles via `json.dumps()` for safe path escaping
  - All other deny flags retained verbatim (`--deny-net`, `--deny-env`, `--deny-run`, `--deny-ffi`, `--deny-sys`, `--no-prompt`, `--no-remote`, `--no-npm`)
- **`src/agent/prompt.py`** — added `## Workspace` section to system prompt documenting the `WORKSPACE` constant, file APIs, dynamic imports, and self-improvement workflow; corrected `CUSTOM_TOOLS_TEMPLATE` execution environment description
- **`main.py`** — workspace directory created at startup via `_ensure_workspace_dir()` in all three commands (`main`, `chat`, `serve`)

### Web API
- **`src/web/routers/workspace.py`** (new) — four endpoints:
  - `GET /api/workspace` — list directory contents, returns entries + total/max size
  - `GET /api/workspace/file` — read file content (256KB cap)
  - `DELETE /api/workspace/file` — delete file or directory (rejects workspace root deletion)
  - `POST /api/workspace/dir` — create directory
  - All endpoints protected with `Path.resolve()` + `relative_to()` traversal checks
- **`src/web/app.py`** — router registered

### Frontend
- **`web/src/components/workspace/WorkspaceView.tsx`** (new) — file browser with breadcrumb nav, file/directory listing, content viewer panel, delete with confirmation, mkdir dialog, and workspace size indicator (progress bar)
- Nav item (`FolderOpen` icon) and `/workspace` route added

### Tests
- **`tests/test_workspace_permissions.py`** (new) — 28 tests:
  - Deno can write/read/mkdir inside workspace ✓
  - Deno cannot write outside workspace or via path traversal ✓
  - Deno cannot create symlinks ✓
  - Dynamic import from workspace works (`await import(WORKSPACE + "/mod.ts")`) ✓
  - `WORKSPACE` constant correct in both execute_code and custom tool paths ✓
  - Condition code has no `WORKSPACE` constant and cannot write files ✓
  - Web API rejects path traversal on all 4 endpoints ✓
  - Web API rejects deleting workspace root ✓
  - CSRF protection on POST/DELETE ✓
  - All 314 tests pass (28 new + 286 existing, zero regressions)

### Docs
- **`README.md`** — added Workspace section with security model and configuration; updated Storage and Tool Calling sections

## Security model

The workspace stays inside Deno's trust boundary. No Python execution, no shell access, no process spawning. The agent writes TypeScript that runs in the same Deno sandbox, just with scoped filesystem access added.

| Risk | Mitigation |
|------|------------|
| Path traversal | Deno `--allow-write=<workspace>` scoping + Python-side `Path.resolve()` + `relative_to()` |
| Symlink escape | Deno denies `Deno.symlink()` — not covered by `--allow-write` |
| Disk exhaustion | Configurable size limit (default 1GB) with monitoring + web UI visibility |
| Secret persistence | Already exists (memory entries, tool code). Workspace adds no new exfil pathway. Mitigated by operator visibility via web UI file browser. |

## Test plan

- [x] `pytest tests/test_workspace_permissions.py` — 28 tests pass
- [x] `pytest tests/` — all 314 tests pass, zero regressions
- [x] `npx tsc --noEmit` in `web/` — TypeScript compiles cleanly
- [ ] Manual: start `serve`, write a file via `execute_code`, verify it appears in `/workspace` web UI