### PR TITLE
Persist structured tool turns across chat turns

### DIFF
--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -535,6 +535,44 @@ def _format_tool_result(result: dict[str, Any]) -> str | list[dict[str, Any]]:
     return content_str
 
 
+def _persistable_message(message: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of a message safe to persist long-term.
+
+    Image data in tool results is replaced with a short text placeholder so we
+    never write large base64 blobs to the store. Images are ephemeral — they
+    only matter for the turn that produced them — and text tool results are
+    already capped at MAX_TOOL_RESULT_LENGTH, so this only affects the image
+    path (the only unbounded payload). The in-memory conversation keeps the
+    full content for the current turn; only the persisted copy is bounded.
+    """
+    content = message.get("content")
+    if not isinstance(content, list):
+        return message
+
+    new_content: list[Any] = []
+    changed = False
+    for block in content:
+        if (
+            isinstance(block, dict)
+            and block.get("type") == "tool_result"
+            and isinstance(block.get("content"), list)
+        ):
+            new_content.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": block.get("tool_use_id"),
+                    "content": "[tool result: image omitted from history]",
+                }
+            )
+            changed = True
+        else:
+            new_content.append(block)
+
+    if not changed:
+        return message
+    return {**message, "content": new_content}
+
+
 def _timestamp_prefix(message: str) -> str:
     """prefix user mesages with a formatted timestamp for agent awareness"""
     now = datetime.now(timezone.utc)
@@ -678,6 +716,18 @@ class Agent:
         messages with tool_use blocks that lack matching tool_result responses.
         The Anthropic API rejects these. This method patches them up.
         """
+        # Drop assistant messages that carry no content blocks. Some providers
+        # can return an empty turn, and the APIs reject an empty content list.
+        conversation[:] = [
+            m
+            for m in conversation
+            if not (
+                m.get("role") == "assistant"
+                and isinstance(m.get("content"), list)
+                and len(m["content"]) == 0
+            )
+        ]
+
         i = 0
         while i < len(conversation):
             msg = conversation[i]
@@ -843,6 +893,28 @@ class Agent:
                 split_idx = i
                 break
 
+        # Don't split a tool_use/tool_result pair: if `recent` would start with
+        # a tool_result message, move the boundary back so the matching
+        # assistant tool_use stays in `recent` too. Otherwise we'd summarize the
+        # tool_use while _repair_conversation later neutralizes the orphaned
+        # result, dropping the tool's actual output from the model's context.
+        def _starts_with_tool_result(idx: int) -> bool:
+            if idx >= len(conversation):
+                return False
+            m = conversation[idx]
+            c = m.get("content")
+            return (
+                m.get("role") == "user"
+                and isinstance(c, list)
+                and any(
+                    isinstance(b, dict) and b.get("type") == "tool_result"
+                    for b in c
+                )
+            )
+
+        while split_idx > 0 and _starts_with_tool_result(split_idx):
+            split_idx -= 1
+
         older = conversation[:split_idx]
         recent = conversation[split_idx:]
         if not older:
@@ -995,7 +1067,7 @@ class Agent:
             if on_message is None:
                 return
             try:
-                await on_message(message)
+                await on_message(_persistable_message(message))
             except Exception:
                 logger.exception("on_message callback failed; continuing")
         # refresh the system prompt before each operator turn so that newly
@@ -1026,6 +1098,11 @@ class Agent:
             )
         else:
             effective_system_prompt = self._system_prompt or ""
+
+        # Repair any dangling tool_use/tool_result pairs left by a previously
+        # interrupted turn BEFORE compaction, so the summary and checkpoint are
+        # built from an API-valid, semantically explicit history.
+        self._repair_conversation(conversation)
 
         # compact the conversation if it's gotten huge
         try:
@@ -1100,7 +1177,10 @@ class Agent:
             if resp.reasoning_content:
                 assistant_msg["reasoning_content"] = resp.reasoning_content
             conversation.append(assistant_msg)
-            await _persist(assistant_msg)
+            # Skip persisting an empty assistant turn (no text or tool_use
+            # blocks): the APIs reject an empty content list on reload.
+            if assistant_content:
+                await _persist(assistant_msg)
 
             # find any tool calls that we need to handle
             if resp.stop_reason == "tool_use":
@@ -1178,12 +1258,12 @@ class Agent:
             if isinstance(block, AgentTextBlock):
                 text_response += block.text
         if text_response:
-            await _persist(
-                {
-                    "role": "assistant",
-                    "content": [{"type": "text", "text": text_response}],
-                }
-            )
+            final_msg = {
+                "role": "assistant",
+                "content": [{"type": "text", "text": text_response}],
+            }
+            conversation.append(final_msg)
+            await _persist(final_msg)
         if total_usage:
             logger.info("Chat total usage: %s", total_usage)
         return text_response

--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -557,13 +557,18 @@ def _persistable_message(message: dict[str, Any]) -> dict[str, Any]:
             and block.get("type") == "tool_result"
             and isinstance(block.get("content"), list)
         ):
