### PR TITLE
refactor: initialize MCP OAuth state eagerly instead of lazily

### DIFF
--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -419,6 +419,8 @@ class MCPManager:
         self._connections: dict[str, MCPConnection] = {}
         self._locks: dict[str, asyncio.Lock] = {}
         self._health_task: asyncio.Task | None = None
+        # Per-server OAuth paste-back state, keyed by server name.
+        self._oauth_state: dict[str, dict[str, Any]] = {}
 
     def _get_lock(self, name: str) -> asyncio.Lock:
         """Get or create a per-server lock for serializing operations."""
@@ -1154,9 +1156,7 @@ class MCPManager:
             scope=None,
         )
 
-        # Per-server state for the paste-back flow
-        if not hasattr(self, "_oauth_state"):
-            self._oauth_state: dict[str, dict[str, Any]] = {}
+        # Reset only this server's paste-back state; never the shared container.
         self._oauth_state[server_name] = {
             "consent_url": None,
             "pending_callback": None,
@@ -1231,7 +1231,7 @@ class MCPManager:
 
     def get_oauth_consent_url(self, name: str) -> str | None:
         """Return the OAuth consent URL if one was generated during connect."""
-        state = getattr(self, "_oauth_state", {}).get(name, {})
+        state = self._oauth_state.get(name, {})
         return state.get("consent_url")
 
     async def submit_oauth_callback(self, name: str, redirect_url: str) -> str:
@@ -1240,7 +1240,7 @@ class MCPManager:
         This resolves the pending callback handler and allows the OAuth flow
         to continue.
         """
-        state = getattr(self, "_oauth_state", {}).get(name, {})
+        state = self._oauth_state.get(name, {})
         future = state.get("pending_callback")
         if future is None or future.done():
             return f"No pending OAuth callback for '{name}'. Start a connection first."

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2412,3 +2412,27 @@ async def test_connect_all_propagates_genuine_cancellation(tmp_path):
 
     await manager.stop_health_monitor()
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_oauth_state_initialized_and_isolated_per_server(tmp_path):
+    """OAuth paste-back state is initialized up front and kept per-server.
+
+    The manager owns one ``_oauth_state`` dict keyed by server name. It exists
+    from construction (no lazy ``hasattr`` init), and building a provider for
+    one server only touches that server's entry — never the container — so
+    other servers' consent URLs and pending callbacks are preserved.
+    """
+    manager, store = await _make_manager(tmp_path)
+
+    # State exists before any provider is built.
+    assert manager._oauth_state == {}
+
+    manager._create_oauth_provider("srvA", "https://a.example/mcp")
+    manager._create_oauth_provider("srvB", "https://b.example/mcp")
+
+    assert set(manager._oauth_state) == {"srvA", "srvB"}
+    assert manager._oauth_state["srvA"]["pending_callback"] is None
+    assert manager._oauth_state["srvB"]["pending_callback"] is None
+
+    await store.close()


### PR DESCRIPTION
## Context

This came out of the MCP bug hunt as a suspected "cross-server OAuth state race." On closer inspection **that race is not reachable**: `_create_oauth_provider` is fully synchronous — there is no `await` between the `if not hasattr(self, "_oauth_state")` check and the assignment — so under asyncio's single-threaded cooperative model the block runs atomically. The container `self._oauth_state = {}` is only ever assigned once and cannot wipe a populated dict, even with concurrent connects to different servers.

So this is **not a bug fix** — it's a small hardening/clarity change that removes the fragile pattern the finding pointed at.

## Change

- Initialize `self._oauth_state: dict[str, dict[str, Any]] = {}` eagerly in `MCPManager.__init__`.
- Drop the lazy `if not hasattr(...)` init in `_create_oauth_provider` (it now only resets the one server's entry).
- Drop the `getattr(self, "_oauth_state", {})` fallbacks in `get_oauth_consent_url` / `submit_oauth_callback` since the attribute always exists.

No behavior change for the OAuth paste-back flow.

## Tests

New `test_oauth_state_initialized_and_isolated_per_server`: the state dict exists from construction and building a provider for one server leaves another server's entry intact. (The eager-init assertion fails on the pre-change code, where the attribute doesn't exist until the first provider is built.) Full suite: 307 passed.
