### PR TITLE
feat: web.save_url_as_pdf — download or render a URL to a PDF in the workspace

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,11 @@ jobs:
           pip install -e .
           pip install pytest pytest-asyncio
 
+      # web.save_url_as_pdf renders pages with headless Chromium via Playwright;
+      # install the browser + its OS deps so the render tests actually run.
+      - name: Install Playwright Chromium
+        run: python -m playwright install --with-deps chromium
+
       - name: Run tests
         run: |
           python -m pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ real browser that does its own DNS/redirects, so its authoritative protection is
 to loopback, link-local (169.254/16, incl. cloud metadata), RFC1918,
 CGNAT/tailnet (100.64/10), and unique-local ranges. Without that the render path
 is rebinding-exploitable. An nftables example is in the `web_pdf.py` module
-docstring.
+docstring. A hostile page can also try to exhaust memory while rendering — run
+victrola under an OS memory limit (cgroup/container) as the backstop.
 
 > End-to-end "send a web page to my device" also needs an upload tool (e.g. a
 > registered Supernote MCP server) for the agent to call after the PDF is saved.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,35 @@ WORKSPACE_DIR=data/workspace
 WORKSPACE_MAX_SIZE_MB=1024
 ```
 
+### Saving web pages as PDFs (`web.save_url_as_pdf`)
+
+The agent can turn a URL into a PDF in its workspace: if the URL is already a
+PDF it's downloaded; otherwise the page is rendered with a headless Chromium
+(Playwright). It then reads the file from the workspace and can hand it to an
+upload tool.
+
+**Deploy (Linux):** `playwright` is a dependency; install the browser once:
+
+```bash
+playwright install --with-deps chromium
+```
+
+If Chromium won't launch on a locked-down host, set
+`WEB_PDF_CHROMIUM_NO_SANDBOX=1` (prefer running victrola as a non-root user / in
+a container over disabling Chromium's sandbox).
+
+**SSRF — required egress filtering.** Only public addresses are allowed. The
+*download* path is pinned in code (rebinding-safe). The *render* path uses a
+real browser that does its own DNS/redirects, so its authoritative protection is
+**host egress filtering**: the victrola process MUST be denied outbound access
+to loopback, link-local (169.254/16, incl. cloud metadata), RFC1918,
+CGNAT/tailnet (100.64/10), and unique-local ranges. Without that the render path
+is rebinding-exploitable. An nftables example is in the `web_pdf.py` module
+docstring.
+
+> End-to-end "send a web page to my device" also needs an upload tool (e.g. a
+> registered Supernote MCP server) for the agent to call after the PDF is saved.
+
 ## Storage
 
 Everything persistent lives under `./data/`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "httpx>=0.28.0",
     "mcp>=1.28.0",
     "numpy>=2.0.0",
+    "playwright>=1.40.0",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.12.0",
     "uvicorn[standard]>=0.34.0",

--- a/src/tools/definitions/__init__.py
+++ b/src/tools/definitions/__init__.py
@@ -7,3 +7,4 @@ import src.tools.definitions.scheduler  # noqa: F401
 import src.tools.definitions.summarize  # noqa: F401
 import src.tools.definitions.system  # noqa: F401
 import src.tools.definitions.web  # noqa: F401
+import src.tools.definitions.web_pdf  # noqa: F401

--- a/src/tools/definitions/web_pdf.py
+++ b/src/tools/definitions/web_pdf.py
@@ -6,11 +6,37 @@ happens here and the result lands in the workspace for the agent to use.
 - If the URL is already a PDF, it's downloaded as-is.
 - Otherwise the page is rendered to a PDF with a headless Chromium (Playwright).
 
-SSRF: only public (globally-routable) addresses are allowed. The entry URL and
-every redirect hop are validated, and during rendering each http(s) sub-resource
-request is checked too. Residual: DNS can change between validation and the
-actual connection (rebinding), and the browser may follow JS/meta redirects we
-don't see — so this is a strong guard, not an airtight network jail.
+## SSRF model (read before deploying)
+
+Only public (globally-routable) addresses are allowed.
+
+* **Download path** — closed in code: the host is resolved, every IP is checked,
+  and the connection is *pinned* to the validated IP (Host header + TLS SNI keep
+  cert verification against the real hostname). Each redirect hop is re-checked.
+  This defeats DNS rebinding for downloads.
+
+* **Render path** — a headless browser does its own DNS, follows redirects, and
+  loads sub-resources we can't fully pin from here. The in-process checks
+  (entry URL + a fail-closed per-request guard) are *best-effort only*. The
+  **authoritative** control for rendering is **host egress filtering**: the
+  process running victrola MUST be denied outbound access to loopback,
+  link-local (169.254/16 incl. cloud metadata), RFC1918, CGNAT/tailnet
+  (100.64/10), and unique-local ranges. Example (nftables, adjust to taste):
+
+      table inet egress {
+        chain out {
+          type filter hook output priority 0;
+          ip daddr { 127.0.0.0/8, 169.254.0.0/16, 10.0.0.0/8, 172.16.0.0/12,
+                     192.168.0.0/16, 100.64.0.0/10 } drop
+          ip6 daddr { ::1, fe80::/10, fc00::/7 } drop
+        }
+      }
+
+  Without that egress policy the render path is rebinding-exploitable.
+
+Chromium's own process sandbox is kept ON by default; set
+``WEB_PDF_CHROMIUM_NO_SANDBOX=1`` only if the host can't otherwise launch it
+(prefer running victrola as a non-root user / in a container instead).
 """
 from __future__ import annotations
 
@@ -22,7 +48,8 @@ import re
 import socket
 from pathlib import Path
 from typing import Any
-from urllib.parse import unquote, urljoin, urlsplit
+from urllib.parse import unquote, urljoin, urlsplit, urlunsplit
+from uuid import uuid4
 
 import httpx
 
@@ -31,15 +58,18 @@ from src.tools.registry import TOOL_REGISTRY, ToolContext, ToolParameter
 
 logger = logging.getLogger(__name__)
 
-MAX_BYTES = 100 * 1024 * 1024  # 100 MB cap on download / fetched body
+MAX_BYTES = 100 * 1024 * 1024  # 100 MB cap on download / rendered PDF
 MAX_REDIRECTS = 5
 RENDER_TIMEOUT_MS = 30_000
+MAX_CONCURRENT_RENDERS = 2  # bound concurrent Chromium launches (memory/CPU)
 
 # NAT64 translation prefixes (RFC 6052/8215); embedded IPv4 is in the low 32 bits.
 _NAT64_PREFIXES = (
     ipaddress.ip_network("64:ff9b::/96"),
     ipaddress.ip_network("64:ff9b:1::/96"),
 )
+
+_render_sem = asyncio.Semaphore(MAX_CONCURRENT_RENDERS)
 
 
 class SsrfError(Exception):
@@ -51,7 +81,7 @@ class RenderUnavailable(Exception):
 
 
 # --------------------------------------------------------------------------- #
-# SSRF: public-address validation
+# SSRF: public-address validation + connection pinning
 # --------------------------------------------------------------------------- #
 def _normalize_ip(addr: str) -> ipaddress._BaseAddress:
     """Collapse IPv6 forms that embed an IPv4 address (mapped / 6to4 / NAT64) to
@@ -74,8 +104,12 @@ def _is_public(ip: ipaddress._BaseAddress) -> bool:
     return bool(ip.is_global) and not ip.is_multicast and not ip.is_reserved
 
 
-def _check_public_url(url: str) -> None:
-    """Raise SsrfError unless url is http(s) and resolves only to public IPs."""
+def _resolve_pinned(url: str) -> tuple[str, str, int | None, str]:
+    """Validate url and return (scheme, host, port, pinned_ip).
+
+    Raises SsrfError unless it's http(s) and *every* resolved address is public.
+    The pinned_ip is the address the caller must connect to, so the IP that was
+    validated is the IP that's used (closes DNS rebinding)."""
     sp = urlsplit(url)
     if sp.scheme not in ("http", "https"):
         raise SsrfError("only http and https URLs are allowed")
@@ -93,28 +127,49 @@ def _check_public_url(url: str) -> None:
         raise SsrfError(f"cannot resolve host {host!r}: {exc}")
     if not infos:
         raise SsrfError(f"no addresses for host {host!r}")
+    pinned: str | None = None
     for info in infos:
         ip = _normalize_ip(info[4][0])
         if not _is_public(ip):
             raise SsrfError(f"{host!r} -> {ip} is not a public address")
+        if pinned is None:
+            pinned = str(ip)
+    assert pinned is not None
+    return sp.scheme, host, port, pinned
+
+
+def _check_public_url(url: str) -> None:
+    """Validate-only wrapper (raises SsrfError); used for best-effort checks."""
+    _resolve_pinned(url)
 
 
 # --------------------------------------------------------------------------- #
-# Fetch (download path) with per-hop revalidation
+# Download path (pinned, per-hop revalidation)
 # --------------------------------------------------------------------------- #
 async def _fetch_guarded(ctx: ToolContext, url: str) -> tuple[bytes, str, str]:
-    """Return (body, content_type, final_url). Redirects are followed manually
-    so each hop is re-validated; the body is size-capped."""
+    """Return (body, content_type, final_url). Connects to the validated IP at
+    every hop (pinned), follows redirects manually, and caps the body size."""
     current = url
     for _ in range(MAX_REDIRECTS + 1):
-        _check_public_url(current)
+        scheme, host, port, ip = _resolve_pinned(current)
+        sp = urlsplit(current)
+        ip_host = f"[{ip}]" if ":" in ip else ip
+        ip_netloc = f"{ip_host}:{port}" if port else ip_host
+        ip_url = urlunsplit((scheme, ip_netloc, sp.path or "/", sp.query, ""))
+        host_header = f"{host}:{port}" if port else host
         async with ctx.http_client.stream(
-            "GET", current, follow_redirects=False, timeout=60.0
+            "GET",
+            ip_url,
+            headers={"Host": host_header},
+            extensions={"sni_hostname": host},  # SNI + cert check vs the hostname
+            follow_redirects=False,
+            timeout=60.0,
         ) as resp:
             if resp.is_redirect:
                 location = resp.headers.get("location")
                 if not location:
                     raise SsrfError("redirect without a Location header")
+                # Resolve relative to the real-host URL, then revalidate next hop.
                 current = urljoin(current, location)
                 continue
             resp.raise_for_status()
@@ -129,23 +184,27 @@ async def _fetch_guarded(ctx: ToolContext, url: str) -> tuple[bytes, str, str]:
 
 
 # --------------------------------------------------------------------------- #
-# Render (page -> PDF) with sub-resource guarding
+# Render path (best-effort guard; host egress filtering is authoritative)
 # --------------------------------------------------------------------------- #
 async def _guard_route(route: Any) -> None:
-    """Abort http(s) sub-resource requests to non-public hosts during render."""
+    """Best-effort per-request guard during render. Fails CLOSED: any http(s)
+    request that isn't provably public is aborted (a dropped sub-resource just
+    means a missing image, not a failed render). The real control is egress
+    filtering — this can't see browser-followed redirects."""
     req_url = route.request.url
     if urlsplit(req_url).scheme in ("http", "https"):
         try:
             await asyncio.to_thread(_check_public_url, req_url)
-        except SsrfError:
+        except Exception:  # noqa: BLE001 - SsrfError OR resolver error -> abort
             await route.abort()
             return
-        except Exception:  # noqa: BLE001 - never break a page on a resolver hiccup
-            logger.warning("save_url_as_pdf: route guard resolver error for %s", req_url)
     await route.continue_()
 
 
 async def _render_pdf(url: str) -> bytes:
+    # NOTE: callers pass a URL already validated by _fetch_guarded; the browser
+    # re-resolves on its own, so egress filtering (not this code) is the real
+    # SSRF control here.
     try:
         from playwright.async_api import async_playwright
     except ImportError as exc:
@@ -154,22 +213,27 @@ async def _render_pdf(url: str) -> bytes:
             "`playwright install chromium`"
         ) from exc
 
-    async with async_playwright() as p:
-        try:
-            browser = await p.chromium.launch(
-                args=["--no-sandbox", "--disable-dev-shm-usage"]
-            )
-        except Exception as exc:  # noqa: BLE001
-            raise RenderUnavailable(
-                f"could not launch Chromium (run `playwright install chromium`): {exc}"
-            ) from exc
-        try:
-            page = await browser.new_page()
-            await page.route("**/*", _guard_route)
-            await page.goto(url, wait_until="load", timeout=RENDER_TIMEOUT_MS)
-            return await page.pdf(format="A4", print_background=True)
-        finally:
-            await browser.close()
+    launch_args = ["--disable-dev-shm-usage"]
+    if os.environ.get("WEB_PDF_CHROMIUM_NO_SANDBOX"):
+        launch_args.append("--no-sandbox")
+
+    async with _render_sem:  # bound concurrent Chromium launches
+        async with async_playwright() as p:
+            try:
+                browser = await p.chromium.launch(args=launch_args)
+            except Exception as exc:  # noqa: BLE001
+                raise RenderUnavailable(
+                    "could not launch Chromium (run `playwright install chromium`; "
+                    "on locked-down Linux you may need WEB_PDF_CHROMIUM_NO_SANDBOX=1 "
+                    f"and a non-root/container setup): {exc}"
+                ) from exc
+            try:
+                page = await browser.new_page()
+                await page.route("**/*", _guard_route)
+                await page.goto(url, wait_until="load", timeout=RENDER_TIMEOUT_MS)
+                return await page.pdf(format="A4", print_background=True)
+            finally:
+                await browser.close()
 
 
 # --------------------------------------------------------------------------- #
@@ -189,14 +253,28 @@ def _safe_pdf_name(name: str) -> str:
 
 
 def _write_to_workspace(name: str, data: bytes) -> str:
+    """Write `data` to <workspace>/<name> safely.
+
+    Writes to a fresh temp file (O_EXCL|O_NOFOLLOW => guaranteed new regular
+    file) then atomically renames it onto `name`. os.replace swaps the directory
+    ENTRY, so even if `name` is already a symlink or a hardlink to a file
+    OUTSIDE the workspace, that outside inode is never written through.
+    """
     workspace = Path(CONFIG.workspace_dir)
     workspace.mkdir(parents=True, exist_ok=True)
     dest = workspace / name
-    # O_NOFOLLOW: never write THROUGH a (planted) symlink out of the workspace.
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
-    fd = os.open(dest, flags, 0o644)
-    with os.fdopen(fd, "wb") as f:
-        f.write(data)
+    tmp = workspace / f".{name}.{os.getpid()}.{uuid4().hex}.tmp"
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o644)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        os.replace(tmp, dest)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
     return name
 
 
@@ -244,7 +322,8 @@ async def save_url_as_pdf(
     except httpx.HTTPError as exc:
         return {"error": f"fetch failed: {exc}"}
 
-    is_pdf = "application/pdf" in ctype.split(";")[0].strip().lower() or data[:5] == b"%PDF-"
+    media = ctype.split(";")[0].strip().lower()
+    is_pdf = media == "application/pdf" or data[:5] == b"%PDF-"
 
     if is_pdf:
         pdf_bytes, kind = data, "downloaded"

--- a/src/tools/definitions/web_pdf.py
+++ b/src/tools/definitions/web_pdf.py
@@ -37,6 +37,10 @@ Only public (globally-routable) addresses are allowed.
 Chromium's own process sandbox is kept ON by default; set
 ``WEB_PDF_CHROMIUM_NO_SANDBOX=1`` only if the host can't otherwise launch it
 (prefer running victrola as a non-root user / in a container instead).
+
+A hostile page can also try to exhaust memory while rendering. We bound render
+time (page.pdf timeout) and concurrent renders, but the authoritative protection
+is again deploy-level: run victrola under an OS memory limit (cgroup/container).
 """
 from __future__ import annotations
 
@@ -60,7 +64,8 @@ logger = logging.getLogger(__name__)
 
 MAX_BYTES = 100 * 1024 * 1024  # 100 MB cap on download / rendered PDF
 MAX_REDIRECTS = 5
-RENDER_TIMEOUT_MS = 30_000
+RENDER_TIMEOUT_MS = 30_000  # page navigation timeout
+RENDER_PDF_TIMEOUT_S = 30  # cap on page.pdf() so a hostile page can't run forever
 MAX_CONCURRENT_RENDERS = 2  # bound concurrent Chromium launches (memory/CPU)
 
 # NAT64 translation prefixes (RFC 6052/8215); embedded IPv4 is in the low 32 bits.
@@ -231,7 +236,13 @@ async def _render_pdf(url: str) -> bytes:
                 page = await browser.new_page()
                 await page.route("**/*", _guard_route)
                 await page.goto(url, wait_until="load", timeout=RENDER_TIMEOUT_MS)
-                return await page.pdf(format="A4", print_background=True)
+                # Bound page.pdf(): a hostile page can otherwise build an
+                # enormous document. This caps time; cap memory at the OS layer
+                # (run the render process under a cgroup/container memory limit).
+                return await asyncio.wait_for(
+                    page.pdf(format="A4", print_background=True),
+                    timeout=RENDER_PDF_TIMEOUT_S,
+                )
             finally:
                 await browser.close()
 
@@ -260,7 +271,9 @@ def _write_to_workspace(name: str, data: bytes) -> str:
     ENTRY, so even if `name` is already a symlink or a hardlink to a file
     OUTSIDE the workspace, that outside inode is never written through.
     """
-    workspace = Path(CONFIG.workspace_dir)
+    # resolve() the root (matches executor / workspace router) so a symlinked
+    # workspace_dir anchors to its real target consistently.
+    workspace = Path(CONFIG.workspace_dir).resolve()
     workspace.mkdir(parents=True, exist_ok=True)
     dest = workspace / name
     tmp = workspace / f".{name}.{os.getpid()}.{uuid4().hex}.tmp"

--- a/src/tools/definitions/web_pdf.py
+++ b/src/tools/definitions/web_pdf.py
@@ -1,0 +1,274 @@
+"""Save a web URL as a PDF in the agent workspace.
+
+Host-side (Python) tool: the Deno sandbox has no network, so fetching/rendering
+happens here and the result lands in the workspace for the agent to use.
+
+- If the URL is already a PDF, it's downloaded as-is.
+- Otherwise the page is rendered to a PDF with a headless Chromium (Playwright).
+
+SSRF: only public (globally-routable) addresses are allowed. The entry URL and
+every redirect hop are validated, and during rendering each http(s) sub-resource
+request is checked too. Residual: DNS can change between validation and the
+actual connection (rebinding), and the browser may follow JS/meta redirects we
+don't see — so this is a strong guard, not an airtight network jail.
+"""
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+import os
+import re
+import socket
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urljoin, urlsplit
+
+import httpx
+
+from src.config import CONFIG
+from src.tools.registry import TOOL_REGISTRY, ToolContext, ToolParameter
+
+logger = logging.getLogger(__name__)
+
+MAX_BYTES = 100 * 1024 * 1024  # 100 MB cap on download / fetched body
+MAX_REDIRECTS = 5
+RENDER_TIMEOUT_MS = 30_000
+
+# NAT64 translation prefixes (RFC 6052/8215); embedded IPv4 is in the low 32 bits.
+_NAT64_PREFIXES = (
+    ipaddress.ip_network("64:ff9b::/96"),
+    ipaddress.ip_network("64:ff9b:1::/96"),
+)
+
+
+class SsrfError(Exception):
+    """The URL is not allowed by the public-address policy."""
+
+
+class RenderUnavailable(Exception):
+    """Playwright / Chromium is not available to render a page."""
+
+
+# --------------------------------------------------------------------------- #
+# SSRF: public-address validation
+# --------------------------------------------------------------------------- #
+def _normalize_ip(addr: str) -> ipaddress._BaseAddress:
+    """Collapse IPv6 forms that embed an IPv4 address (mapped / 6to4 / NAT64) to
+    that IPv4 so the public check can't be bypassed via the alternate form."""
+    ip = ipaddress.ip_address(addr)
+    if ip.version == 6:
+        if ip.ipv4_mapped is not None:
+            return ip.ipv4_mapped
+        if ip.sixtofour is not None:
+            return ip.sixtofour
+        for prefix in _NAT64_PREFIXES:
+            if ip in prefix:
+                return ipaddress.ip_address(int(ip) & 0xFFFFFFFF)
+    return ip
+
+
+def _is_public(ip: ipaddress._BaseAddress) -> bool:
+    """is_global already excludes loopback/private/link-local/CGNAT(tailnet)/
+    unspecified, but returns True for multicast and some reserved space."""
+    return bool(ip.is_global) and not ip.is_multicast and not ip.is_reserved
+
+
+def _check_public_url(url: str) -> None:
+    """Raise SsrfError unless url is http(s) and resolves only to public IPs."""
+    sp = urlsplit(url)
+    if sp.scheme not in ("http", "https"):
+        raise SsrfError("only http and https URLs are allowed")
+    host = sp.hostname
+    if not host:
+        raise SsrfError("URL has no host")
+    try:
+        port = sp.port
+    except ValueError:
+        raise SsrfError("URL has an invalid port")
+    default_port = 443 if sp.scheme == "https" else 80
+    try:
+        infos = socket.getaddrinfo(host, port or default_port, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        raise SsrfError(f"cannot resolve host {host!r}: {exc}")
+    if not infos:
+        raise SsrfError(f"no addresses for host {host!r}")
+    for info in infos:
+        ip = _normalize_ip(info[4][0])
+        if not _is_public(ip):
+            raise SsrfError(f"{host!r} -> {ip} is not a public address")
+
+
+# --------------------------------------------------------------------------- #
+# Fetch (download path) with per-hop revalidation
+# --------------------------------------------------------------------------- #
+async def _fetch_guarded(ctx: ToolContext, url: str) -> tuple[bytes, str, str]:
+    """Return (body, content_type, final_url). Redirects are followed manually
+    so each hop is re-validated; the body is size-capped."""
+    current = url
+    for _ in range(MAX_REDIRECTS + 1):
+        _check_public_url(current)
+        async with ctx.http_client.stream(
+            "GET", current, follow_redirects=False, timeout=60.0
+        ) as resp:
+            if resp.is_redirect:
+                location = resp.headers.get("location")
+                if not location:
+                    raise SsrfError("redirect without a Location header")
+                current = urljoin(current, location)
+                continue
+            resp.raise_for_status()
+            ctype = resp.headers.get("content-type", "")
+            buf = bytearray()
+            async for chunk in resp.aiter_bytes():
+                buf.extend(chunk)
+                if len(buf) > MAX_BYTES:
+                    raise SsrfError(f"response exceeds {MAX_BYTES} bytes")
+            return bytes(buf), ctype, current
+    raise SsrfError(f"too many redirects (> {MAX_REDIRECTS})")
+
+
+# --------------------------------------------------------------------------- #
+# Render (page -> PDF) with sub-resource guarding
+# --------------------------------------------------------------------------- #
+async def _guard_route(route: Any) -> None:
+    """Abort http(s) sub-resource requests to non-public hosts during render."""
+    req_url = route.request.url
+    if urlsplit(req_url).scheme in ("http", "https"):
+        try:
+            await asyncio.to_thread(_check_public_url, req_url)
+        except SsrfError:
+            await route.abort()
+            return
+        except Exception:  # noqa: BLE001 - never break a page on a resolver hiccup
+            logger.warning("save_url_as_pdf: route guard resolver error for %s", req_url)
+    await route.continue_()
+
+
+async def _render_pdf(url: str) -> bytes:
+    try:
+        from playwright.async_api import async_playwright
+    except ImportError as exc:
+        raise RenderUnavailable(
+            "rendering needs Playwright: `pip install playwright` then "
+            "`playwright install chromium`"
+        ) from exc
+
+    async with async_playwright() as p:
+        try:
+            browser = await p.chromium.launch(
+                args=["--no-sandbox", "--disable-dev-shm-usage"]
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise RenderUnavailable(
+                f"could not launch Chromium (run `playwright install chromium`): {exc}"
+            ) from exc
+        try:
+            page = await browser.new_page()
+            await page.route("**/*", _guard_route)
+            await page.goto(url, wait_until="load", timeout=RENDER_TIMEOUT_MS)
+            return await page.pdf(format="A4", print_background=True)
+        finally:
+            await browser.close()
+
+
+# --------------------------------------------------------------------------- #
+# Filenames + workspace write
+# --------------------------------------------------------------------------- #
+def _name_from_url(url: str) -> str:
+    sp = urlsplit(url)
+    tail = unquote(sp.path.rsplit("/", 1)[-1]) if sp.path else ""
+    return tail or (sp.hostname or "page")
+
+
+def _safe_pdf_name(name: str) -> str:
+    base = os.path.basename((name or "").replace("\\", "/")).strip()
+    stem = os.path.splitext(base)[0]
+    stem = re.sub(r"[^A-Za-z0-9._-]", "_", stem).strip("._") or "page"
+    return f"{stem}.pdf"
+
+
+def _write_to_workspace(name: str, data: bytes) -> str:
+    workspace = Path(CONFIG.workspace_dir)
+    workspace.mkdir(parents=True, exist_ok=True)
+    dest = workspace / name
+    # O_NOFOLLOW: never write THROUGH a (planted) symlink out of the workspace.
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
+    fd = os.open(dest, flags, 0o644)
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+    return name
+
+
+# --------------------------------------------------------------------------- #
+# Tool
+# --------------------------------------------------------------------------- #
+@TOOL_REGISTRY.tool(
+    name="web.save_url_as_pdf",
+    description=(
+        "Fetch a web URL and save it as a PDF in the workspace. If the URL is "
+        "already a PDF it is downloaded as-is; otherwise the page is rendered to "
+        "a PDF with a headless browser. Only public web addresses are allowed "
+        "(internal/loopback/private/tailnet hosts are refused). Returns the "
+        "workspace-relative path — read it with Deno via WORKSPACE + '/' + path, "
+        "or hand it to an upload tool (e.g. to send it to a device)."
+    ),
+    parameters=[
+        ToolParameter(
+            name="url",
+            type="string",
+            description="The http(s) URL of the page or PDF to save.",
+        ),
+        ToolParameter(
+            name="filename",
+            type="string",
+            description=(
+                "Optional name to save as; a .pdf extension is enforced. "
+                "Defaults to a name derived from the URL."
+            ),
+            required=False,
+            default=None,
+        ),
+    ],
+)
+async def save_url_as_pdf(
+    ctx: ToolContext, url: str, filename: str | None = None
+) -> dict[str, Any]:
+    if not url:
+        return {"error": "url is required"}
+
+    try:
+        data, ctype, final_url = await _fetch_guarded(ctx, url)
+    except SsrfError as exc:
+        return {"error": f"refused: {exc}"}
+    except httpx.HTTPError as exc:
+        return {"error": f"fetch failed: {exc}"}
+
+    is_pdf = "application/pdf" in ctype.split(";")[0].strip().lower() or data[:5] == b"%PDF-"
+
+    if is_pdf:
+        pdf_bytes, kind = data, "downloaded"
+    else:
+        try:
+            pdf_bytes = await _render_pdf(final_url)
+        except RenderUnavailable as exc:
+            return {"error": str(exc)}
+        except Exception as exc:  # noqa: BLE001
+            return {"error": f"render failed: {exc}"}
+        kind = "rendered"
+        if len(pdf_bytes) > MAX_BYTES:
+            return {"error": f"rendered PDF exceeds {MAX_BYTES} bytes"}
+
+    name = _safe_pdf_name(filename or _name_from_url(final_url))
+    try:
+        saved = _write_to_workspace(name, pdf_bytes)
+    except OSError as exc:
+        return {"error": f"could not write {name!r} to the workspace: {exc}"}
+
+    logger.info("save_url_as_pdf: %s -> %s (%d bytes, %s)", url, saved, len(pdf_bytes), kind)
+    return {
+        "path": saved,
+        "kind": kind,
+        "size_bytes": len(pdf_bytes),
+        "source_url": final_url,
+    }

--- a/tests/test_web_pdf.py
+++ b/tests/test_web_pdf.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os
 import socket
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -155,9 +156,24 @@ async def test_download_pins_validated_ip(temp_workspace, monkeypatch):
     out = await save_url_as_pdf(ToolContext(http_client=client), "http://example.test/p.pdf")
     assert out["kind"] == "downloaded"
     call = client.calls[0]
-    assert "93.184.216.34" in call["url"]            # connected to the validated IP
+    parsed = urlsplit(call["url"])
+    assert parsed.scheme == "http" and parsed.netloc == "93.184.216.34"  # exact pin
     assert call["headers"]["Host"] == "example.test"
     assert call["extensions"]["sni_hostname"] == "example.test"
+
+
+async def test_write_resolves_symlinked_workspace_root(tmp_path, monkeypatch):
+    """A symlinked workspace_dir anchors to its real target (matches executor)."""
+    real = tmp_path / "real_ws"
+    real.mkdir()
+    link = tmp_path / "ws_link"
+    os.symlink(real, link)
+    monkeypatch.setattr(CONFIG, "workspace_dir", str(link))
+
+    ctx = _ctx([_FakeStream(PDF_BYTES, "application/pdf")])
+    out = await save_url_as_pdf(ctx, "http://1.1.1.1/p.pdf")
+    assert "error" not in out
+    assert (real / "p.pdf").read_bytes() == PDF_BYTES
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_web_pdf.py
+++ b/tests/test_web_pdf.py
@@ -1,0 +1,169 @@
+"""Tests for web.save_url_as_pdf (download-or-render a URL to the workspace)."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from src.config import CONFIG
+from src.tools.definitions import web_pdf
+from src.tools.definitions.web_pdf import (
+    SsrfError,
+    _check_public_url,
+    _name_from_url,
+    _render_pdf,
+    _safe_pdf_name,
+    save_url_as_pdf,
+)
+from src.tools.registry import ToolContext
+
+PDF_BYTES = b"%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<<>>\n%%EOF\n"
+
+
+# --------------------------------------------------------------------------- #
+# SSRF policy (network-free: IP literals resolve to themselves)
+# --------------------------------------------------------------------------- #
+BLOCKED = [
+    "http://127.0.0.1/x",                      # loopback
+    "http://169.254.169.254/latest",           # link-local / metadata
+    "http://10.0.0.5/x",                        # RFC1918
+    "http://192.168.1.1/x",                     # RFC1918
+    "http://100.104.167.50:19072/x",            # tailnet (CGNAT)
+    "http://[::ffff:127.0.0.1]/x",              # IPv4-mapped loopback
+    "http://[64:ff9b::a9fe:a9fe]/x",            # NAT64 -> 169.254.169.254
+    "http://[2002:7f00:1::]/x",                 # 6to4 -> 127.0.0.1
+    "http://[::1]/x",                            # IPv6 loopback
+    "http://224.0.0.1/x",                        # multicast
+    "http://0.0.0.0/x",                          # unspecified
+    "ftp://example.com/x",                       # bad scheme
+    "http:///nohost",                            # no host
+]
+ALLOWED = ["http://1.1.1.1/x", "https://8.8.8.8/x.pdf"]
+
+
+@pytest.mark.parametrize("url", BLOCKED)
+def test_check_public_url_blocks(url):
+    with pytest.raises(SsrfError):
+        _check_public_url(url)
+
+
+@pytest.mark.parametrize("url", ALLOWED)
+def test_check_public_url_allows(url):
+    _check_public_url(url)  # must not raise
+
+
+def test_name_helpers():
+    assert _name_from_url("https://h.example/a/b/report%20v2.html?x=1") == "report v2.html"
+    assert _safe_pdf_name("report v2.html") == "report_v2.pdf"
+    assert _safe_pdf_name("paper.pdf") == "paper.pdf"
+    assert _safe_pdf_name("../../etc/passwd") == "passwd.pdf"
+    assert _safe_pdf_name("") == "page.pdf"
+    assert _safe_pdf_name("..") == "page.pdf"
+
+
+# --------------------------------------------------------------------------- #
+# Fake httpx client for the download path
+# --------------------------------------------------------------------------- #
+class _FakeStream:
+    def __init__(self, body=b"", content_type="application/octet-stream", location=None):
+        self._body = body
+        self.headers = {"content-type": content_type}
+        self.is_redirect = location is not None
+        if location:
+            self.headers["location"] = location
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    async def aiter_bytes(self):
+        yield self._body
+
+
+class _FakeClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    def stream(self, method, url, **kwargs):
+        return self._responses.pop(0)
+
+
+def _ctx(responses):
+    return ToolContext(http_client=_FakeClient(responses))
+
+
+@pytest.fixture
+def temp_workspace(tmp_path: Path, monkeypatch):
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    monkeypatch.setattr(CONFIG, "workspace_dir", str(ws))
+    return ws
+
+
+async def test_download_pdf_branch(temp_workspace):
+    ctx = _ctx([_FakeStream(PDF_BYTES, "application/pdf")])
+    out = await save_url_as_pdf(ctx, "http://1.1.1.1/paper.pdf")
+    assert out["kind"] == "downloaded"
+    assert out["path"] == "paper.pdf"
+    assert (temp_workspace / "paper.pdf").read_bytes() == PDF_BYTES
+
+
+async def test_download_pdf_by_magic_even_with_wrong_content_type(temp_workspace):
+    ctx = _ctx([_FakeStream(PDF_BYTES, "application/octet-stream")])
+    out = await save_url_as_pdf(ctx, "http://1.1.1.1/paper")
+    assert out["kind"] == "downloaded"  # sniffed %PDF- magic
+
+
+async def test_redirect_to_private_is_refused(temp_workspace):
+    ctx = _ctx([_FakeStream(location="http://127.0.0.1/secret.pdf")])
+    out = await save_url_as_pdf(ctx, "http://1.1.1.1/redir")
+    assert "error" in out
+    assert "public address" in out["error"]
+
+
+async def test_render_branch_mocked(temp_workspace, monkeypatch):
+    """Non-PDF content goes through the render path and is saved."""
+    async def fake_fetch(ctx, url):
+        return b"<html><body>hi</body></html>", "text/html; charset=utf-8", url
+
+    async def fake_render(url):
+        return b"%PDF-1.4 rendered"
+
+    monkeypatch.setattr(web_pdf, "_fetch_guarded", fake_fetch)
+    monkeypatch.setattr(web_pdf, "_render_pdf", fake_render)
+
+    out = await save_url_as_pdf(_ctx([]), "http://1.1.1.1/article")
+    assert out["kind"] == "rendered"
+    assert out["path"] == "article.pdf"
+    assert (temp_workspace / "article.pdf").read_bytes() == b"%PDF-1.4 rendered"
+
+
+async def test_write_refuses_symlink_in_workspace(temp_workspace, monkeypatch, tmp_path):
+    """A planted symlink at the destination name must not be written through."""
+    outside = tmp_path / "outside.pdf"
+    outside.write_bytes(b"ORIGINAL")
+    os.symlink(outside, temp_workspace / "x.pdf")  # planted symlink
+
+    ctx = _ctx([_FakeStream(PDF_BYTES, "application/pdf")])
+    out = await save_url_as_pdf(ctx, "http://1.1.1.1/x.pdf", filename="x.pdf")
+    assert "error" in out
+    assert outside.read_bytes() == b"ORIGINAL"  # not clobbered through the symlink
+
+
+# --------------------------------------------------------------------------- #
+# Real render smoke (skips if Playwright/Chromium isn't installed)
+# --------------------------------------------------------------------------- #
+async def test_render_pdf_real_smoke():
+    pytest.importorskip("playwright")
+    try:
+        pdf = await _render_pdf("data:text/html,<h1>Hello PDF</h1>")
+    except web_pdf.RenderUnavailable as e:
+        pytest.skip(f"chromium not installed: {e}")
+    assert pdf[:5] == b"%PDF-"
+    assert len(pdf) > 200

--- a/tests/test_web_pdf.py
+++ b/tests/test_web_pdf.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import socket
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,7 @@ from src.tools.definitions import web_pdf
 from src.tools.definitions.web_pdf import (
     SsrfError,
     _check_public_url,
+    _guard_route,
     _name_from_url,
     _render_pdf,
     _safe_pdf_name,
@@ -25,19 +27,19 @@ PDF_BYTES = b"%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<<>>\n%%EOF\n"
 # SSRF policy (network-free: IP literals resolve to themselves)
 # --------------------------------------------------------------------------- #
 BLOCKED = [
-    "http://127.0.0.1/x",                      # loopback
-    "http://169.254.169.254/latest",           # link-local / metadata
-    "http://10.0.0.5/x",                        # RFC1918
-    "http://192.168.1.1/x",                     # RFC1918
-    "http://100.104.167.50:19072/x",            # tailnet (CGNAT)
-    "http://[::ffff:127.0.0.1]/x",              # IPv4-mapped loopback
-    "http://[64:ff9b::a9fe:a9fe]/x",            # NAT64 -> 169.254.169.254
-    "http://[2002:7f00:1::]/x",                 # 6to4 -> 127.0.0.1
-    "http://[::1]/x",                            # IPv6 loopback
-    "http://224.0.0.1/x",                        # multicast
-    "http://0.0.0.0/x",                          # unspecified
-    "ftp://example.com/x",                       # bad scheme
-    "http:///nohost",                            # no host
+    "http://127.0.0.1/x",
+    "http://169.254.169.254/latest",
+    "http://10.0.0.5/x",
+    "http://192.168.1.1/x",
+    "http://100.104.167.50:19072/x",        # tailnet (CGNAT)
+    "http://[::ffff:127.0.0.1]/x",          # IPv4-mapped loopback
+    "http://[64:ff9b::a9fe:a9fe]/x",        # NAT64 -> 169.254.169.254
+    "http://[2002:7f00:1::]/x",             # 6to4 -> 127.0.0.1
+    "http://[::1]/x",
+    "http://224.0.0.1/x",                    # multicast
+    "http://0.0.0.0/x",                      # unspecified
+    "ftp://example.com/x",                   # bad scheme
+    "http:///nohost",                        # no host
 ]
 ALLOWED = ["http://1.1.1.1/x", "https://8.8.8.8/x.pdf"]
 
@@ -50,7 +52,7 @@ def test_check_public_url_blocks(url):
 
 @pytest.mark.parametrize("url", ALLOWED)
 def test_check_public_url_allows(url):
-    _check_public_url(url)  # must not raise
+    _check_public_url(url)
 
 
 def test_name_helpers():
@@ -63,7 +65,7 @@ def test_name_helpers():
 
 
 # --------------------------------------------------------------------------- #
-# Fake httpx client for the download path
+# Fake httpx client (records calls so we can assert pinning)
 # --------------------------------------------------------------------------- #
 class _FakeStream:
     def __init__(self, body=b"", content_type="application/octet-stream", location=None):
@@ -89,8 +91,10 @@ class _FakeStream:
 class _FakeClient:
     def __init__(self, responses):
         self._responses = list(responses)
+        self.calls = []
 
     def stream(self, method, url, **kwargs):
+        self.calls.append({"method": method, "url": url, **kwargs})
         return self._responses.pop(0)
 
 
@@ -106,6 +110,9 @@ def temp_workspace(tmp_path: Path, monkeypatch):
     return ws
 
 
+# --------------------------------------------------------------------------- #
+# Download path
+# --------------------------------------------------------------------------- #
 async def test_download_pdf_branch(temp_workspace):
     ctx = _ctx([_FakeStream(PDF_BYTES, "application/pdf")])
     out = await save_url_as_pdf(ctx, "http://1.1.1.1/paper.pdf")
@@ -120,15 +127,43 @@ async def test_download_pdf_by_magic_even_with_wrong_content_type(temp_workspace
     assert out["kind"] == "downloaded"  # sniffed %PDF- magic
 
 
+async def test_content_type_pdfx_is_not_treated_as_pdf(temp_workspace, monkeypatch):
+    async def fake_render(url):
+        return b"%PDF-1.4 rendered"
+
+    monkeypatch.setattr(web_pdf, "_render_pdf", fake_render)
+    ctx = _ctx([_FakeStream(b"<html>not a pdf</html>", "application/pdfx")])
+    out = await save_url_as_pdf(ctx, "http://1.1.1.1/x")
+    assert out["kind"] == "rendered"  # exact media-type match, not substring
+
+
 async def test_redirect_to_private_is_refused(temp_workspace):
     ctx = _ctx([_FakeStream(location="http://127.0.0.1/secret.pdf")])
     out = await save_url_as_pdf(ctx, "http://1.1.1.1/redir")
-    assert "error" in out
-    assert "public address" in out["error"]
+    assert "error" in out and "public address" in out["error"]
 
 
+async def test_download_pins_validated_ip(temp_workspace, monkeypatch):
+    """The connection targets the IP we validated (closes DNS rebinding), with
+    Host + SNI preserved against the real hostname."""
+
+    def fake_gai(host, port, *a, **k):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", port or 80))]
+
+    monkeypatch.setattr(web_pdf.socket, "getaddrinfo", fake_gai)
+    client = _FakeClient([_FakeStream(PDF_BYTES, "application/pdf")])
+    out = await save_url_as_pdf(ToolContext(http_client=client), "http://example.test/p.pdf")
+    assert out["kind"] == "downloaded"
+    call = client.calls[0]
+    assert "93.184.216.34" in call["url"]            # connected to the validated IP
+    assert call["headers"]["Host"] == "example.test"
+    assert call["extensions"]["sni_hostname"] == "example.test"
+
+
+# --------------------------------------------------------------------------- #
+# Render branch (mocked) + route guard
+# --------------------------------------------------------------------------- #
 async def test_render_branch_mocked(temp_workspace, monkeypatch):
-    """Non-PDF content goes through the render path and is saved."""
     async def fake_fetch(ctx, url):
         return b"<html><body>hi</body></html>", "text/html; charset=utf-8", url
 
@@ -144,16 +179,62 @@ async def test_render_branch_mocked(temp_workspace, monkeypatch):
     assert (temp_workspace / "article.pdf").read_bytes() == b"%PDF-1.4 rendered"
 
 
-async def test_write_refuses_symlink_in_workspace(temp_workspace, monkeypatch, tmp_path):
-    """A planted symlink at the destination name must not be written through."""
+class _FakeRoute:
+    def __init__(self, url):
+        self.request = type("R", (), {"url": url})()
+        self.action = None
+
+    async def abort(self):
+        self.action = "abort"
+
+    async def continue_(self):
+        self.action = "continue"
+
+
+async def test_route_guard_fails_closed_on_private():
+    r = _FakeRoute("http://127.0.0.1/x")
+    await _guard_route(r)
+    assert r.action == "abort"
+
+
+async def test_route_guard_allows_public():
+    r = _FakeRoute("http://1.1.1.1/x")
+    await _guard_route(r)
+    assert r.action == "continue"
+
+
+async def test_route_guard_allows_non_http_scheme():
+    r = _FakeRoute("data:text/html,<h1>hi</h1>")
+    await _guard_route(r)
+    assert r.action == "continue"
+
+
+# --------------------------------------------------------------------------- #
+# Workspace write safety (atomic replace never writes through a planted link)
+# --------------------------------------------------------------------------- #
+async def test_write_does_not_clobber_through_symlink(temp_workspace, tmp_path):
     outside = tmp_path / "outside.pdf"
     outside.write_bytes(b"ORIGINAL")
-    os.symlink(outside, temp_workspace / "x.pdf")  # planted symlink
+    os.symlink(outside, temp_workspace / "x.pdf")  # planted symlink at dest
 
     ctx = _ctx([_FakeStream(PDF_BYTES, "application/pdf")])
     out = await save_url_as_pdf(ctx, "http://1.1.1.1/x.pdf", filename="x.pdf")
-    assert "error" in out
-    assert outside.read_bytes() == b"ORIGINAL"  # not clobbered through the symlink
+    assert "error" not in out
+    assert outside.read_bytes() == b"ORIGINAL"  # not written through the symlink
+    dest = temp_workspace / "x.pdf"
+    assert not dest.is_symlink() and dest.read_bytes() == PDF_BYTES
+
+
+async def test_write_does_not_clobber_through_hardlink(temp_workspace, tmp_path):
+    outside = tmp_path / "outside_hl.pdf"
+    outside.write_bytes(b"ORIGINAL")
+    os.link(outside, temp_workspace / "x.pdf")  # planted hardlink at dest
+
+    ctx = _ctx([_FakeStream(PDF_BYTES, "application/pdf")])
+    out = await save_url_as_pdf(ctx, "http://1.1.1.1/x.pdf", filename="x.pdf")
+    assert "error" not in out
+    assert outside.read_bytes() == b"ORIGINAL"  # outside inode untouched
+    assert (temp_workspace / "x.pdf").read_bytes() == PDF_BYTES
 
 
 # --------------------------------------------------------------------------- #

--- a/uv.lock
+++ b/uv.lock
@@ -587,6 +587,73 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/fb/d97dc261209c80744b7c8132693a30d70ec6e7315e632cb0a10b3fec94dd/greenlet-3.5.3-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5795cd1101371140551c645f2d408b8d3c01a5a29cf8a9bce6e759c983682d23", size = 622351, upload-time = "2026-06-26T19:24:16.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/e5fee13cbbd0e8de312d9a146584b8a51891c68847330ef9dc8b5109d23f/greenlet-3.5.3-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:af4923b3096e26a36d7e9cf24ab88083a20f97d191e3b97f253731ce9b41b28c", size = 425395, upload-time = "2026-06-26T19:25:37.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
+    { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/6fea0e3d6600f785069481ee637e09378dd4118acdfd38ad88ae2db31c98/greenlet-3.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:c4e7b79d83805475f0102008843f6eb45fd3bb0b2e88c774adab5fbaab27117d", size = 238211, upload-time = "2026-06-26T18:22:37.671Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/2f5b1adf256d039f5dab8005de8d3d7ad2b0070a3219c0e036b3fbfeb440/greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1", size = 625580, upload-time = "2026-06-26T19:24:18.344Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/ab7fc9e543e44d6879b0a6ef9a4b2188940fd180cc65d6f646883ddf7201/greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda", size = 427933, upload-time = "2026-06-26T19:25:38.219Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7e/220a7f5824a64a60443fc03b39dfac4ea63a7fb6d481efa27eafa928e7f4/greenlet-3.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:dc133a1569ee667b2a6ef56ce551084aeefd87a5acbc4736d336d1e2edc6cfc4", size = 238141, upload-time = "2026-06-26T18:22:48.507Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a9/73fa62893d5b84b4205544e6b673c654cc43aa5b9899bac00f04d64af73d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d19fe6c39ebff9259f07bcc685d3290f8fa4ea2278e51dd0008e4d6b0f2d814", size = 670657, upload-time = "2026-06-26T19:24:19.967Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/2ffce64929fb3cab7b65d5a0b20aaf9764e227681d731b041077fc9a525a/greenlet-3.5.3-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:962c5df2db8cb446da51edf1ca5296c389d93b99c9d8aa2ee4c7d0d8f1218260", size = 473497, upload-time = "2026-06-26T19:25:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/68d0983e79e02138f64b4d303c500c27ddb48e5e77f3debb80888a921eae/greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605", size = 239549, upload-time = "2026-06-26T18:22:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
+    { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/8faec206b851c22b1733545fda900829a1f3f5b1c78ae7e0fb3dba57d9f4/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b897d97759425953f69a9c0fac67f8fe333ec0ce7377ef186fb2b0c3ad5e354d", size = 659582, upload-time = "2026-06-26T19:24:21.357Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/55/50c19e49f8045834ada71ef12f8ad048eba8517c6aa41161bed676328fae/greenlet-3.5.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3236754d423955ea08e9bb5f6c04a7895f9e22c290b66aa7653fcb922d839eb0", size = 491037, upload-time = "2026-06-26T19:25:40.672Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/93928dce91e6b3598b5e779e8d1fd6576a504640c58e78627077f6a7a91a/greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc", size = 288860, upload-time = "2026-06-26T18:22:48.07Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ca/69db42d447a1378043e2c8f19c09cbbd1263371505053c496b49066d3d16/greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47", size = 659747, upload-time = "2026-06-26T19:07:15.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0b/af7ac2ef8dd41e3da1a40dda6305c23b9a03e13ba975ec916357b50f8575/greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81", size = 670419, upload-time = "2026-06-26T19:10:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/25/aa/952cf28c2ff949a8c971134fb43854dd7eaa737218723aaef758f8c9aead/greenlet-3.5.3-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cefa9cef4b371f9844c6053db71f1138bc6807bab1578b0dae5149c1f1141357", size = 674261, upload-time = "2026-06-26T19:24:22.79Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1e/1d51640cacbfc455dbe9f9a9f594c49e4e244f63b9971a2f4764e46cc53d/greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d", size = 668787, upload-time = "2026-06-26T18:32:24.298Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/b00d6f5e63e531a93562b2ec1a4c320fbee91f580fc42e6417af69d706e5/greenlet-3.5.3-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:6219b6d04dbf6ba6084d77dc609e8473060dc55f759cbf626d512122781fa128", size = 480322, upload-time = "2026-06-26T19:25:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4030d5b0b5894500023f003bb054d9bb354dfbd1e186c3a296759172f5f5/greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34", size = 1626305, upload-time = "2026-06-26T19:09:08.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/50/5221371c7550108dfa3c378debc41d032aa9c78e89abb01d8011cfc93289/greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b", size = 1688631, upload-time = "2026-06-26T18:31:51.278Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/00d469daae3c65d2bf620b10eee82eb022127d483c6bc8c69fae6f3fbf17/greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930", size = 241027, upload-time = "2026-06-26T18:22:38.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/883785b44c5780ed71e83d3e4437e710470be17a2e181e8b601e2da0dc4a/greenlet-3.5.3-cp315-cp315-win_arm64.whl", hash = "sha256:499fef2acede88c1864a57bb586b4bf533c81e1b82df7ab93451cdb47dfec227", size = 240085, upload-time = "2026-06-26T18:23:54.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/4f4a8450962fad137c1c8981a3f1b8919d06c829993d4d476f9c525d5173/greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c", size = 297221, upload-time = "2026-06-26T18:23:27.176Z" },
+    { url = "https://files.pythonhosted.org/packages/57/66/b3bfae3e220a9b63ea539a0eea681800c69ab1aada757eae8789f183e7ce/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f", size = 657221, upload-time = "2026-06-26T19:07:16.973Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/81/b6d4d73a709684fc77e7fa034d7c2fe82cffa9fc920fadcaa659c2626213/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2", size = 663226, upload-time = "2026-06-26T19:10:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/39/0e0938a75115b939d42733a2a12e1d349653c9531fe6fe563e8a681f04e6/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d192579ed281051396dddd7f7754dac6259e6b1fb26378c87b66622f8e3f91", size = 663706, upload-time = "2026-06-26T19:24:24.312Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/07/e210b02b589f16e74ff48b730690e4a34ffe984219fce4f3c1a0e7ec8545/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608", size = 660802, upload-time = "2026-06-26T18:32:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/41/35d1c678cdb3c3b9e6bee691728e563cfb294202b23c7a4c3c2ccc343589/greenlet-3.5.3-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:4399eb8d041f20b68d943918bc55502a93d6fdc0a37c14da7881c04139acee9d", size = 498803, upload-time = "2026-06-26T19:25:43.063Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2e/5303eb3fa06bca089060f479707182a93e360683bc252acf846c3090d34e/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb", size = 1622157, upload-time = "2026-06-26T19:09:09.527Z" },
+    { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/ca7d15afbdc397e3401134c9e1800d51d12b829661786187a4ad08fe484f/greenlet-3.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:b7068bd09f761f3f5b4d214c2bed063186b2a86148c740b3873e3f56d79bac31", size = 242586, upload-time = "2026-06-26T18:23:37.93Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -985,6 +1052,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1184,6 +1270,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -1607,6 +1705,7 @@ dependencies = [
     { name = "httpx" },
     { name = "mcp" },
     { name = "numpy" },
+    { name = "playwright" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1629,6 +1728,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "mcp", specifier = ">=1.28.0" },
     { name = "numpy", specifier = ">=2.0.0" },
+    { name = "playwright", specifier = ">=1.40.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },


### PR DESCRIPTION
## What

Adds a built-in host-side tool **`web.save_url_as_pdf(url, filename?)`**: give it a
URL and it lands a PDF in the agent **workspace**.

- If the URL is **already a PDF**, it's downloaded as-is.
- Otherwise the page is **rendered to a PDF** with headless Chromium (Playwright).

It returns the workspace-relative path; the agent reads it (`WORKSPACE + "/" + path`)
and can hand it to an upload tool (e.g. a Supernote MCP server) to send it on.

The Deno sandbox has no network, so fetching/rendering must happen host-side in
Python — this is that tool.

## Security model (SSRF)

Only public/global addresses are allowed.

- **Download path — pinned in code.** The host is resolved, every IP is checked
  (incl. IPv4-mapped / 6to4 / NAT64 / CGNAT-tailnet / loopback / link-local /
  multicast / reserved), and the connection is **pinned to the validated IP**
  (IP-literal URL + `Host` header + TLS `sni_hostname` so cert verification stays
  against the real hostname). Each redirect hop is re-validated. This defeats DNS
  rebinding for downloads.
- **Render path — relies on host egress filtering (deploy-level).** A real browser
  does its own DNS, follows redirects, and loads sub-resources we can't fully pin.
  The in-process guards (entry-URL check + a fail-closed per-request guard) are
  best-effort; the **authoritative** control is **host egress filtering** denying
  the victrola process outbound access to loopback / 169.254/16 (metadata) /
  RFC1918 / 100.64/10 / ULA. An nftables example is in the module docstring + README.
- **Workspace write** uses an `O_EXCL|O_NOFOLLOW` temp file + atomic `os.replace`,
  so a planted symlink/hardlink at the destination is never written through; the
  workspace root is `.resolve()`d (matches the executor / workspace router).
- **Resource limits:** body size-capped (100 MB), `page.pdf()` time-bounded,
  concurrent renders bounded by a semaphore; an OS memory limit (cgroup/container)
  is documented as the backstop. Chromium's sandbox stays ON by default
  (`WEB_PDF_CHROMIUM_NO_SANDBOX=1` opt-in only if the host can't launch otherwise).

## Deploy notes (Linux)

- `playwright` is now a dependency; install the browser once:
  `playwright install --with-deps chromium` (CI does this).
- Configure **egress filtering** and an **OS memory limit** for the victrola
  process (see README → "Saving web pages as PDFs").
- End-to-end "send a web page to my device" also needs an upload tool (e.g. a
  registered Supernote MCP server) for the agent to call after the PDF is saved.

## Tests

- 29 new tests in `tests/test_web_pdf.py`: SSRF block/allow (incl. mapped/6to4/
  NAT64/tailnet), **IP-pinning** (exact connected netloc + Host/SNI), redirect-to-
  private refusal, symlink + hardlink **no-clobber**, fail-closed route guard,
  exact content-type, symlinked-workspace-root, and a real Chromium render smoke.
- Full suite green; CI installs Chromium so the render test runs.

## Review

Two-reviewer code review (standard + adversarial), 3 cycles to clean. Cycle-1
found 2 SSRF blockers + a hardlink-clobber + memory/DoS issues; all fixed.
Accepted residuals (render rebinding → egress filtering; render memory → OS limit)
are deploy-level and documented.
