### PR TITLE
fix: retain a strong reference to detached MCP cleanup tasks

### DIFF
--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -419,6 +419,7 @@ class MCPManager:
         self._connections: dict[str, MCPConnection] = {}
         self._locks: dict[str, asyncio.Lock] = {}
         self._health_task: asyncio.Task | None = None
+        self._background_tasks: set[asyncio.Task] = set()
         # Per-server OAuth paste-back state, keyed by server name.
         self._oauth_state: dict[str, dict[str, Any]] = {}
 
@@ -427,6 +428,18 @@ class MCPManager:
         if name not in self._locks:
             self._locks[name] = asyncio.Lock()
         return self._locks[name]
+
+    def _spawn_detached_disconnect(self, conn: "MCPConnection") -> None:
+        """Close a connection in the background, holding a strong task ref.
+
+        The event loop keeps only a weak reference to a bare create_task, so an
+        unreferenced cleanup task can be garbage-collected before it closes the
+        transport — leaking a stdio child process and its pipes. Retain the task
+        until it finishes, then drop it.
+        """
+        task = asyncio.create_task(_detached_disconnect(conn))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     # -- loading from store --
 
@@ -535,7 +548,7 @@ class MCPManager:
         conn = self._connections.pop(name, None)
         if conn:
             conn._session = None
-            asyncio.create_task(_detached_disconnect(conn))
+            self._spawn_detached_disconnect(conn)
 
     async def disconnect_server(self, name: str) -> None:
         """Disconnect a server and unregister its tools."""
@@ -654,7 +667,7 @@ class MCPManager:
                 conn = self._connections.pop(name, None)
                 if conn:
                     conn._session = None
-                    asyncio.create_task(_detached_disconnect(conn))
+                    self._spawn_detached_disconnect(conn)
                 return False
             except Exception as e:
                 logger.warning("Auto-reconnect failed for '%s': %s", name, e)
@@ -673,7 +686,7 @@ class MCPManager:
         conn = self._connections.pop(name, None)
         if conn:
             conn._session = None
-            asyncio.create_task(_detached_disconnect(conn))
+            self._spawn_detached_disconnect(conn)
         await self._connect_server_impl(name, auto=True)
 
     async def connect_all(self) -> None:
@@ -938,7 +951,7 @@ class MCPManager:
                     conn = self._connections.pop(server_name, None)
                     if conn:
                         conn._session = None
-                        asyncio.create_task(_detached_disconnect(conn))
+                        self._spawn_detached_disconnect(conn)
                     return {"error": f"MCP tool call failed: {e}. Auto-reconnect timed out."}
                 except Exception as reconnect_err:
                     if server_name in self._connections:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2530,3 +2530,42 @@ async def test_call_tool_timeout_does_not_reconnect_server(tmp_path):
     await manager.stop_health_monitor()
     await manager.disconnect_server("srv")
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_spawn_detached_disconnect_retains_strong_reference(tmp_path):
+    """Background cleanup tasks must be strongly referenced until they finish.
+
+    A bare asyncio.create_task is only weakly referenced by the loop, so an
+    unreferenced cleanup task can be garbage-collected before it closes the
+    transport — leaking a stdio child process and its pipes. The manager must
+    retain the task until it completes, then drop it.
+    """
+    import asyncio
+
+    manager, store = await _make_manager(tmp_path)
+
+    assert manager._background_tasks == set()
+
+    release = asyncio.Event()
+
+    async def slow_disconnect():
+        await release.wait()
+
+    conn = MagicMock()
+    conn.disconnect = AsyncMock(side_effect=slow_disconnect)
+
+    manager._spawn_detached_disconnect(conn)
+
+    # A strong reference is held while the cleanup is in flight.
+    assert len(manager._background_tasks) == 1
+
+    release.set()
+    # Let the task complete and its done-callback fire.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    conn.disconnect.assert_awaited_once()
+    assert manager._background_tasks == set()
+
+    await store.close()


### PR DESCRIPTION
## Problem

Four sites scheduled background transport cleanup with a bare `asyncio.create_task(_detached_disconnect(conn))` and discarded the returned `Task`:

- `_cleanup_connection` (used by `delete_server`)
- `_reconnect_server` (timeout path)
- `_reconnect_server_impl`
- `call_tool` (timeout path)

Per the asyncio docs, the event loop keeps only a **weak** reference to a task. An unreferenced cleanup task is garbage-collectable between `await` points, so it can be collected before `_detached_disconnect` finishes closing the transport — leaking a stdio MCP server's child process and its pipes (sockets for sse/streamable_http). This accumulates across reconnects.

## Fix

Add a `_background_tasks: set[asyncio.Task]` on the manager and a `_spawn_detached_disconnect` helper that holds a strong reference until the task completes (`task.add_done_callback(self._background_tasks.discard)`), and route all four sites through it. This is purely a lifetime fix — the intentional "abandon a hung transport on timeout" behavior in `_detached_disconnect` is unchanged.

## Tests

New `test_spawn_detached_disconnect_retains_strong_reference`: a strong reference is held while the cleanup is in flight and dropped once it completes, and the disconnect actually runs. Fails on the pre-fix code (no tracking set). Full suite: 307 passed.