-            new_content.append(
-                {
-                    "type": "tool_result",
-                    "tool_use_id": block.get("tool_use_id"),
-                    "content": "[tool result: image omitted from history]",
-                }
-            )
+            # Keep any text blocks; replace only the image block(s) with a
+            # placeholder so we preserve the tool's textual output but never
+            # store the base64 blob.
+            inner: list[Any] = []
+            for b in block["content"]:
+                if isinstance(b, dict) and b.get("type") == "image":
+                    inner.append(
+                        {"type": "text", "text": "[image omitted from history]"}
+                    )
+                else:
+                    inner.append(b)
+            new_content.append({**block, "content": inner})
             changed = True
         else:
             new_content.append(block)
@@ -1099,12 +1104,10 @@ class Agent:
         else:
             effective_system_prompt = self._system_prompt or ""
 
-        # Repair any dangling tool_use/tool_result pairs left by a previously
-        # interrupted turn BEFORE compaction, so the summary and checkpoint are
-        # built from an API-valid, semantically explicit history.
-        self._repair_conversation(conversation)
-
-        # compact the conversation if it's gotten huge
+        # compact the conversation if it's gotten huge. Repair runs inside the
+        # iteration loop (before each API call), not here: mutating the
+        # conversation before compaction would desync the caller's parallel
+        # msg_ids list and make on_compact checkpoint the wrong store row.
         try:
             await self._maybe_compact(conversation, on_compact=on_compact)
         except Exception:
@@ -1158,7 +1161,10 @@ class Agent:
 
             for block in resp.content:
                 if isinstance(block, AgentTextBlock):
-                    assistant_content.append({"type": "text", "text": block.text})
+                    # Skip empty text blocks: the APIs reject a zero-length text
+                    # block, and persisting one would 400 the next reload.
+                    if block.text:
+                        assistant_content.append({"type": "text", "text": block.text})
                     text_response += block.text
                 elif isinstance(block, AgentToolUseBlock):  # type: ignore
                     assistant_content.append(

--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -928,6 +928,7 @@ class Agent:
         conversation: list[dict[str, Any]],
         on_event: Callable[[AgentEvent], Awaitable[None]] | None = None,
         on_compact: Callable[[str, int], Awaitable[None]] | None = None,
+        on_message: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         images: list[dict[str, str]] | None = None,
     ) -> str:
         """Send a message and get a response, handling tool calls.
@@ -949,13 +950,28 @@ class Agent:
         that were summarized. Callers use this to persist a compaction checkpoint
         to the store so the summary can be reused on reload instead of
         re-summarizing from scratch.
+
+        `on_message` is an optional callback invoked once for each message the
+        agent appends to the conversation during the turn — every assistant
+        message (including ones carrying only tool_use blocks) and every
+        tool-results message. Callers use it to persist the full structured
+        turn so the agent's tool history survives across turns, instead of only
+        the final text reply. The current user message is not re-emitted here;
+        callers persist it themselves before calling chat().
         """
 
         async def _emit(event: AgentEvent) -> None:
             if on_event is not None:
                 await on_event(event)
 
-        return await self._chat_impl(user_message, conversation, _emit, on_compact=on_compact, images=images)
+        return await self._chat_impl(
+            user_message,
+            conversation,
+            _emit,
+            on_compact=on_compact,
+            on_message=on_message,
+            images=images,
+        )
 
     async def _chat_impl(
         self,
@@ -963,10 +979,25 @@ class Agent:
         conversation: list[dict[str, Any]],
         _emit: Callable[[AgentEvent], Awaitable[None]],
         on_compact: Callable[[str, int], Awaitable[None]] | None = None,
+        on_message: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         images: list[dict[str, str]] | None = None,
     ) -> str:
         """Inner chat loop. `conversation` is the caller-owned list that
         will be mutated in place. Do not call directly — go through `chat()`."""
+
+        async def _persist(message: dict[str, Any]) -> None:
+            """Hand a freshly-appended message to the on_message callback.
+
+            Serialization happens inside the callback, so later in-place
+            mutation of the conversation (trimming, repair) does not affect
+            what was persisted. Failures are logged but never abort the turn.
+            """
+            if on_message is None:
+                return
+            try:
+                await on_message(message)
+            except Exception:
+                logger.exception("on_message callback failed; continuing")
         # refresh the system prompt before each operator turn so that newly
         # added secrets, approved custom tools, self-note edits, and skills
         # show up without restarting the harness.
@@ -1069,6 +1100,7 @@ class Agent:
             if resp.reasoning_content:
                 assistant_msg["reasoning_content"] = resp.reasoning_content
             conversation.append(assistant_msg)
+            await _persist(assistant_msg)
 
             # find any tool calls that we need to handle
             if resp.stop_reason == "tool_use":
@@ -1108,7 +1140,9 @@ class Agent:
                             }
                         )
 
