### PR TITLE
fix: don't silently drop OAuth tokens on a non-not-found write error

### DIFF
--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -386,15 +386,15 @@ class MCPOAuthTokenStorage:
         if self._store.documents is None:
             raise RuntimeError("DocumentStore is not initialized")
         content = json.dumps(tokens.model_dump())
+        from src.store.store import StoreNotFound
+
         try:
             await self._store.documents.update(self._rkey, content)
-        except Exception:
-            from src.store.store import StoreNotFound
-
-            try:
-                await self._store.documents.create(self._rkey, content)
-            except Exception:
-                logger.warning("Failed to store OAuth tokens for '%s'", self._server_name, exc_info=True)
+        except StoreNotFound:
+            # First write for this server — the document doesn't exist yet.
+            # Any other update error is a real persistence failure and must
+            # propagate rather than be masked by a conflicting create.
+            await self._store.documents.create(self._rkey, content)
 
     async def get_client_info(self) -> Any:
         return None

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2415,6 +2415,55 @@ async def test_connect_all_propagates_genuine_cancellation(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_set_tokens_propagates_real_update_error():
+    """A non-not-found update failure must not be masked by a conflicting create.
+
+    Only a genuine "document does not exist yet" (StoreNotFound) should fall
+    back to create. A transient update error while the token doc already exists
+    must propagate, not trigger a create that StoreConflicts and gets swallowed
+    — which would silently drop a refreshed token.
+    """
+    from src.store.store import StoreConflict
+    from src.tools.mcp import MCPOAuthTokenStorage
+
+    documents = MagicMock()
+    documents.update = AsyncMock(side_effect=RuntimeError("db locked"))
+    documents.create = AsyncMock(side_effect=StoreConflict("exists"))
+    store = MagicMock()
+    store.documents = documents
+
+    storage = MCPOAuthTokenStorage(store, "srv")
+    tokens = MagicMock()
+    tokens.model_dump.return_value = {"access_token": "x"}
+
+    with pytest.raises(RuntimeError):
+        await storage.set_tokens(tokens)
+
+    documents.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_tokens_creates_on_first_write():
+    """A missing token document (StoreNotFound) falls back to create."""
+    from src.store.store import StoreNotFound
+    from src.tools.mcp import MCPOAuthTokenStorage
+
+    documents = MagicMock()
+    documents.update = AsyncMock(side_effect=StoreNotFound("nope"))
+    documents.create = AsyncMock()
+    store = MagicMock()
+    store.documents = documents
+
+    storage = MCPOAuthTokenStorage(store, "srv")
+    tokens = MagicMock()
+    tokens.model_dump.return_value = {"access_token": "x"}
+
+    await storage.set_tokens(tokens)
+
+    documents.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_call_tool_timeout_does_not_reconnect_server(tmp_path):
     """A slow-but-healthy tool that times out must not tear down the server.
 


### PR DESCRIPTION
## Problem

`MCPOAuthTokenStorage.set_tokens` wrapped `documents.update` in a broad `except Exception` and fell back to `documents.create`:

```python
try:
    await self._store.documents.update(self._rkey, content)
except Exception:
    try:
        await self._store.documents.create(self._rkey, content)
    except Exception:
        logger.warning("Failed to store OAuth tokens ...")
```

`DocumentStore.update` raises the typed `StoreNotFound` only when the doc is absent; other DB errors re-raise as a generic `Exception`. `create` raises `StoreConflict` when the doc already exists. So when `update` failed transiently (e.g. `db locked`) **while the token doc already existed**, the fallback `create` deterministically `StoreConflict`ed and got swallowed — silently dropping a refreshed token. On the next restart, `connect_all` reads the stale token and auto-connect fails (with only a logged warning, since `get_oauth_status_async` checks existence, not validity).

## Fix

Narrow the fallback to `StoreNotFound` (the genuine first-write case). Any other `update` error now propagates instead of being masked by a conflicting `create`.

## Tests

- `test_set_tokens_propagates_real_update_error`: a non-not-found `update` error propagates and `create` is not attempted (fails on the pre-fix code, which swallowed it).
- `test_set_tokens_creates_on_first_write`: a `StoreNotFound` update still falls back to `create`.

Full suite: 309 passed.
