### PR TITLE
feat: files.upload_workspace_file — send a workspace file to Supernote (avoids the Deno bridge size limit)

### DIFF
--- a/src/tools/definitions/__init__.py
+++ b/src/tools/definitions/__init__.py
@@ -8,3 +8,4 @@ import src.tools.definitions.summarize  # noqa: F401
 import src.tools.definitions.system  # noqa: F401
 import src.tools.definitions.web  # noqa: F401
 import src.tools.definitions.web_pdf  # noqa: F401
+import src.tools.definitions.workspace_upload  # noqa: F401

--- a/src/tools/definitions/workspace_upload.py
+++ b/src/tools/definitions/workspace_upload.py
@@ -1,0 +1,148 @@
+"""Upload a workspace file to a registered MCP server (e.g. the Supernote cloud).
+
+The agent runs in a Deno sandbox whose tool-call bridge caps arguments at ~64 KiB,
+so it can't pass a base64'd PDF to an MCP `upload_file` tool inline. This
+host-side tool takes a workspace **path** instead: it reads the file in Python
+(safely scoped to the workspace), base64-encodes it host-side, and calls the MCP
+server's `upload_file(filename, content_base64, dest)` over HTTP — nothing large
+crosses the Deno bridge.
+
+Pairs with `web.save_url_as_pdf` (which saves a PDF into the workspace) to send a
+rendered page to the device.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import re
+import stat
+from pathlib import Path
+from typing import Any
+
+from src.config import CONFIG
+from src.tools.registry import TOOL_REGISTRY, ToolContext, ToolParameter
+
+logger = logging.getLogger(__name__)
+
+MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MB
+
+
+def _read_workspace_file(rel_path: str) -> tuple[bytes, str]:
+    """Read a workspace-relative file safely; return (bytes, own_filename).
+
+    Refuses anything that would read outside the workspace: path traversal,
+    symlink components, the final component being a symlink (`O_NOFOLLOW`), and
+    multi-linked files (a hardlink could share an inode with an outside file).
+    """
+    if not rel_path or not rel_path.strip():
+        raise ValueError("path is required")
+    workspace = Path(CONFIG.workspace_dir).resolve()
+    target = Path(os.path.normpath(workspace / rel_path))
+    if target != workspace and workspace not in target.parents:
+        raise ValueError("path is outside the workspace")
+    cur = workspace
+    for part in target.relative_to(workspace).parts:
+        cur = cur / part
+        if cur.is_symlink():
+            raise ValueError("symlinks are not permitted in the workspace path")
+    try:
+        fd = os.open(target, os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError as exc:
+        raise ValueError(f"cannot open {rel_path!r}: {exc}")
+    # Validate the fd before fdopen (fdopen on a dir raises IsADirectoryError).
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            raise ValueError("path is not a regular file")
+        if st.st_nlink > 1:
+            raise ValueError("refusing a multi-linked file (possible hardlink outside the workspace)")
+        if st.st_size > MAX_UPLOAD_BYTES:
+            raise ValueError(f"file exceeds {MAX_UPLOAD_BYTES} bytes")
+    except BaseException:
+        os.close(fd)
+        raise
+    with os.fdopen(fd, "rb") as f:  # takes ownership of fd, closes on exit
+        data = f.read()
+    return data, target.name
+
+
+def _safe_name(name: str) -> str:
+    base = os.path.basename((name or "").replace("\\", "/")).strip()
+    base = re.sub(r"[^A-Za-z0-9._-]", "_", base).strip("._")
+    return base or "file"
+
+
+@TOOL_REGISTRY.tool(
+    name="files.upload_workspace_file",
+    description=(
+        "Upload a file from the workspace to a registered MCP server's upload "
+        "tool (default: the Supernote cloud, which syncs to the device). Pass the "
+        "workspace-relative path; the file is read and base64-encoded host-side "
+        "and sent over HTTP, so it works for large files that can't be passed "
+        "inline. Use this to send a workspace PDF (e.g. one from "
+        "web.save_url_as_pdf) to the device."
+    ),
+    parameters=[
+        ToolParameter(
+            name="path",
+            type="string",
+            description="Workspace-relative path of the file to upload, e.g. 'article.pdf'.",
+        ),
+        ToolParameter(
+            name="dest",
+            type="string",
+            description="Destination folder (Document or Note, or a subpath like Note/Research). Defaults to Document.",
+            required=False,
+            default="Document",
+        ),
+        ToolParameter(
+            name="filename",
+            type="string",
+            description="Name to store it as; defaults to the file's own name.",
+            required=False,
+            default=None,
+        ),
+        ToolParameter(
+            name="server",
+            type="string",
+            description="MCP server to upload via (must expose upload_file(filename, content_base64, dest)). Defaults to 'supernote'.",
+            required=False,
+            default="supernote",
+        ),
+    ],
+)
+async def upload_workspace_file(
+    ctx: ToolContext,
+    path: str,
+    dest: str = "Document",
+    filename: str | None = None,
+    server: str = "supernote",
+) -> dict[str, Any]:
+    try:
+        data, own_name = _read_workspace_file(path)
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    if ctx.mcp_manager is None:
+        return {"error": "MCP manager is not available"}
+
+    name = _safe_name(filename or own_name)
+    b64 = base64.b64encode(data).decode("ascii")
+    result = await ctx.mcp_manager.call_tool(
+        server, "upload_file", {"filename": name, "content_base64": b64, "dest": dest}
+    )
+    if isinstance(result, dict) and result.get("error"):
+        return {"error": f"upload via '{server}' failed: {result['error']}"}
+
+    logger.info(
+        "upload_workspace_file: %s -> %s/%s via %s (%d bytes)",
+        path, dest, name, server, len(data),
+    )
+    return {
+        "uploaded": True,
+        "filename": name,
+        "dest": dest,
+        "size_bytes": len(data),
+        "result": result,
+    }

--- a/src/tools/definitions/workspace_upload.py
+++ b/src/tools/definitions/workspace_upload.py
@@ -57,7 +57,8 @@ def _read_workspace_file(rel_path: str) -> tuple[bytes, str]:
         fd = os.open(target, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
     except OSError as exc:
         raise ValueError(f"cannot open {rel_path!r}: {exc}")
-    # Validate the fd before fdopen (fdopen on a dir raises IsADirectoryError).
+    # Validate the raw fd BEFORE handing it to fdopen (fdopen on a dir raises
+    # IsADirectoryError). We own fd here, so close it ourselves on any failure.
     try:
         st = os.fstat(fd)
         if not stat.S_ISREG(st.st_mode):
@@ -66,18 +67,17 @@ def _read_workspace_file(rel_path: str) -> tuple[bytes, str]:
             raise ValueError("refusing a multi-linked file (possible hardlink outside the workspace)")
         if st.st_size > MAX_UPLOAD_BYTES:
             raise ValueError(f"file exceeds {MAX_UPLOAD_BYTES} bytes")
-        with os.fdopen(fd, "rb") as f:  # takes ownership of fd, closes on exit
-            # Capped read: enforce the limit on the bytes actually read, in case
-            # the file grew after fstat.
-            data = f.read(MAX_UPLOAD_BYTES + 1)
-            if len(data) > MAX_UPLOAD_BYTES:
-                raise ValueError(f"file exceeds {MAX_UPLOAD_BYTES} bytes")
     except BaseException:
-        try:
-            os.close(fd)
-        except OSError:
-            pass
+        os.close(fd)
         raise
+    # Ownership transfers to the file object now; its context manager is the
+    # only thing that closes fd (so a later raise can't double-close it).
+    with os.fdopen(fd, "rb") as f:
+        # Capped read: enforce the limit on the bytes actually read, in case the
+        # file grew after fstat.
+        data = f.read(MAX_UPLOAD_BYTES + 1)
+        if len(data) > MAX_UPLOAD_BYTES:
+            raise ValueError(f"file exceeds {MAX_UPLOAD_BYTES} bytes")
     return data, target.name
 
 

--- a/src/tools/definitions/workspace_upload.py
+++ b/src/tools/definitions/workspace_upload.py
@@ -27,6 +27,11 @@ logger = logging.getLogger(__name__)
 
 MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MB
 
+# Fixed destination MCP server. NOT agent-controllable: letting the model choose
+# the server would let a prompt-injected agent route the file's bytes to any
+# other connected MCP (exfiltration).
+_UPLOAD_SERVER = "supernote"
+
 
 def _read_workspace_file(rel_path: str) -> tuple[bytes, str]:
     """Read a workspace-relative file safely; return (bytes, own_filename).