-                conversation.append({"role": "user", "content": tool_results})
+                tool_results_msg = {"role": "user", "content": tool_results}
+                conversation.append(tool_results_msg)
+                await _persist(tool_results_msg)
             else:
                 # once there are no more tool calls, we proceed to the text response
                 if total_usage:
@@ -1143,6 +1177,13 @@ class Agent:
         for block in resp.content:
             if isinstance(block, AgentTextBlock):
                 text_response += block.text
+        if text_response:
+            await _persist(
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": text_response}],
+                }
+            )
         if total_usage:
             logger.info("Chat total usage: %s", total_usage)
         return text_response

--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -344,8 +344,13 @@ class OpenAICompatibleClient(AgentClient):
                         oai_msg["tool_calls"] = tool_calls
                     result.append(oai_msg)
                 elif role == "user":
-                    if content and content[0].get("type") == "tool_result":
-                        for block in content:
+                    tool_result_blocks = [
+                        b
+                        for b in content
+                        if isinstance(b, dict) and b.get("type") == "tool_result"
+                    ]
+                    if tool_result_blocks:
+                        for block in tool_result_blocks:
                             raw = block.get("content", "")
                             if isinstance(raw, list):
                                 # image content blocks — convert to OAI format
@@ -383,6 +388,20 @@ class OpenAICompatibleClient(AgentClient):
                                         "content": raw,
                                     }
                                 )
+                        # Non-tool_result blocks mixed into the same user turn
+                        # (e.g. text left behind when orphan repair neutralizes
+                        # one of several tool_results) become a trailing user
+                        # message, so a tool_result is never stringified into
+                        # user content and tool-call pairing stays intact.
+                        leftover = " ".join(
+                            b.get("text", "")
+                            for b in content
+                            if isinstance(b, dict)
+                            and b.get("type") == "text"
+                            and b.get("text")
+                        ).strip()
+                        if leftover:
+                            result.append({"role": "user", "content": leftover})
                     else:
                         # User message with multi-block content (e.g. images
                         # pasted alongside text). Convert any Anthropic image

--- a/src/agent/conversation.py
+++ b/src/agent/conversation.py
@@ -25,14 +25,20 @@ class ConversationManager:
         return self._ctx.store
 
     async def save_message(self, session_id: str, message: dict[str, Any]) -> None:
-        """Save a message to the session as a chat message record."""
+        """Save a message to the session as a chat message record.
+
+        Structured content (lists of tool_use / tool_result / text blocks) is
+        embedded directly in the payload so a single ``json.loads`` on load
+        restores it as a list, keeping multi-block turns intact across reloads.
+        Pre-serializing the list here would double-encode it, and the agent
+        would later see a JSON string instead of structured blocks.
+        """
         role = message.get("role", "user")
         content = message.get("content", "")
 
-        # serialize structured content (tool results, multi-block assistant messages)
-        if isinstance(content, list):
-            content = json.dumps(content, default=str)
-        elif not isinstance(content, str):
+        # Coerce only exotic content to a string; strings and block lists are
+        # embedded as-is so the round-trip preserves structure.
+        if not isinstance(content, (str, list)):
             content = str(content)
 
         payload = json.dumps({"role": role, "content": content}, default=str)

--- a/src/agent/conversation.py
+++ b/src/agent/conversation.py
@@ -163,26 +163,43 @@ async def maybe_generate_session_title(
     # count user messages and sample the first couple of turns
     msgs = await store.chat.list_messages(session_id=session_id, limit=20)
     records = msgs.get("messages", [])
-    user_count = sum(1 for r in records if r.get("sender") == "user")
+
+    def _display_text(record: dict[str, Any]) -> str:
+        """Extract the human-readable text from a stored message record.
+
+        Structured tool turns (tool_use / tool_result blocks) carry no text
+        and return "" so they don't count as conversation turns or pollute the
+        title transcript with blank lines.
+        """
+        content = record.get("content", "")
+        try:
+            parsed = json.loads(content)
+            text = parsed.get("content", "")
+        except (json.JSONDecodeError, TypeError):
+            return str(content)
+        if isinstance(text, list):
+            return " ".join(
+                b.get("text", "")
+                for b in text
+                if isinstance(b, dict) and b.get("type") == "text"
+            )
+        return str(text)
+
+    # Count only human user turns. Tool-result turns are also stored with
+    # sender="user" but carry no displayable text, so they must not inflate the
+    # auto-title threshold.
+    user_count = sum(
+        1 for r in records if r.get("sender") == "user" and _display_text(r).strip()
+    )
     if user_count < TITLE_GEN_MIN_USER_MESSAGES:
         return None
 
     transcript_parts: list[str] = []
     for r in records[:10]:
-        sender = r.get("sender", "?")
-        content = r.get("content", "")
-        try:
-            parsed = json.loads(content)
-            text = parsed.get("content", "")
-            if isinstance(text, list):
-                text = " ".join(
-                    b.get("text", "") for b in text
-                    if isinstance(b, dict) and b.get("type") == "text"
-                )
-        except (json.JSONDecodeError, TypeError):
-            text = str(content)
-        text = str(text)[:500]
-        transcript_parts.append(f"{sender}: {text}")
+        text = _display_text(r).strip()
+        if not text:
+            continue
+        transcript_parts.append(f"{r.get('sender', '?')}: {text[:500]}")
     transcript = "\n".join(transcript_parts)
 
     try:

--- a/src/signal_bot/bot.py
+++ b/src/signal_bot/bot.py
@@ -286,6 +286,12 @@ class SignalBot:
                             self._session_rkey, last_id, summary
                         )
 
