### PR TITLE
Fix all 7 bugs from the src/ bug hunt

### DIFF
--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -733,6 +733,50 @@ class Agent:
             else:
                 i += 1
 
+        # Second pass: neutralize orphaned tool_results — tool_result blocks
+        # whose tool_use_id has no matching tool_use anywhere in the
+        # conversation. This happens when compaction's char-budget split
+        # removes an assistant tool_use message but leaves its tool_result,
+        # which the Anthropic API rejects with a 400.
+        all_tool_use_ids: set[str] = set()
+        for msg in conversation:
+            if msg.get("role") != "assistant":
+                continue
+            content = msg.get("content", [])
+            if not isinstance(content, list):
+                continue
+            for b in content:
+                if isinstance(b, dict) and b.get("type") == "tool_use":
+                    all_tool_use_ids.add(b["id"])
+
+        for i, msg in enumerate(conversation):
+            if msg.get("role") != "user":
+                continue
+            content = msg.get("content", [])
+            if not isinstance(content, list):
+                continue
+            new_content: list = []
+            changed = False
+            for b in content:
+                if (
+                    isinstance(b, dict)
+                    and b.get("type") == "tool_result"
+                    and b.get("tool_use_id") not in all_tool_use_ids
+                ):
+                    new_content.append({
+                        "type": "text",
+                        "text": "[orphaned tool result removed]",
+                    })
+                    changed = True
+                    continue
+                new_content.append(b)
+            if changed:
+                logger.warning(
+                    "Neutralized orphaned tool_result(s) at conversation index %d",
+                    i,
+                )
+                conversation[i] = {**msg, "content": new_content}
+
     def _trim_old_tool_results(self, conversation: list[dict[str, Any]]) -> None:
         """Replace verbose tool_result content with a short summary for older messages.
 

--- a/src/discord_bot/bot.py
+++ b/src/discord_bot/bot.py
@@ -192,6 +192,13 @@ class DiscordBot:
         self._agent = agent
         self._executor = executor
 
+        # Per-thread locks to serialize concurrent messages in the same
+        # Discord thread (which maps to a single chat session). Without
+        # this, two rapid messages interleave load/save/agent.chat and
+        # corrupt the conversation history.
+        self._session_locks: dict[str, asyncio.Lock] = {}
+        self._locks_guard = asyncio.Lock()
+
         # Parse the allowlist of Discord user IDs
         raw_ids = CONFIG.discord_allowed_user_ids.strip()
         if raw_ids:
@@ -232,6 +239,13 @@ class DiscordBot:
             self._channel_name,
         )
 
+    async def _get_thread_lock(self, thread_id: str) -> asyncio.Lock:
+        """Return (or create) the per-thread serialization lock."""
+        async with self._locks_guard:
+            if thread_id not in self._session_locks:
+                self._session_locks[thread_id] = asyncio.Lock()
+            return self._session_locks[thread_id]
+
     async def on_message(self, message: discord.Message) -> None:
         # Ignore self and other bots
         if message.author == self._client.user or message.author.bot:
@@ -251,14 +265,21 @@ class DiscordBot:
         if thread is None:
             return  # not in our sessions channel
 
-        try:
-            await self._handle_message(message, thread)
-        except Exception as e:
-            logger.exception("Discord message handling failed")
+        lock = await self._get_thread_lock(str(thread.id))
+        async with lock:
             try:
-                await thread.send(f"⚠️ Error: `{type(e).__name__}`: {e}")
-            except Exception:
-                pass
+                await self._handle_message(message, thread)
+            except Exception as e:
+                logger.exception("Discord message handling failed")
+                try:
+                    await thread.send(f"⚠️ Error: `{type(e).__name__}`: {e}")
+                except Exception:
+                    pass
+        # Prune the lock if no other task is waiting on it
+        if not lock.locked():
+            async with self._locks_guard:
+                if not lock.locked():
+                    self._session_locks.pop(str(thread.id), None)
 
     async def _resolve_thread(
         self, message: discord.Message

--- a/src/memory/store.py
+++ b/src/memory/store.py
@@ -141,8 +141,8 @@ class MemoryStore:
         """
         now = _now()
 