@@ -47,7 +52,9 @@ def _read_workspace_file(rel_path: str) -> tuple[bytes, str]:
         if cur.is_symlink():
             raise ValueError("symlinks are not permitted in the workspace path")
     try:
-        fd = os.open(target, os.O_RDONLY | os.O_NOFOLLOW)
+        # O_NONBLOCK so opening a FIFO/device doesn't block waiting for a writer;
+        # O_NOFOLLOW so a final-component symlink can't redirect the read.
+        fd = os.open(target, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
     except OSError as exc:
         raise ValueError(f"cannot open {rel_path!r}: {exc}")
     # Validate the fd before fdopen (fdopen on a dir raises IsADirectoryError).
@@ -59,11 +66,18 @@ def _read_workspace_file(rel_path: str) -> tuple[bytes, str]:
             raise ValueError("refusing a multi-linked file (possible hardlink outside the workspace)")
         if st.st_size > MAX_UPLOAD_BYTES:
             raise ValueError(f"file exceeds {MAX_UPLOAD_BYTES} bytes")
+        with os.fdopen(fd, "rb") as f:  # takes ownership of fd, closes on exit
+            # Capped read: enforce the limit on the bytes actually read, in case
+            # the file grew after fstat.
+            data = f.read(MAX_UPLOAD_BYTES + 1)
+            if len(data) > MAX_UPLOAD_BYTES:
+                raise ValueError(f"file exceeds {MAX_UPLOAD_BYTES} bytes")
     except BaseException:
-        os.close(fd)
+        try:
+            os.close(fd)
+        except OSError:
+            pass
         raise
-    with os.fdopen(fd, "rb") as f:  # takes ownership of fd, closes on exit
-        data = f.read()
     return data, target.name
 
 
@@ -76,12 +90,11 @@ def _safe_name(name: str) -> str:
 @TOOL_REGISTRY.tool(
     name="files.upload_workspace_file",
     description=(
-        "Upload a file from the workspace to a registered MCP server's upload "
-        "tool (default: the Supernote cloud, which syncs to the device). Pass the "
-        "workspace-relative path; the file is read and base64-encoded host-side "
-        "and sent over HTTP, so it works for large files that can't be passed "
-        "inline. Use this to send a workspace PDF (e.g. one from "
-        "web.save_url_as_pdf) to the device."
+        "Upload a file from the workspace to the Supernote cloud (it syncs to "
+        "the device). Pass the workspace-relative path; the file is read and "
+        "base64-encoded host-side and sent over HTTP, so it works for large files "
+        "that can't be passed inline. Use this to send a workspace PDF (e.g. one "
+        "from web.save_url_as_pdf) to the device."
     ),
     parameters=[
         ToolParameter(
@@ -103,13 +116,6 @@ def _safe_name(name: str) -> str:
             required=False,
             default=None,
         ),
-        ToolParameter(
-            name="server",
-            type="string",
-            description="MCP server to upload via (must expose upload_file(filename, content_base64, dest)). Defaults to 'supernote'.",
-            required=False,
-            default="supernote",
-        ),
     ],
 )
 async def upload_workspace_file(
@@ -117,7 +123,6 @@ async def upload_workspace_file(
     path: str,
     dest: str = "Document",
     filename: str | None = None,
-    server: str = "supernote",
 ) -> dict[str, Any]:
     try:
         data, own_name = _read_workspace_file(path)
@@ -130,14 +135,14 @@ async def upload_workspace_file(
     name = _safe_name(filename or own_name)
     b64 = base64.b64encode(data).decode("ascii")
     result = await ctx.mcp_manager.call_tool(
-        server, "upload_file", {"filename": name, "content_base64": b64, "dest": dest}
+        _UPLOAD_SERVER, "upload_file", {"filename": name, "content_base64": b64, "dest": dest}
     )
     if isinstance(result, dict) and result.get("error"):
-        return {"error": f"upload via '{server}' failed: {result['error']}"}
+        return {"error": f"upload via '{_UPLOAD_SERVER}' failed: {result['error']}"}
 
     logger.info(
-        "upload_workspace_file: %s -> %s/%s via %s (%d bytes)",
-        path, dest, name, server, len(data),
+        "upload_workspace_file: %s -> %s/%s (%d bytes)",
+        path, dest, name, len(data),
     )
     return {
         "uploaded": True,

--- a/tests/test_workspace_upload.py
+++ b/tests/test_workspace_upload.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from src.config import CONFIG
+from src.tools.definitions import workspace_upload as wu
 from src.tools.definitions.workspace_upload import (
     _read_workspace_file,
     _safe_name,
@@ -86,6 +87,20 @@ def test_read_rejects_directory(temp_workspace):
         _read_workspace_file("d")
 
 
+def test_read_rejects_fifo_without_hanging(temp_workspace):
+    # O_NONBLOCK must keep opening a FIFO from blocking on a writer.
+    os.mkfifo(temp_workspace / "pipe")
+    with pytest.raises(ValueError):
+        _read_workspace_file("pipe")
+
+
+def test_read_rejects_oversize(temp_workspace, monkeypatch):
+    monkeypatch.setattr(wu, "MAX_UPLOAD_BYTES", 8)
+    (temp_workspace / "big.bin").write_bytes(b"x" * 64)
+    with pytest.raises(ValueError):
+        _read_workspace_file("big.bin")
+
+
 def test_safe_name():
     assert _safe_name("a b.pdf") == "a_b.pdf"
     assert _safe_name("../../etc/passwd") == "passwd"
@@ -121,3 +136,22 @@ async def test_upload_no_mcp_manager(temp_workspace):
 async def test_upload_bad_path_returns_error(temp_workspace):
     out = await upload_workspace_file(_ctx(_FakeMCP({})), "../escape.pdf")
     assert "error" in out and "outside the workspace" in out["error"]
+
+
+async def test_upload_symlink_sends_nothing(temp_workspace, tmp_path):
+    outside = tmp_path / "secret.pdf"
+    outside.write_bytes(b"SECRET")
+    os.symlink(outside, temp_workspace / "x.pdf")
+    mcp = _FakeMCP({"uploaded": True})
+    out = await upload_workspace_file(_ctx(mcp), "x.pdf")
+    assert "error" in out
+    assert mcp.calls == []  # outside bytes were never sent
+
+
+async def test_upload_oversize_sends_nothing(temp_workspace, monkeypatch):
+    monkeypatch.setattr(wu, "MAX_UPLOAD_BYTES", 8)
+    (temp_workspace / "big.bin").write_bytes(b"x" * 64)
+    mcp = _FakeMCP({"uploaded": True})
+    out = await upload_workspace_file(_ctx(mcp), "big.bin")
+    assert "error" in out
+    assert mcp.calls == []

--- a/tests/test_workspace_upload.py
+++ b/tests/test_workspace_upload.py
@@ -1,0 +1,123 @@
+"""Tests for files.upload_workspace_file."""
+from __future__ import annotations
+
+import base64
+import os
+from pathlib import Path
+
+import pytest
+
+from src.config import CONFIG
+from src.tools.definitions.workspace_upload import (
+    _read_workspace_file,
+    _safe_name,
+    upload_workspace_file,
+)
+from src.tools.registry import ToolContext
+
+PDF = b"%PDF-1.4 hello"
+
+
+@pytest.fixture
+def temp_workspace(tmp_path: Path, monkeypatch):
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    monkeypatch.setattr(CONFIG, "workspace_dir", str(ws))
+    return ws
+
+
+class _FakeMCP:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    async def call_tool(self, server, tool, params):
+        self.calls.append((server, tool, params))
+        return self.result
+
+
+def _ctx(mcp):
+    ctx = ToolContext()
+    ctx._mcp_manager = mcp
+    return ctx
+
+
+# -------------------- safe read --------------------
+def test_read_regular_file(temp_workspace):
+    (temp_workspace / "a.pdf").write_bytes(PDF)
+    data, name = _read_workspace_file("a.pdf")
+    assert data == PDF and name == "a.pdf"
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "../outside", "/etc/passwd", "a/../../x"])
+def test_read_rejects_bad_paths(temp_workspace, bad):
+    with pytest.raises(ValueError):
+        _read_workspace_file(bad)
+
+
+def test_read_rejects_symlink_component(temp_workspace, tmp_path):
+    outside = tmp_path / "secret"
+    outside.mkdir()
+    (outside / "f.pdf").write_bytes(b"SECRET")
+    os.symlink(outside, temp_workspace / "link")
+    with pytest.raises(ValueError):
+        _read_workspace_file("link/f.pdf")
+
+
+def test_read_rejects_final_symlink(temp_workspace, tmp_path):
+    outside = tmp_path / "s.pdf"
+    outside.write_bytes(b"SECRET")
+    os.symlink(outside, temp_workspace / "x.pdf")
+    with pytest.raises(ValueError):
+        _read_workspace_file("x.pdf")
+
+
+def test_read_rejects_hardlink(temp_workspace, tmp_path):
+    outside = tmp_path / "h.pdf"
+    outside.write_bytes(b"SECRET")
+    os.link(outside, temp_workspace / "x.pdf")
+    with pytest.raises(ValueError):
+        _read_workspace_file("x.pdf")
+
+
+def test_read_rejects_directory(temp_workspace):
+    (temp_workspace / "d").mkdir()
+    with pytest.raises(ValueError):
+        _read_workspace_file("d")
+
+
+def test_safe_name():
+    assert _safe_name("a b.pdf") == "a_b.pdf"
+    assert _safe_name("../../etc/passwd") == "passwd"
+    assert _safe_name("") == "file"
+
+
+# -------------------- upload --------------------
+async def test_upload_success(temp_workspace):
+    (temp_workspace / "a.pdf").write_bytes(PDF)
+    mcp = _FakeMCP({"uploaded": True, "filename": "a.pdf"})
+    out = await upload_workspace_file(_ctx(mcp), "a.pdf", dest="Note")
+    assert out["uploaded"] is True
+    assert out["size_bytes"] == len(PDF)
+    server, tool, params = mcp.calls[0]
+    assert server == "supernote" and tool == "upload_file"
+    assert params["filename"] == "a.pdf" and params["dest"] == "Note"
+    assert base64.b64decode(params["content_base64"]) == PDF
+
+
+async def test_upload_passes_through_mcp_error(temp_workspace):
+    (temp_workspace / "a.pdf").write_bytes(PDF)
+    mcp = _FakeMCP({"error": "folder 'Inbox' not found"})
+    out = await upload_workspace_file(_ctx(mcp), "a.pdf", dest="Inbox")
+    assert "error" in out and "folder" in out["error"]
+
+
+async def test_upload_no_mcp_manager(temp_workspace):
+    (temp_workspace / "a.pdf").write_bytes(PDF)
+    out = await upload_workspace_file(_ctx(None), "a.pdf")
+    assert "error" in out and "MCP manager" in out["error"]
+
+
+async def test_upload_bad_path_returns_error(temp_workspace):
+    out = await upload_workspace_file(_ctx(_FakeMCP({})), "../escape.pdf")
+    assert "error" in out and "outside the workspace" in out["error"]


### PR DESCRIPTION
## What

Adds a built-in host-side tool **`files.upload_workspace_file(path, dest?, filename?)`**:
it sends a file from the agent workspace to the **Supernote** cloud (which syncs to
the device).

## Why

The agent's Deno↔Python tool-call bridge frames each call as one newline-delimited
line read by an asyncio `StreamReader` with the **default 64 KiB cap**. So the agent
*cannot* pass a base64'd PDF to `supernote.upload_file` inline — it fails with
`LimitOverrunError: "Separator is not found, and chunk exceed the limit"`. (base64
inflates 4/3, so even a ~48 KB PDF is over.)

This tool takes a workspace **path** instead (tiny): it reads the file **host-side**
in Python, base64-encodes it **host-side**, and calls the Supernote MCP's
`upload_file(filename, content_base64, dest)` over HTTP via `ctx.mcp_manager`.
Nothing large crosses the Deno bridge, so it works for real PDFs.

Pairs with `web.save_url_as_pdf` (which saves a rendered page to the workspace) to
do "render an arbitrary page → send it to the device" end-to-end.

## Security

- **Destination is pinned** (`_UPLOAD_SERVER = "supernote"`), not agent-controllable —
  a prompt-injected agent can't route the file's bytes to some other connected MCP.
- **Workspace-scoped read**: lexical containment (no traversal/absolute escape),
  reject any symlink path component, `O_NOFOLLOW` (final-component symlink),
  `O_NONBLOCK` (a FIFO/device can't hang the open), `fstat`-validate before `fdopen`
  (regular file, reject multi-linked/hardlink-out), and a capped read enforcing the
  100 MB limit on the bytes actually read.

## Tests

19 tests: regular read/upload success (asserts the pinned server + correct base64),
traversal/absolute, symlink component, final symlink, hardlink, directory, FIFO
(no hang), oversize, and "no MCP call / outside bytes never sent" on the denial
paths. Full suite green.

## Review

Two-reviewer code review (standard + adversarial), 3 cycles to clean. Cycle-1 found a
High (agent-controlled destination server → exfil) + FIFO-hang + size-TOCTOU; cycle-2
an fd double-close; all fixed.