+            # Persist each structured message (assistant turns and tool-result
+            # turns) as the agent produces it, so the agent's tool history
+            # survives across turns instead of only the final text reply.
+            async def on_message(message: dict[str, Any]) -> None:
+                await conv_manager.save_message(self._session_rkey, message)
+
             # Run agent with a typing indicator while it thinks
             typing_stop = asyncio.Event()
             typing_task = asyncio.create_task(self._typing_loop(typing_stop))
@@ -294,6 +300,7 @@ class SignalBot:
                     user_text,
                     conversation=messages,
                     on_compact=on_compact,
+                    on_message=on_message,
                     images=images or None,
                 )
             finally:
@@ -302,15 +309,10 @@ class SignalBot:
                     await typing_task
                 await self._stop_typing()
 
-            # Save assistant response
+            # The structured turn (assistant + tool-result messages) was
+            # persisted incrementally via on_message during agent.chat(), so
+            # here we only deliver the reply to the operator.
             if response:
-                await store.chat.create_message(
-                    session_id=self._session_rkey,
-                    sender="assistant",
-                    content=json.dumps(
-                        {"role": "assistant", "content": response}, default=str
-                    ),
-                )
                 await self._send_response(response)
             else:
                 await self._send_response("(empty response)")

--- a/src/web/routers/chat.py
+++ b/src/web/routers/chat.py
@@ -113,6 +113,15 @@ async def chat(
                         except Exception:
                             logger.exception("Failed to persist compaction checkpoint")
 
+            # Persist each structured message (assistant turns and tool-result
+            # turns) as the agent produces it, so the agent's tool history
+            # survives across turns instead of only the final text reply.
+            async def on_message(message: dict[str, Any]) -> None:
+                try:
+                    await conv_manager.save_message(session_id, message)
+                except Exception:
+                    logger.exception("Failed to persist conversation message")
+
             # 4. run agent.chat as a background task — agent.chat() appends
             # the user_message to the conversation list internally
             chat_task = asyncio.create_task(
@@ -121,6 +130,7 @@ async def chat(
                     conversation=conversation,
                     on_event=on_event,
                     on_compact=on_compact,
+                    on_message=on_message,
                     images=body.images,
                 )
             )
@@ -158,17 +168,10 @@ async def chat(
                 # 8. synthesize response event
                 yield _sse("response", {"text": response})
 
-                # 9. save assistant response
+                # 9. The structured turn (assistant + tool-result messages) was
+                # persisted incrementally via on_message during agent.chat();
+                # here we only auto-generate a session title.
                 if response:
-                    try:
-                        await conv_manager.save_message(
-                            session_id,
-                            {"role": "assistant", "content": response},
-                        )
-                    except Exception:
-                        logger.exception("Failed to persist assistant message")
-
-                    # 10. trigger title generation
                     try:
                         await maybe_generate_session_title(
                             store, session_id, executor.llm_client
@@ -176,7 +179,7 @@ async def chat(
                     except Exception:
                         logger.exception("Failed to auto-generate session title")
 
-                # 11. done
+                # 10. done
                 yield _sse("done", {})
             finally:
                 if not chat_task.done():

--- a/tests/test_compaction_agent.py
+++ b/tests/test_compaction_agent.py
@@ -285,10 +285,15 @@ def test_persistable_message_strips_tool_result_images():
         ],
     }
     out = _persistable_message(msg)
-    assert out["content"][0]["content"] == "[tool result: image omitted from history]"
+    inner = out["content"][0]["content"]
+    # Text is preserved; only the image block is replaced.
+    assert isinstance(inner, list)
+    assert {"type": "text", "text": "here"} in inner
+    assert {"type": "text", "text": "[image omitted from history]"} in inner
+    assert "A" * 5000 not in json.dumps(out)
     assert out["content"][0]["tool_use_id"] == "t1"
     # Original message is not mutated.
-    assert isinstance(msg["content"][0]["content"], list)
+    assert any(b.get("type") == "image" for b in msg["content"][0]["content"])
 
     # String tool results pass through unchanged (same object).
     str_msg = {
@@ -337,6 +342,47 @@ async def test_on_message_persists_image_tool_result_without_base64(tmp_path):
     blob = json.dumps(tool_result_turn)
     assert "B" * 5000 not in blob
     assert "image omitted" in blob
+
+    await store.close()
+
+
+async def test_empty_text_block_not_persisted_alongside_tool_use(tmp_path):
+    """An empty text block returned next to a tool_use is filtered out so the
+    persisted/reloaded assistant turn never carries a zero-length text block."""
+    from src.agent.agent import AgentResponse, AgentTextBlock, AgentToolUseBlock
+
+    agent, store, mock_client = await _make_agent_with_stub_client(tmp_path)
+    mock_client.complete = AsyncMock(
+        side_effect=[
+            AgentResponse(
+                content=[
+                    AgentTextBlock(text=""),
+                    AgentToolUseBlock(id="t1", name="execute_code", input={"code": "1"}),
+                ],
+                stop_reason="tool_use",
+                usage={},
+            ),
+            AgentResponse(
+                content=[AgentTextBlock(text="done")], stop_reason="end_turn", usage={}
+            ),
+        ]
+    )
+    agent._handle_tool_call = AsyncMock(return_value={"output": "ok"})
+
+    received = []
+
+    async def on_message(message):
+        received.append(message)
+
+    await agent.chat("go", conversation=[], on_message=on_message)
+
+    # First persisted turn is the assistant tool_use turn — tool_use only.
+    assert [b["type"] for b in received[0]["content"]] == ["tool_use"]
+    # No empty text block anywhere in the persisted turns.
+    for m in received:
+        for b in m["content"]:
+            if b.get("type") == "text":
+                assert b["text"] != ""
 
     await store.close()
 

--- a/tests/test_compaction_agent.py
+++ b/tests/test_compaction_agent.py
@@ -237,6 +237,167 @@ async def test_on_message_optional(tmp_path):
     await store.close()
 
 
+async def test_on_message_skips_empty_assistant_turn(tmp_path):
+    """An empty assistant turn (no text/tool_use blocks) is not persisted —
+    reloading one would send an empty content list and 400 the API."""
+    from src.agent.agent import AgentResponse
+
+    agent, store, mock_client = await _make_agent_with_stub_client(tmp_path)
+    mock_client.complete = AsyncMock(
+        return_value=AgentResponse(content=[], stop_reason="end_turn", usage={})
+    )
+
+    received = []
+
+    async def on_message(message):
+        received.append(message)
+
+    response = await agent.chat("hi", conversation=[], on_message=on_message)
+    assert response == ""
+    assert received == []
+
+    await store.close()
+
+
+def test_persistable_message_strips_tool_result_images():
+    """Image blocks in tool results are replaced with a placeholder for storage,
+    without mutating the original (in-memory) message."""
+    from src.agent.agent import _persistable_message
+
+    msg = {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "t1",
+                "content": [
+                    {"type": "text", "text": "here"},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "A" * 5000,
+                        },
+                    },
+                ],
+            }
+        ],
+    }
+    out = _persistable_message(msg)
+    assert out["content"][0]["content"] == "[tool result: image omitted from history]"
+    assert out["content"][0]["tool_use_id"] == "t1"
+    # Original message is not mutated.
+    assert isinstance(msg["content"][0]["content"], list)
+
+    # String tool results pass through unchanged (same object).
+    str_msg = {
+        "role": "user",
+        "content": [{"type": "tool_result", "tool_use_id": "t2", "content": "ok"}],
+    }
+    assert _persistable_message(str_msg) is str_msg
+
+
+async def test_on_message_persists_image_tool_result_without_base64(tmp_path):
+    """A tool result carrying an image is persisted without the base64 blob."""
+    from src.agent.agent import AgentResponse, AgentTextBlock, AgentToolUseBlock
+
+    agent, store, mock_client = await _make_agent_with_stub_client(tmp_path)
+    mock_client.complete = AsyncMock(
+        side_effect=[
+            AgentResponse(
+                content=[
+                    AgentToolUseBlock(id="t1", name="execute_code", input={"code": "1"})
+                ],
+                stop_reason="tool_use",
+                usage={},
+            ),
+            AgentResponse(
+                content=[AgentTextBlock(text="done")], stop_reason="end_turn", usage={}
+            ),
+        ]
+    )
+    agent._handle_tool_call = AsyncMock(
+        return_value={
+            "output": {
+                "type": "image_result",
+                "image": {"type": "base64", "media_type": "image/png", "data": "B" * 5000},
+            }
+        }
+    )
+
+    received = []
+
+    async def on_message(message):
+        received.append(message)
+
+    await agent.chat("show", conversation=[], on_message=on_message)
+
+    tool_result_turn = next(m for m in received if m["role"] == "user")
+    blob = json.dumps(tool_result_turn)
+    assert "B" * 5000 not in blob
+    assert "image omitted" in blob
+
+    await store.close()
+
+
+async def test_title_generation_ignores_tool_result_user_rows(tmp_path):
+    """tool_result rows (sender=user, no text) must not satisfy the auto-title
+    user-message threshold."""
+    from src.agent.conversation import maybe_generate_session_title
+
+    store = Store(path=tmp_path / "test.db")
+    await store.initialize()
+    session_id = "sess"
+    await store.chat.ensure_session(rkey=session_id, title="")
+
+    # One real human user turn + a structured tool turn whose tool_result row is
+    # also stored with sender="user".
+    await store.chat.create_message(
+        session_id=session_id,
+        sender="user",
+        content=json.dumps({"role": "user", "content": "do a thing"}),
+    )
+    await store.chat.create_message(
+        session_id=session_id,
+        sender="assistant",
+        content=json.dumps(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "execute_code", "input": {"code": "x"}}
+                ],
+            }
+        ),
+    )
+    await store.chat.create_message(
+        session_id=session_id,
+        sender="user",
+        content=json.dumps(
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}],
+            }
+        ),
+    )
+
+    class _CountingLLM:
+        def __init__(self):
+            self.called = False
+
+        async def complete(self, *args, **kwargs):
+            self.called = True
+            return "Some Title"
+
+    llm = _CountingLLM()
+    # Only one real human user turn (< TITLE_GEN_MIN_USER_MESSAGES) -> no title.
+    result = await maybe_generate_session_title(store, session_id, llm)
+    assert result is None
+    assert llm.called is False
+
+    await store.close()
+
+
 async def test_load_session_with_ids_no_checkpoint(tmp_path):
     """load_session_with_ids returns messages and IDs with no compaction."""
     store = Store(path=tmp_path / "test.db")