+        # Step 1: short locked read of current values
         async with self._write_lock:
-            # Fetch current values inside the lock to prevent read-modify-write races
             cur = await self._db.execute(
                 "SELECT content, metadata FROM memory_entries WHERE id = ?",
                 (id,),
@@ -154,25 +154,28 @@ class MemoryStore:
             current_content = row[0]
             current_meta = row[1]
 
-            new_content = content if content is not None else current_content
-            if metadata is not None:
-                new_meta = json.dumps(metadata)
-            else:
-                new_meta = current_meta
+        # Step 2: compute new values and regenerate embedding OUTSIDE the
+        # lock so a slow embed doesn't block all other store writes.
+        new_content = content if content is not None else current_content
+        if metadata is not None:
+            new_meta = json.dumps(metadata)
+        else:
+            new_meta = current_meta
 
-            # Regenerate embedding if content changed
-            new_embedding: bytes | None = None
-            regenerate_embedding = content is not None and self._embedding_client is not None
-            if regenerate_embedding:
-                try:
-                    new_embedding = await self._embedding_client.embed(new_content)
-                except Exception:
-                    logger.warning("Failed to regenerate embedding on update", exc_info=True)
-                    new_embedding = None
+        new_embedding: bytes | None = None
+        regenerate_embedding = content is not None and self._embedding_client is not None
+        if regenerate_embedding:
+            try:
+                new_embedding = await self._embedding_client.embed(new_content)
+            except Exception:
+                logger.warning("Failed to regenerate embedding on update", exc_info=True)
+                new_embedding = None
 
-            # Validate embedding size before storing
-            new_embedding = self._validate_embedding(new_embedding)
+        # Validate embedding size before storing
+        new_embedding = self._validate_embedding(new_embedding)
 
+        # Step 3: locked UPDATE with precomputed values
+        async with self._write_lock:
             try:
                 await self._db.execute("BEGIN IMMEDIATE")
                 if regenerate_embedding and new_embedding is not None:

--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -96,11 +96,13 @@ class Scheduler:
         on_fire: Callable[[str, str], Awaitable[str]] | None = None,
         condition_runner: ConditionRunner | None = None,
         legacy_path: Path | None = None,
+        fire_timeout_seconds: int = 600,
     ) -> None:
         self._store = store
         self._on_fire = on_fire
         self._condition_runner = condition_runner
         self._legacy_path = legacy_path
+        self._fire_timeout = fire_timeout_seconds
         self._tasks: dict[str, ScheduledTask] = {}
         self._running = False
 
@@ -397,18 +399,35 @@ class Scheduler:
         self._running = False
 
     async def _tick(self) -> None:
-        """Check all tasks and fire any that are due."""
+        """Check all tasks and fire any that are due.
+
+        Due tasks are fired concurrently so one slow callback cannot
+        starve the others.
+        """
         now = datetime.now(timezone.utc)
 
+        due: list[ScheduledTask] = []
         for task in list(self._tasks.values()):
             if not task.enabled:
                 continue
-
             try:
                 if self._is_due(task, now):
-                    await self._fire(task, now)
+                    due.append(task)
             except Exception:
-                logger.exception("Error checking/firing schedule '%s'", task.name)
+                logger.exception("Error checking schedule '%s'", task.name)
+
+        if not due:
+            return
+
+        results = await asyncio.gather(
+            *(self._fire(t, now) for t in due),
+            return_exceptions=True,
+        )
+        for task, result in zip(due, results):
+            if isinstance(result, Exception):
+                logger.exception(
+                    "Error firing schedule '%s'", task.name, exc_info=result
+                )
 
     def _is_due(self, task: ScheduledTask, now: datetime) -> bool:
         """Check if a task is due to run."""
@@ -453,7 +472,10 @@ class Scheduler:
         # --- Agent wake ---
         if self._on_fire:
             try:
