### PR TITLE
fix: don't reconnect MCP server when a tool call merely times out

### DIFF
--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -903,6 +903,22 @@ class MCPManager:
                 }
             try:
                 return await conn.call_tool(tool_name, params)
+            except asyncio.TimeoutError:
+                # A call exceeding _CALL_TIMEOUT means the tool is slow, not
+                # that the connection is dead. Reconnecting the whole server
+                # here is futile (the retry would just time out again) and
+                # disruptive (it re-discovers and re-registers every tool and
+                # incurs OAuth round-trips). Return the timeout and leave the
+                # connection intact; the health monitor's ping reconnects
+                # genuinely dead links.
+                logger.warning(
+                    "MCP tool call timed out: %s.%s after %.0fs",
+                    server_name, tool_name, _CALL_TIMEOUT,
+                )
+                return {
+                    "error": f"MCP tool '{server_name}.{tool_name}' timed out "
+                    f"after {_CALL_TIMEOUT:.0f}s."
+                }
             except Exception as e:
                 logger.warning("MCP tool call failed: %s.%s: %s", server_name, tool_name, e)
                 # Attempt one bounded reconnection + retry. The full disconnect

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2412,3 +2412,52 @@ async def test_connect_all_propagates_genuine_cancellation(tmp_path):
 
     await manager.stop_health_monitor()
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_timeout_does_not_reconnect_server(tmp_path):
+    """A slow-but-healthy tool that times out must not tear down the server.
+
+    A tool call exceeding _CALL_TIMEOUT raises asyncio.TimeoutError. A timeout
+    means the tool is slow, not that the connection is dead: call_tool must
+    return an error and leave the connection intact rather than reconnecting the
+    whole server (re-discovering/re-registering every tool, OAuth round-trips)
+    and retrying. Genuinely dead links are handled by the health monitor's ping.
+    """
+    import asyncio
+
+    manager, store = await _make_manager(tmp_path)
+    config = MCPServerConfig(name="srv", transport="sse", url="https://example.com")
+    await manager.create_server(config)
+
+    slow_conn = MagicMock()
+    slow_conn.is_connected = True
+    slow_conn.connect = AsyncMock()
+    slow_conn.disconnect = AsyncMock()
+    slow_conn.list_tools = AsyncMock(return_value=[])
+    slow_conn.call_tool = AsyncMock(side_effect=asyncio.TimeoutError())
+
+    conn_count = 0
+
+    def conn_factory(*args, **kwargs):
+        nonlocal conn_count
+        conn_count += 1
+        return slow_conn
+
+    with patch("src.tools.mcp.MCPConnection", side_effect=conn_factory):
+        await manager.connect_server("srv")
+        result = await manager.call_tool("srv", "search", {"q": "test"})
+
+    assert isinstance(result, dict) and "error" in result
+    assert "timed out" in result["error"].lower()
+    # No reconnect: the tool was called exactly once (no retry) and no second
+    # connection was constructed.
+    slow_conn.call_tool.assert_awaited_once()
+    assert conn_count == 1, "call_tool reconnected the server on a slow-tool timeout"
+    slow_conn.disconnect.assert_not_awaited()
+    # The connection is left intact for the next call.
+    assert manager.is_connected("srv")
+
+    await manager.stop_health_monitor()
+    await manager.disconnect_server("srv")
+    await store.close()


### PR DESCRIPTION
## Problem

`MCPManager.call_tool` caught *every* exception from a tool call in one broad `except Exception` and responded by tearing down and reconnecting the entire server, then retrying once.

But `MCPConnection.call_tool` wraps the call in `asyncio.wait_for(..., timeout=_CALL_TIMEOUT)` (60s), so a **slow-but-healthy** tool raises `asyncio.TimeoutError` — indistinguishable, to the old code, from a dead connection. The result:

- The whole server is reconnected: re-discovers and re-registers **every** tool, plus OAuth round-trips.
- Worst case ~140s before the agent gets an error (60s call + up to 20s reconnect + 60s retry).
- The per-server lock is held the whole time, blocking every other tool on that server.
- The retry just times out again — the reconnect was futile.

## Fix

Classify the failure. A `asyncio.TimeoutError` means the tool is slow, not that the link is dead: return the timeout error and leave the connection intact. Connection-level exceptions keep the existing reconnect-and-retry path. Genuinely dead connections are still detected and reconnected by the health monitor's periodic ping.

## Tests

New `test_call_tool_timeout_does_not_reconnect_server`: a tool whose call raises `asyncio.TimeoutError` returns an error, is invoked exactly once (no retry), constructs no second connection (no reconnect), and leaves the server connected. Fails on the pre-fix code (which reconnects + retries).

Existing `test_call_tool_auto_reconnects_on_failure` / `test_call_tool_returns_error_when_reconnect_fails` (which use connection-level `RuntimeError`) still pass — that path is unchanged. Full suite: 307 passed.