@@ -426,5 +587,12 @@ async def test_compaction_does_not_orphan_tool_result(tmp_path):
                         f"Orphaned tool_result for tool_use_id={b['tool_use_id']} "
                         f"with no matching tool_use in conversation"
                     )
+
+    # The pair is kept together in `recent`, so the tool's actual output
+    # survives compaction rather than being neutralized to a placeholder.
+    joined = json.dumps(conversation)
+    assert "tool_1" in joined
+    assert "R" * 400 in joined
+    assert "[orphaned tool result removed]" not in joined
 
     await store.close()

--- a/tests/test_compaction_agent.py
+++ b/tests/test_compaction_agent.py
@@ -167,6 +167,76 @@ async def test_on_compact_callback_failure_does_not_crash(tmp_path):
     await store.close()
 
 
+async def test_on_message_persists_assistant_turn(tmp_path):
+    """on_message fires once with the assistant message on a no-tool turn."""
+    agent, store, mock_client = await _make_agent_with_stub_client(tmp_path)
+
+    received = []
+
+    async def on_message(message):
+        received.append(message)
+
+    await agent.chat("hi", conversation=[], on_message=on_message)
+
+    assert len(received) == 1
+    assert received[0]["role"] == "assistant"
+    assert received[0]["content"][0]["type"] == "text"
+    assert received[0]["content"][0]["text"] == "stub response"
+
+    await store.close()
+
+
+async def test_on_message_persists_full_tool_turn(tmp_path):
+    """on_message fires for the assistant tool_use turn, the tool_result turn,
+    and the final assistant text turn — in order."""
+    from src.agent.agent import AgentResponse, AgentTextBlock, AgentToolUseBlock
+
+    agent, store, mock_client = await _make_agent_with_stub_client(tmp_path)
+
+    mock_client.complete = AsyncMock(
+        side_effect=[
+            AgentResponse(
+                content=[
+                    AgentToolUseBlock(id="t1", name="execute_code", input={"code": "1"})
+                ],
+                stop_reason="tool_use",
+                usage={},
+            ),
+            AgentResponse(
+                content=[AgentTextBlock(text="done")],
+                stop_reason="end_turn",
+                usage={},
+            ),
+        ]
+    )
+    # Bypass the real Deno executor.
+    agent._handle_tool_call = AsyncMock(return_value={"output": "ok"})
+
+    received = []
+
+    async def on_message(message):
+        received.append(message)
+
+    await agent.chat("run it", conversation=[], on_message=on_message)
+
+    shape = [(m["role"], m["content"][0]["type"]) for m in received]
+    assert shape == [
+        ("assistant", "tool_use"),
+        ("user", "tool_result"),
+        ("assistant", "text"),
+    ]
+
+    await store.close()
+
+
+async def test_on_message_optional(tmp_path):
+    """chat() without on_message should work fine."""
+    agent, store, mock_client = await _make_agent_with_stub_client(tmp_path)
+    response = await agent.chat("test", conversation=[])
+    assert response == "stub response"
+    await store.close()
+
+
 async def test_load_session_with_ids_no_checkpoint(tmp_path):
     """load_session_with_ids returns messages and IDs with no compaction."""
     store = Store(path=tmp_path / "test.db")