-                response = await self._on_fire(task.name, task.prompt)
+                response = await asyncio.wait_for(
+                    self._on_fire(task.name, task.prompt),
+                    timeout=self._fire_timeout,
+                )
                 logger.info(
                     "Schedule '%s' completed: %s",
                     task.name,
@@ -463,6 +485,15 @@ class Scheduler:
                 task.last_run = now.isoformat()
                 task._retry_count = 0
                 task._condition_retry_count = 0
+                await self._save_task(task)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Schedule '%s' callback timed out after %ds — "
+                    "advancing last_run to prevent infinite retries",
+                    task.name, self._fire_timeout,
+                )
+                task.last_run = now.isoformat()
+                task._retry_count = 0
                 await self._save_task(task)
             except Exception:
                 task._retry_count += 1

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -437,6 +437,35 @@ import {{ output, debug }} from "./runtime.ts";
         # Maximum stderr bytes to capture (prevents memory exhaustion)
         MAX_STDERR_SIZE = 64 * 1024
 
+        # Drain stderr concurrently to avoid a pipe-buffer deadlock: if the
+        # process fills the OS stderr pipe buffer (~64KB) while nobody is
+        # reading it, the process blocks on stderr write, never produces
+        # stdout, and the readline loop below deadlocks until the read
+        # timeout.
+        async def _drain_stderr() -> bytes:
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                try:
+                    chunk = await process.stderr.read(MAX_STDERR_SIZE)
+                except Exception:
+                    break
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total <= MAX_STDERR_SIZE:
+                    chunks.append(chunk)
+                else:
+                    excess = total - MAX_STDERR_SIZE
+                    keep = len(chunk) - excess
+                    if keep > 0:
+                        chunks.append(chunk[:keep])
+                    chunks.append(b"\n... (stderr truncated)")
+                    break
+            return b"".join(chunks)
+
+        stderr_task = asyncio.create_task(_drain_stderr())
+
         outputs: list[Any] = []
         debug_messages: list[str] = []
         error: str | None = None
@@ -539,25 +568,17 @@ import {{ output, debug }} from "./runtime.ts";
 
         await process.wait()
 
-        # Read stderr with a size cap to prevent memory exhaustion
-        stderr_chunks: list[bytes] = []
-        stderr_total = 0
-        while True:
-            chunk = await process.stderr.read(MAX_STDERR_SIZE)
-            if not chunk:
-                break
-            stderr_total += len(chunk)
-            if stderr_total <= MAX_STDERR_SIZE:
-                stderr_chunks.append(chunk)
-            else:
-                # Truncate — keep what fits and add a marker
-                excess = stderr_total - MAX_STDERR_SIZE
-                keep = len(chunk) - excess
-                if keep > 0:
-                    stderr_chunks.append(chunk[:keep])
-                stderr_chunks.append(b"\n... (stderr truncated)")
-                break
-        stderr_content = b"".join(stderr_chunks)
+        # Await the concurrent stderr drain (the process has exited, so the
+        # stderr pipe will hit EOF quickly).
+        try:
+            stderr_content = await asyncio.wait_for(stderr_task, timeout=5.0)
+        except Exception:
+            stderr_task.cancel()
+            try:
+                await stderr_task
+            except Exception:
+                pass
+            stderr_content = b""
 
         if stderr_content:
             stderr_str = stderr_content.decode().strip()

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -323,6 +323,22 @@ import {{ output, debug }} from "./runtime.ts";
         except ProcessLookupError:
             pass
 
+    @staticmethod
+    def _minimal_env(extra: dict[str, str] | None = None) -> dict[str, str]:
+        """Build a minimal environment for Deno subprocesses.
+
+        Only PATH (for binary resolution) and HOME (for Deno's cache dir)
+        are inherited from the parent. Arbitrary parent env vars — including
+        API keys and secrets — are never passed through unless explicitly
+        granted via *extra*.
+        """
+        env: dict[str, str] = {
+            k: os.environ[k] for k in ("PATH", "HOME") if k in os.environ
+        }
+        if extra:
+            env.update(extra)
+        return env
+
     async def _run_deno(self, script_path: str) -> dict[str, Any]:
         """run the input script in a deno subprocess"""
 
@@ -347,6 +363,7 @@ import {{ output, debug }} from "./runtime.ts";
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=self._minimal_env(),
         )
 
         return await self._process_deno_output(process)