--- a/tests/test_compaction_agent.py
+++ b/tests/test_compaction_agent.py
@@ -387,6 +387,46 @@ async def test_empty_text_block_not_persisted_alongside_tool_use(tmp_path):
     await store.close()
 
 
+def test_openai_convert_handles_mixed_tool_result_and_text():
+    """A user turn mixing a leftover text block with a tool_result (as orphan
+    repair can produce) must still emit a `role:tool` message, not stringify the
+    tool_result into user content (which would break OpenAI tool-call pairing)."""
+    from src.agent.agent import OpenAICompatibleClient
+
+    client = OpenAICompatibleClient(
+        api_key="x", model_name="m", endpoint="http://localhost"
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": "t1", "name": "execute_code", "input": {}},
+                {"type": "tool_use", "id": "t2", "name": "execute_code", "input": {}},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "[orphaned tool result removed]"},
+                {"type": "tool_result", "tool_use_id": "t2", "content": "ok"},
+            ],
+        },
+    ]
+    out = client._convert_messages(messages, system="sys")
+
+    tool_msgs = [m for m in out if m.get("role") == "tool"]
+    assert len(tool_msgs) == 1
+    assert tool_msgs[0]["tool_call_id"] == "t2"
+    assert tool_msgs[0]["content"] == "ok"
+    # The leftover text becomes a user message; no tool_result is smuggled into
+    # a stringified user message.
+    assert not any("tool_use_id" in str(m.get("content", "")) for m in out)
+    assert any(
+        m.get("role") == "user" and m.get("content") == "[orphaned tool result removed]"
+        for m in out
+    )
+
+
 async def test_title_generation_ignores_tool_result_user_rows(tmp_path):
     """tool_result rows (sender=user, no text) must not satisfy the auto-title
     user-message threshold."""

--- a/tests/test_signal_bot.py
+++ b/tests/test_signal_bot.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from src.agent.conversation import ConversationManager
 from src.signal_bot.bot import SignalBot
 from src.store.store import Store
 from src.tools.registry import ToolContext, ToolRegistry
@@ -133,19 +134,60 @@ async def test_signal_empty_message_ignored(signal_bot):
     agent.chat.assert_not_called()
 
 
-async def test_signal_persists_user_and_assistant_messages(signal_bot):
-    """User message and agent response are both saved to the store."""
+async def test_signal_persists_structured_turn(signal_bot):
+    """User message is saved up front; the agent's full structured turn
+    (assistant tool_use, tool_result, final text) is persisted via on_message."""
     bot, agent, store, mock_http = signal_bot
+
+    async def mock_chat(
+        user_text, conversation, on_compact=None, on_message=None, images=None
+    ):
+        assert on_message is not None
+        await on_message(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "execute_code", "input": {"code": "x"}}
+                ],
+            }
+        )
+        await on_message(
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "t1", "content": "ok"}
+                ],
+            }
+        )
+        await on_message(
+            {"role": "assistant", "content": [{"type": "text", "text": "agent response"}]}
+        )
+        return "agent response"
+
+    agent.chat = mock_chat
 
     msg = _make_signal_message("+2222222222", "test message")
     await bot._handle_message(msg)
 
-    # Check that both user and assistant messages were saved
     data = await store.chat.list_messages(session_id="signal-persistent", limit=100)
     messages = data["messages"]
-    assert len(messages) == 2
-    assert messages[0]["sender"] == "user"
-    assert messages[1]["sender"] == "assistant"
+    # user + assistant(tool_use) + tool_result(role=user) + assistant(text)
+    assert len(messages) == 4
+    assert [m["sender"] for m in messages] == ["user", "assistant", "user", "assistant"]
+
+    # The tool_use turn round-trips as structured content.
+    tool_use_turn = json.loads(messages[1]["content"])
+    assert tool_use_turn["content"][0]["type"] == "tool_use"
+
+    # And the agent would see the full structured history on the next turn.
+    conv_mgr = ConversationManager(ctx=bot._executor.ctx)
+    reloaded, _ = await conv_mgr.load_session_with_ids("signal-persistent")
+    types = [
+        (m["role"], m["content"][0]["type"] if isinstance(m["content"], list) else "text")
+        for m in reloaded
+    ]
+    assert ("assistant", "tool_use") in types
+    assert ("user", "tool_result") in types
 
 
 async def test_signal_compaction_persisted(signal_bot):