@@ -396,14 +413,8 @@ import {{ output, debug }} from "./runtime.ts";
         args.append(script_path)
 
         # Don't inherit the parent env wholesale — it can contain MODEL_API_KEY
-        # and other secrets the tool was never granted. Keep only the minimum
-        # Deno needs (PATH for binary resolution, HOME for its cache dir) and
-        # then layer on the explicitly-declared secrets.
-        proc_env: dict[str, str] = {
-            k: os.environ[k] for k in ("PATH", "HOME") if k in os.environ
-        }
-        if env:
-            proc_env.update(env)
+        # and other secrets the tool was never granted.
+        proc_env = self._minimal_env(env)
 
         process = await asyncio.create_subprocess_exec(
             *args,

--- a/src/web/routers/chat.py
+++ b/src/web/routers/chat.py
@@ -20,28 +20,17 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-# Per-session locks to serialize concurrent chat requests on the same session.
-# Without this, two simultaneous requests could interleave save/load/agent calls
-# and corrupt the conversation history.
-_session_locks: dict[str, asyncio.Lock] = {}
-# Guard dict mutation itself so check+create is atomic across concurrent requests.
+# Per-session in-flight tracking to serialize concurrent chat requests on the
+# same session. Without this, two simultaneous requests could interleave
+# save/load/agent calls and corrupt the conversation history.
+#
+# The session_id is added to _in_flight only when the event_stream generator
+# actually begins iterating — never before the StreamingResponse is returned.
+# This ensures a client that disconnects before the body is consumed cannot
+# leak the in-flight marker (which would permanently 409 the session).
+_in_flight: set[str] = set()
+# Guard set mutation itself so check+add is atomic across concurrent requests.
 _locks_guard = asyncio.Lock()
-
-
-async def _get_session_lock(session_id: str) -> asyncio.Lock:
-    async with _locks_guard:
-        if session_id not in _session_locks:
-            _session_locks[session_id] = asyncio.Lock()
-        return _session_locks[session_id]
-
-
-async def _release_session_lock(session_id: str, lock: asyncio.Lock) -> None:
-    """Release the lock and prune it from the dict if no one is waiting."""
-    async with _locks_guard:
-        lock.release()
-        # Only remove if no other task is waiting on it
-        if not lock.locked():
-            _session_locks.pop(session_id, None)
 
 
 def _sse(event: str, data: dict[str, Any] | None = None) -> str:
@@ -70,17 +59,21 @@ async def chat(
     if not user_text:
         raise HTTPException(400, "Message cannot be empty")
 
-    # Atomically acquire the per-session lock BEFORE returning the response.
-    # This ensures the 409 check and lock acquisition are not racy.
+    # Early peek: if a chat is already in-flight for this session, reject
+    # immediately. The authoritative check happens inside the generator to
+    # close the tiny race this peek can miss.
     async with _locks_guard:
-        if session_id not in _session_locks:
-            _session_locks[session_id] = asyncio.Lock()
-        lock = _session_locks[session_id]
-        if lock.locked():
+        if session_id in _in_flight:
             raise HTTPException(409, "A chat is already in progress for this session")
-        await lock.acquire()
 
     async def event_stream():
+        # Acquire the in-flight marker inside the generator so a client that
+        # disconnects before the body is consumed never leaks it.
+        async with _locks_guard:
+            if session_id in _in_flight:
+                yield _sse("error", {"message": "A chat is already in progress for this session"})
+                return
+            _in_flight.add(session_id)
         try:
             # 1. load full conversation history first — agent.chat() will
             # append the new user turn to this list in place
@@ -193,7 +186,8 @@ async def chat(
                     except (asyncio.CancelledError, Exception):
                         pass
         finally:
-            await _release_session_lock(session_id, lock)
+            async with _locks_guard:
+                _in_flight.discard(session_id)
 
     return StreamingResponse(
         event_stream(),

--- a/tests/test_compaction_agent.py
+++ b/tests/test_compaction_agent.py
@@ -295,3 +295,66 @@ async def test_load_session_with_ids_no_drop_tail(tmp_path):
     assert msgs_keep[0]["content"] == "unanswered question"
 
     await store.close()
+
+
+async def test_compaction_does_not_orphan_tool_result(tmp_path):
+    """After compaction + repair, no tool_result lacks a matching tool_use.
+
+    Compaction splits purely by char budget, so it can land between an
+    assistant tool_use message and its user tool_result message — orphaning
+    the tool_result. _repair_conversation must neutralize such orphans.
+    """
+    sub_llm = _StubSubLLM("Compacted summary.")
+    agent, store, _ = await _make_agent_with_stub_client(
+        tmp_path, sub_llm=sub_llm, compact_threshold=500
+    )
+
+    conversation = []
+    # padding messages to push us over the threshold
+    for i in range(6):
+        conversation.append({
+            "role": "user" if i % 2 == 0 else "assistant",
+            "content": f"Padding message {i} " * 20,
+        })
+    # assistant tool_use message
+    conversation.append({
+        "role": "assistant",
+        "content": [{
+            "type": "tool_use", "id": "tool_1",
+            "name": "execute_code", "input": {"code": "1+1"},
+        }],
+    })
+    # user tool_result — large enough that the char-budget split keeps it
+    # in `recent` while its matching tool_use falls into `older`.
+    conversation.append({
+        "role": "user",
+        "content": [{
+            "type": "tool_result", "tool_use_id": "tool_1",
+            "content": "R" * 400,
+        }],
+    })
+
+    await agent._maybe_compact(conversation)
+    agent._repair_conversation(conversation)
+
+    # Collect all tool_use ids present in the conversation
+    tool_use_ids: set[str] = set()
+    for msg in conversation:
+        content = msg.get("content", [])
+        if msg["role"] == "assistant" and isinstance(content, list):
+            for b in content:
+                if isinstance(b, dict) and b.get("type") == "tool_use":
+                    tool_use_ids.add(b["id"])
+
+    # Assert: every tool_result has a matching tool_use
+    for msg in conversation:
+        content = msg.get("content", [])
+        if msg["role"] == "user" and isinstance(content, list):
+            for b in content:
+                if isinstance(b, dict) and b.get("type") == "tool_result":
+                    assert b["tool_use_id"] in tool_use_ids, (
+                        f"Orphaned tool_result for tool_use_id={b['tool_use_id']} "
+                        f"with no matching tool_use in conversation"
+                    )
+
+    await store.close()

--- a/tests/test_discord_serialization.py
+++ b/tests/test_discord_serialization.py
@@ -1,0 +1,96 @@
+"""Tests for Discord bot per-thread message serialization."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.config import CONFIG
+from src.store.store import Store
+from src.tools.registry import ToolContext
+
+
+@pytest.mark.asyncio
+async def test_discord_serializes_same_thread_messages(tmp_path: Path):
+    """Concurrent messages in the same Discord thread must be serialized.
+
+    Without a per-thread lock, two rapid messages interleave load/save/
+    agent.chat and corrupt the conversation history.
+    """
+    from src.discord_bot.bot import DiscordBot
+
+    store = Store(path=tmp_path / "test.db")
+    await store.initialize()
+
+    ctx = ToolContext(store=store)
+    executor = MagicMock()
+    executor.store = store
+    executor.ctx = ctx
+    executor.llm_client = None
+
+    call_log: list[tuple[str, str]] = []
+
+    class SlowAgent:
+        async def chat(self, user_message, conversation=None, on_event=None,
+                       on_compact=None, images=None):
+            call_log.append(("start", user_message))
+            await asyncio.sleep(0.2)
+            call_log.append(("end", user_message))
+            return f"reply to {user_message}"
+
+    with patch.object(CONFIG, "discord_allowed_user_ids", ""):
+        bot = DiscordBot(
+            token="fake", channel_name="test",
+            agent=SlowAgent(), executor=executor,
+        )
+
+    # Mock Discord thread
+    thread = MagicMock()
+    thread.id = 12345
+    thread.send = AsyncMock()
+    thread.edit = AsyncMock()
+
+    class _FakeTyping:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    thread.typing = MagicMock(return_value=_FakeTyping())
+
+    # Bypass thread resolution
+    bot._resolve_thread = AsyncMock(return_value=thread)
+    bot._client = MagicMock()
+    bot._client.user = MagicMock()
+    bot._client.user.id = 0
+
+    def make_msg(content):
+        msg = MagicMock()
+        msg.author = MagicMock()
+        msg.author.bot = False
+        msg.author.id = 999
+        msg.content = content
+        msg.attachments = []
+        return msg
+
+    msg1 = make_msg("first")
+    msg2 = make_msg("second")
+
+    # Fire both concurrently
+    await asyncio.gather(
+        bot.on_message(msg1),
+        bot.on_message(msg2),
+    )
+
+    # Assert serialization: the first call must finish before the second starts.
+    # On current code (no lock), both start immediately and interleave.
+    starts = [i for i, (event, _) in enumerate(call_log) if event == "start"]
+    ends = [i for i, (event, _) in enumerate(call_log) if event == "end"]
+    assert len(starts) == 2 and len(ends) == 2
+    assert ends[0] < starts[1], (
+        "second message started before first completed — messages not serialized"
+    )
+
+    await store.close()

--- a/tests/test_env_isolation.py
+++ b/tests/test_env_isolation.py
@@ -1,0 +1,29 @@
+"""Tests for execute_code env isolation (Bug 07)."""
+
+import os
+from unittest.mock import patch
+
+from src.tools.executor import ToolExecutor
+
+
+def test_minimal_env_excludes_arbitrary_vars():
+    """_minimal_env should include only PATH and HOME — no secrets."""
+    sentinel = "VICTROLA_TEST_SECRET_BUG07"
+    with patch.dict(os.environ, {sentinel: "leaked", "PATH": "/usr/bin", "HOME": "/tmp"}):
+        env = ToolExecutor._minimal_env()
+
+    assert sentinel not in env, (
+        f"_minimal_env leaked parent env var {sentinel}"
+    )
+    assert env.get("PATH") == "/usr/bin"
+    assert env.get("HOME") == "/tmp"
+
+
+def test_minimal_env_with_extras():
+    """_minimal_env should layer on explicitly-provided vars only."""
+    with patch.dict(os.environ, {"PATH": "/usr/bin", "HOME": "/tmp", "SECRET": "x"}):
+        env = ToolExecutor._minimal_env({"GRANTED_KEY": "value"})
+
+    assert "SECRET" not in env
+    assert env["GRANTED_KEY"] == "value"
+    assert "PATH" in env

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -1,0 +1,61 @@
+"""Tests for MemoryStore write-lock discipline."""
+
+import asyncio
+
+import pytest
+
+from src.store.store import Store
+
+
+@pytest.mark.asyncio
+async def test_update_entry_does_not_hold_lock_during_embed(tmp_path):
+    """update_entry must release the shared write lock during the embed call.
+
+    Holding the global lock across an Ollama embed (which can take seconds)
+    blocks every other store write (documents, records, chat, memory).
+    add_entry already does its embed outside the lock; update_entry should
+    match.
+    """
+    store = Store(path=tmp_path / "test.db")
+    await store.initialize()
+
+    embed_started = asyncio.Event()
+    embed_can_finish = asyncio.Event()
+
+    class FakeEmbeddingClient:
+        async def embed(self, content):
+            embed_started.set()
+            await embed_can_finish.wait()
+            return b"\x00" * (768 * 4)
+
+    store.memory.set_embedding_client(FakeEmbeddingClient(), dimensions=768)
+
+    # Add an entry to update later (embed outside lock, so fast)
+    entry = await store.memory.add_entry(
+        type="factual",
+        scope="test",
+        content="original content",
+        embedding=b"\x00" * (768 * 4),
+    )
+    entry_id = entry["id"]
+
+    # Start update_entry in the background — it will call embed and block
+    update_task = asyncio.create_task(
+        store.memory.update_entry(entry_id, content="new content")
+    )
+
+    # Wait until embed is in-flight
+    await asyncio.wait_for(embed_started.wait(), timeout=5.0)
+
+    # While embed is still running, another store write that needs the same
+    # shared write lock should complete promptly. On current code this blocks
+    # because update_entry holds the lock during embed.
+    await asyncio.wait_for(
+        store.documents.create("test:concurrent", "data"),
+        timeout=3.0,
+    )
+
+    # Let embed finish and clean up
+    embed_can_finish.set()
+    await update_task
+    await store.close()

--- a/tests/test_pr12_scheduler_retry.py
+++ b/tests/test_pr12_scheduler_retry.py
@@ -1,5 +1,7 @@
 """Tests for PR 12: Fix scheduler — advance last_run after callback success."""
 
+import asyncio
+
 import pytest
 from datetime import datetime, timezone, timedelta
 from unittest.mock import AsyncMock, MagicMock
@@ -100,3 +102,41 @@ def test_is_due_no_write_side_effect():
     # Should return True (due now) without writing to last_run
     assert result is True
     assert task.last_run is None  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_slow_task_does_not_block_others(scheduler_with_store):
+    """A slow on_fire callback should not starve other due tasks.
+
+    On serial _tick, the slow task (first in dict order) blocks the fast
+    task indefinitely. With concurrent firing + a per-fire timeout, the
+    fast task completes within a bounded time.
+    """
+    s, _store = scheduler_with_store
+    s._fire_timeout = 0.5  # short timeout for test
+
+    fast_fired = asyncio.Event()
+
+    async def on_fire(name, prompt):
+        if name == "slow":
+            await asyncio.sleep(10)  # would block indefinitely without timeout
+        elif name == "fast":
+            fast_fired.set()
+        return "ok"
+
+    s._on_fire = on_fire
+
+    now = datetime.now(timezone.utc)
+    task_slow = ScheduledTask(name="slow", schedule="1h", prompt="slow")
+    task_slow.last_run = (now - timedelta(hours=2)).isoformat()
+    task_fast = ScheduledTask(name="fast", schedule="1h", prompt="fast")
+    task_fast.last_run = (now - timedelta(hours=2)).isoformat()
+
+    # slow is first so serial firing would block fast
+    s._tasks = {"slow": task_slow, "fast": task_fast}
+
+    await asyncio.wait_for(s._tick(), timeout=3.0)
+
+    assert fast_fired.is_set(), (
+        "fast task should have fired despite slow task blocking"
+    )

--- a/tests/test_pr17_deno_output.py
+++ b/tests/test_pr17_deno_output.py
@@ -100,3 +100,46 @@ async def test_stderr_capped():
     # The stderr should be truncated
     assert "error" in result
     assert "truncated" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_stderr_drained_concurrently_no_deadlock():
+    """_process_deno_output must drain stderr concurrently.
+
+    Without concurrent stderr draining, a process that fills its stderr
+    pipe buffer deadlocks: it can't write more to stderr (pipe full), so
+    it can't write to stdout, and the stdout readline loop blocks until
+    the read timeout.
+
+    This fake encodes that contract: stdout.readline() blocks until
+    stderr.read() has been called. On current code, stderr is only read
+    AFTER the stdout loop, so readline blocks for the full read timeout.
+    """
+    stderr_drained = asyncio.Event()
+
+    class _Stdout:
+        async def readline(self):
+            await stderr_drained.wait()
+            return b""  # EOF
+
+    class _Stderr:
+        async def read(self, n=-1):
+            stderr_drained.set()
+            return b""  # EOF
+
+    process = MagicMock()
+    process.stdin = MagicMock()
+    process.stdout = _Stdout()
+    process.stderr = _Stderr()
+    process.returncode = 0
+    process.pid = 12345
+    process.wait = AsyncMock(return_value=0)
+
+    executor = ToolExecutor(registry=ToolRegistry(), ctx=ToolContext())
+
+    # Should complete quickly (< 5s). On current code this blocks for
+    # the full read timeout (~30s) because stderr is never drained.
+    await asyncio.wait_for(
+        executor._process_deno_output(process),
+        timeout=5.0,
+    )

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -463,12 +463,10 @@ class TestChatSSE:
         resp = app_client.post("/api/sessions", json={"title": "concurrent"})
         rkey = resp.json()["rkey"]
 
-        # acquire the lock manually to simulate a chat in progress
-        from src.web.routers.chat import _session_locks
+        # mark the session as in-flight to simulate a chat in progress
+        from src.web.routers.chat import _in_flight
 
-        lock = asyncio.Lock()
-        app_client._loop.run_until_complete(lock.acquire())
-        _session_locks[rkey] = lock
+        _in_flight.add(rkey)
 
         try:
             resp = app_client.post(
@@ -476,7 +474,31 @@ class TestChatSSE:
             )
             assert resp.status_code == 409
         finally:
-            lock.release()
+            _in_flight.discard(rkey)
+
+    def test_chat_no_leak_after_completion(self, app_client):
+        """After a chat completes normally, the session must not be marked in-flight.
+
+        A client that disconnects before the stream body is consumed must not
+        leave the session permanently locked. The in-flight marker is set inside
+        the generator and removed in its finally block, so a never-iterated
+        generator (pre-iteration disconnect) leaks nothing.
+        """
+        from src.web.routers.chat import _in_flight
+
+        resp = app_client.post("/api/sessions", json={"title": "no-leak"})
+        rkey = resp.json()["rkey"]
+
+        # normal chat should succeed
+        resp = app_client.post(f"/api/sessions/{rkey}/chat", json={"message": "hello"})
+        assert resp.status_code == 200
+
+        # after completion, session must not be in-flight
+        assert rkey not in _in_flight
+
+        # a second chat on the same session should also succeed (not 409)
+        resp = app_client.post(f"/api/sessions/{rkey}/chat", json={"message": "again"})
+        assert resp.status_code == 200
 
 
 class TestMemory:


### PR DESCRIPTION
## Summary

Fixes all seven confirmed bugs from the `src/` bug hunt, each landed as an independent commit with a regression test (RED before fix, GREEN after).

## Bugs fixed

| # | Severity | Fix |
|---|----------|-----|
| **01** | High | **Compaction orphans tool_result to Anthropic 400.** `_repair_conversation` now runs a second pass that neutralizes `tool_result` blocks whose `tool_use_id` has no matching `tool_use` anywhere in the conversation. |
| **02** | Med-High | **Scheduler fires serially, one slow task starves all.** `_tick` now fires due tasks concurrently via `asyncio.gather`. Each `_fire` wraps its callback in `asyncio.wait_for` with a configurable timeout (default 600s). |
| **03** | Med-High | **Deno stderr pipe deadlock.** `_process_deno_output` now spawns a concurrent stderr drain task before the stdout readline loop, preventing deadlock when the subprocess writes >64KB to stderr. |
| **04** | Med-Low | **update_entry holds global write lock over Ollama embed.** Restructured into locked read, unlocked embed, locked UPDATE — mirroring add_entry's discipline. |
| **05** | Med | **Web SSE per-session lock leak on early disconnect.** Replaced pre-response lock acquisition with an in-flight set tracked inside the event_stream generator. A client that disconnects before the stream body is consumed leaks nothing. |
| **06** | Med | **Discord bot has no session serialization.** Added a per-thread lock map; on_message acquires the lock around _handle_message so concurrent messages in the same thread serialize. |
| **07** | Low-Med | **execute_code inherits full parent env incl. secrets.** Extracted _minimal_env helper (PATH + HOME only); _run_deno now passes env=self._minimal_env() instead of inheriting os.environ. |

## Behavior changes worth noting

- **Bug 02:** concurrent scheduled firing means two scheduled prompts can drive agent.chat at once. Each surface owns its own conversation list, so this is safe for the agent, but non-reentrant scheduled side effects are now concurrent.
- **Bug 04:** two concurrent update_entry calls on the same row id become last-writer-wins on content. Acceptable for this harness and strictly better than the status quo.

## Test plan

- [x] Each bug has a new regression test that was RED on the pre-fix code
- [x] Full pytest suite: 294 passed, no existing tests deleted or disabled
- [x] Bug 03 verified structurally + via mock (hard to reproduce deterministically in CI)
- [x] Bug 05 addressed structurally (ASGI test client cannot reproduce the pre-iteration window directly)