@@ -163,7 +205,9 @@ async def test_signal_compaction_persisted(signal_bot):
             content=json.dumps({"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}),
         )
 
-    async def mock_chat(user_text, conversation, on_compact=None, images=None):
+    async def mock_chat(
+        user_text, conversation, on_compact=None, on_message=None, images=None
+    ):
         if on_compact:
             # Simulate compacting 3 messages from the start
             await on_compact("test summary", 3)

--- a/tests/test_signal_bot.py
+++ b/tests/test_signal_bot.py
@@ -222,7 +222,9 @@ async def test_signal_compaction_persisted(signal_bot):
     checkpoint = await store.chat.get_compaction_checkpoint(session_id)
     assert checkpoint is not None
     assert checkpoint["summary"] == "test summary"
-    assert checkpoint["compacted_up_to_msg_id"] > 0
+    # 5 seeded rows (ids 1..5) then the new user row (id 6, dropped on load);
+    # split_idx=3 maps to msg_ids[2] == id 3, so the checkpoint must land there.
+    assert checkpoint["compacted_up_to_msg_id"] == 3
 
 
 async def test_signal_close_stops_polling(signal_bot):

--- a/web/src/components/chat/ChatView.test.tsx
+++ b/web/src/components/chat/ChatView.test.tsx
@@ -60,6 +60,45 @@ describe("ChatView", () => {
     await waitFor(() => expect(screen.getByText(/Send a message to start chatting/)).toBeInTheDocument());
   });
 
+  it("filters out structured tool turns that carry no displayable text", async () => {
+    api.listMessages.mockResolvedValue({
+      messages: [
+        { id: 1, sender: "user", content: JSON.stringify({ role: "user", content: "do a thing" }) },
+        {
+          id: 2,
+          sender: "assistant",
+          content: JSON.stringify({
+            role: "assistant",
+            content: [{ type: "tool_use", id: "t1", name: "execute_code", input: { code: "x" } }],
+          }),
+        },
+        {
+          id: 3,
+          sender: "user",
+          content: JSON.stringify({
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }],
+          }),
+        },
+        {
+          id: 4,
+          sender: "assistant",
+          content: JSON.stringify({
+            role: "assistant",
+            content: [{ type: "text", text: "all done" }],
+          }),
+        },
+      ],
+      cursor: null,
+    });
+    renderChatView();
+    await waitFor(() => expect(screen.getByText("do a thing")).toBeInTheDocument());
+    expect(screen.getByText("all done")).toBeInTheDocument();
+    // The tool_use-only and tool_result turns render no empty bubbles.
+    const bubbles = screen.getAllByText(/do a thing|all done/);
+    expect(bubbles).toHaveLength(2);
+  });
+
   it("disables input and shows thinking state while responding", async () => {
     api.chat.mockReturnValue(new Promise(() => {}));
     renderChatView();

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -65,10 +65,14 @@ export function ChatView() {
     if (!id) return;
     try {
       const data = await api.listMessages(id, 100);
-      const chatItems: ChatItem[] = data.messages.map((m) => {
-        const { role, content } = parseMessage(m);
-        return { type: "message" as const, key: `msg-${m.id}`, role, content };
-      });
+      const chatItems: ChatItem[] = data.messages
+        .map((m) => {
+          const { role, content } = parseMessage(m);
+          return { type: "message" as const, key: `msg-${m.id}`, role, content };
+        })
+        // Structured turns persist tool_use / tool_result blocks that carry no
+        // displayable text; skip them so history shows only real messages.
+        .filter((item) => item.content.trim() !== "");
       setItems(chatItems);
     } catch (e) {
       console.error("Failed to load messages:", e);


### PR DESCRIPTION
## What & why

In long chat sessions the agent kept "forgetting" work it had just done and facts it had been told. Root cause: both the **Signal bot** and the **web chat router** persisted only the agent's *final text reply* each turn, discarding all intermediate `tool_use` / `tool_result` history. So on the next turn the agent reloaded its own answer but none of the work behind it.

This wires up **structured-turn persistence** (the harness's compaction-checkpoint machinery — `chat_compaction_summaries`, `on_compact`, the `msg_ids` parallel list — was already built expecting it; it just wasn't being fed).

For context, the two original hypotheses were ruled out: the system prompt never falls out of context (it's the dedicated `system=` param, refreshed every turn), and the 240K-char compaction threshold was never being reached *because* persistence was text-only. The real issue was memory fidelity.

## Changes

- **`agent.py`**: new `on_message` callback on `chat()` / `_chat_impl`, fired for each assistant turn, each tool-result turn, and the max-iteration final reply (via a guarded `_persist`).
- **`signal_bot/bot.py` + `web/routers/chat.py`**: persist each structured message via `on_message`; removed the old text-only save.
- **`conversation.py`**: fixed a latent double-encoding bug — list content was `json.dumps`'d before being embedded, but load only single-decodes, so structured content round-tripped back as a *string*. Now embedded directly so blocks survive. Also: `maybe_generate_session_title` counts only human user turns (tool-result rows are stored with `sender="user"`).
- **`web/ChatView.tsx`**: filters tool-only turns so rendered history looks exactly as before.

## Robustness fixes from review (3 cycles, standard + adversarial)

- Empty assistant turns / empty text blocks would 400 on reload → filtered + repaired.
- Compaction could split a `tool_use`/`tool_result` pair and lose the tool's output → split snaps to the pair boundary, preserving it.
- Base64 images are stripped from the persisted copy (text is already capped at 4 KB); text blocks in tool results are preserved.
- OpenAI `_convert_messages` now handles a `tool_result` anywhere in a user turn (orphan repair can leave a text block ahead of it), emitting proper `role:tool` messages.

## Testing

- Python: `414 passed`
- Web (vitest): `90 passed`
- New/updated tests cover: `on_message` ordering, structured round-trip + reload, empty-assistant/empty-text filtering, image stripping, compaction pair-boundary output preservation, checkpoint id, title-count regression, and the OpenAI mixed-block converter case.

## Out of scope

The **Discord bot** has the identical bug and is intentionally deferred to a separate change (same ~6-line wiring).
