### PR TITLE
Operator timezone (timestamps + scheduler) and MCP OAuth re-auth fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "playwright>=1.40.0",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.12.0",
+    "tzdata>=2024.1",
     "uvicorn[standard]>=0.34.0",
 ]
 

--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -4,8 +4,9 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timezone, tzinfo
 from typing import Any, Literal
+from zoneinfo import ZoneInfo
 
 import anthropic
 import httpx
@@ -535,9 +536,28 @@ def _format_tool_result(result: dict[str, Any]) -> str | list[dict[str, Any]]:
     return content_str
 
 
+def _resolve_operator_tz() -> tzinfo:
+    """Resolve the operator's configured timezone, falling back to UTC.
+
+    A bad OPERATOR_TIMEZONE (typo, or missing system tz database) must not break
+    message handling — we log once and use UTC.
+    """
+    from src.config import CONFIG
+
+    name = CONFIG.operator_timezone or "UTC"
+    try:
+        return ZoneInfo(name)
+    except Exception:
+        logger.warning(
+            "Invalid OPERATOR_TIMEZONE %r; falling back to UTC", name
+        )
+        return timezone.utc
+
+
 def _timestamp_prefix(message: str) -> str:
-    """prefix user mesages with a formatted timestamp for agent awareness"""
-    now = datetime.now(timezone.utc)
+    """prefix user messages with a timestamp in the operator's local time so the
+    agent reasons about the current time correctly instead of assuming UTC"""
+    now = datetime.now(_resolve_operator_tz())
     ts = now.strftime("%a %b %d, %Y %I:%M%p %Z")
     return f"[{ts}] {message}"
 

--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -4,15 +4,15 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timezone, tzinfo
+from datetime import datetime
 from typing import Any, Literal
-from zoneinfo import ZoneInfo
 
 import anthropic
 import httpx
 from anthropic.types import TextBlock, ToolUseBlock
 
 from src.agent.prompt import build_system_prompt
+from src.config import resolve_operator_tz as _resolve_operator_tz
 from src.tools.executor import ToolExecutor
 
 logger = logging.getLogger(__name__)
@@ -534,24 +534,6 @@ def _format_tool_result(result: dict[str, Any]) -> str | list[dict[str, Any]]:
     if len(content_str) > MAX_TOOL_RESULT_LENGTH:
         content_str = content_str[:MAX_TOOL_RESULT_LENGTH] + "\n... (truncated)"
     return content_str
-
-
-def _resolve_operator_tz() -> tzinfo:
-    """Resolve the operator's configured timezone, falling back to UTC.
-
-    A bad OPERATOR_TIMEZONE (typo, or missing system tz database) must not break
-    message handling — we log once and use UTC.
-    """
-    from src.config import CONFIG
-
-    name = CONFIG.operator_timezone or "UTC"
-    try:
-        return ZoneInfo(name)
-    except Exception:
-        logger.warning(
-            "Invalid OPERATOR_TIMEZONE %r; falling back to UTC", name
-        )
-        return timezone.utc
 
 
 def _timestamp_prefix(message: str) -> str:

--- a/src/config.py
+++ b/src/config.py
@@ -43,6 +43,11 @@ class Config(BaseSettings):
     context_limit: int = 200_000
     """approximate context window of the main model; used for the web UI context bar"""
 
+    operator_timezone: str = "UTC"
+    """IANA timezone for the operator (e.g. 'America/Los_Angeles'). Used to stamp
+    each user message with the operator's local time so the agent reasons about
+    'what time is it' correctly. Falls back to UTC if the name is invalid."""
+
     # discord bot chat
     discord_sessions_channel: str = "victrola-sessions"
     """name of the text channel the Discord bot watches for chat sessions"""

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,13 @@
 from typing import Literal
 
+import logging
+from datetime import timezone, tzinfo
+from zoneinfo import ZoneInfo
+
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 
 class Config(BaseSettings):
@@ -127,3 +133,18 @@ class Config(BaseSettings):
 
 
 CONFIG = Config()
+
+
+def resolve_operator_tz() -> tzinfo:
+    """Resolve the operator's configured timezone, falling back to UTC.
+
+    Shared by the message-timestamp prefix and the scheduler so both speak the
+    operator's local time. A bad OPERATOR_TIMEZONE (typo, or a missing system tz
+    database) must not break message handling or scheduling — we log and use UTC.
+    """
+    name = CONFIG.operator_timezone or "UTC"
+    try:
+        return ZoneInfo(name)
+    except Exception:
+        logger.warning("Invalid OPERATOR_TIMEZONE %r; falling back to UTC", name)
+        return timezone.utc

--- a/src/scheduler/schedule.py
+++ b/src/scheduler/schedule.py
@@ -12,6 +12,8 @@ import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
+from src.config import resolve_operator_tz
+
 # -- patterns --
 
 DURATION_PATTERN = re.compile(r"^(\d+[hms])+$")
@@ -91,31 +93,45 @@ class ScheduleConfig:
                 return from_time + self.interval
 
             case "daily":
-                next_t = from_time.replace(
+                # Absolute times are interpreted in the operator's local
+                # timezone, then converted to UTC for firing. Compute the next
+                # occurrence in naive wall-clock and localize at the end so the
+                # result stays correct across DST transitions.
+                tz = resolve_operator_tz()
+                local_naive = from_time.astimezone(tz).replace(tzinfo=None)
+                naive = local_naive.replace(
                     hour=self.hour, minute=self.minute, second=0, microsecond=0
                 )
-                if next_t <= from_time:
-                    next_t += timedelta(days=1)
-                return next_t
+                if naive <= local_naive:
+                    naive += timedelta(days=1)
+                return naive.replace(tzinfo=tz).astimezone(timezone.utc)
 
             case "weekly":
-                next_t = from_time.replace(
+                tz = resolve_operator_tz()
+                local_naive = from_time.astimezone(tz).replace(tzinfo=None)
+                naive = local_naive.replace(
                     hour=self.hour, minute=self.minute, second=0, microsecond=0
                 )
-                days_until = self.weekday - next_t.weekday()
-                if days_until < 0 or (days_until == 0 and next_t <= from_time):
+                days_until = self.weekday - naive.weekday()
+                if days_until < 0 or (days_until == 0 and naive <= local_naive):
                     days_until += 7
-                return next_t + timedelta(days=days_until)
+                target = naive + timedelta(days=days_until)
+                return target.replace(tzinfo=tz).astimezone(timezone.utc)
 
             case "cron":
                 try:
                     from croniter import croniter  # type: ignore[import-untyped]
-
-                    return croniter(self.cron_expr, from_time).get_next(datetime)  # type: ignore[return-value]
                 except ImportError:
                     raise RuntimeError(
                         "croniter package required for cron schedules: uv add croniter"
                     )
+                # Evaluate the cron expression in the operator's local timezone,
+                # then return UTC for firing.
+                tz = resolve_operator_tz()
+                local_next = croniter(
+                    self.cron_expr, from_time.astimezone(tz)
+                ).get_next(datetime)
+                return local_next.astimezone(timezone.utc)
 
             case _:
                 return from_time + timedelta(hours=1)

--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from src.config import resolve_operator_tz
 from src.scheduler.schedule import ScheduleConfig, parse_schedule
 
 if TYPE_CHECKING:
@@ -253,7 +254,8 @@ class Scheduler:
         self._tasks[task.name] = task
 
         next_run = task.config.next_run(datetime.now(timezone.utc))
-        msg = f"Schedule '{task.name}' created ({task.config}). Next run: {next_run.strftime('%Y-%m-%d %H:%M UTC')}."
+        next_local = next_run.astimezone(resolve_operator_tz())
+        msg = f"Schedule '{task.name}' created ({task.config}). Next run: {next_local.strftime('%Y-%m-%d %H:%M %Z')}."
         if task.condition_code is not None and not task.approved:
             msg += " Schedule has condition code — pending operator approval before it will fire."
         return msg

--- a/src/tools/definitions/scheduler.py
+++ b/src/tools/definitions/scheduler.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from src.config import resolve_operator_tz
 from src.tools.registry import TOOL_REGISTRY, ToolContext, ToolParameter
 
 logger = logging.getLogger(__name__)
@@ -35,7 +36,9 @@ async def list_schedules(ctx: ToolContext) -> str:
                 if last.tzinfo is None:
                     last = last.replace(tzinfo=timezone.utc)
                 next_run = task.config.next_run(last)
-                next_str = next_run.strftime("%Y-%m-%d %H:%M UTC")
+                next_str = next_run.astimezone(resolve_operator_tz()).strftime(
+                    "%Y-%m-%d %H:%M %Z"
+                )
             else:
                 next_str = "pending"
         except Exception:
@@ -95,10 +98,13 @@ async def get_schedule(ctx: ToolContext, name: str) -> str:
 SCHEDULE_SYNTAX_HELP = """Supported schedule expressions:
 - Duration: `30m`, `2h`, `1h30m`, `90s` — fires every interval (min 1 minute)
 - Keywords: `hourly`, `daily`, `weekly`
-- Daily at time: `daily@9:00`, `daily@14:30` — 24h clock, UTC
+- Daily at time: `daily@9:00`, `daily@14:30` — 24h clock, in the operator's local timezone
 - Weekly on day: `weekly@monday`, `weekly@fri`
 - Weekly on day at time: `weekly@monday@9:00`
-- Cron: `cron:0 9 * * *` (if croniter installed)"""
+- Cron: `cron:0 9 * * *` (if croniter installed)
+
+Absolute times (daily@, weekly@…@, cron) are interpreted in the operator's local
+timezone — just use the wall-clock time they asked for. Durations are relative."""
 
 
 @TOOL_REGISTRY.tool(

--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -369,6 +369,7 @@ class MCPOAuthTokenStorage:
         self._store = store
         self._server_name = server_name
         self._rkey = f"mcptoken:{server_name}"
+        self._client_rkey = f"mcpclient:{server_name}"
 
     async def get_tokens(self) -> Any:
         from mcp.shared.auth import OAuthToken
@@ -397,10 +398,31 @@ class MCPOAuthTokenStorage:
             await self._store.documents.create(self._rkey, content)
 
     async def get_client_info(self) -> Any:
-        return None
+        from mcp.shared.auth import OAuthClientInformationFull
+
+        if self._store.documents is None:
+            return None
+        try:
+            doc = await self._store.documents.get(self._client_rkey)
+            data = json.loads(doc["content"])
+            return OAuthClientInformationFull.model_validate(data)
+        except Exception:
+            return None
 
     async def set_client_info(self, client_info: Any) -> None:
-        pass  # We don't persist client info — it's regenerated each time
+        # Persist the dynamically-registered OAuth client so refresh and
+        # reconnect reuse the same client_id. Without this the SDK re-registers
+        # a new client every time, invalidating the saved refresh token (it was
+        # issued to the old client) and forcing a full re-auth.
+        if self._store.documents is None:
+            raise RuntimeError("DocumentStore is not initialized")
+        content = json.dumps(client_info.model_dump(mode="json"))
+        from src.store.store import StoreNotFound
+
+        try:
+            await self._store.documents.update(self._client_rkey, content)
+        except StoreNotFound:
+            await self._store.documents.create(self._client_rkey, content)
 
 
 class MCPManager:
@@ -1105,13 +1127,15 @@ class MCPManager:
         if config is None:
             return f"MCP server '{name}' not found."
 
-        rkey = f"mcptoken:{name}"
         if self._store.documents is None:
             raise RuntimeError("DocumentStore is not initialized")
-        try:
-            await self._store.documents.delete(rkey)
-        except Exception:
-            pass  # not found is fine
+        # Clear both the tokens and the persisted client registration so a
+        # manual re-authorize starts from a clean slate.
+        for rkey in (f"mcptoken:{name}", f"mcpclient:{name}"):
+            try:
+                await self._store.documents.delete(rkey)
+            except Exception:
+                pass  # not found is fine
         return f"OAuth tokens cleared for '{name}'."
 
     # -- internals --

--- a/tests/test_mcp_oauth_storage.py
+++ b/tests/test_mcp_oauth_storage.py
@@ -1,0 +1,76 @@
+"""Tests that MCP OAuth client registration is persisted.
+
+Without persisting the dynamically-registered client, the SDK re-registers a new
+client on every refresh/reconnect, invalidating the saved refresh token and
+forcing a full re-auth. These tests pin the round-trip and the clear behavior.
+"""
+
+import pytest
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+from src.store.store import Store
+from src.tools.mcp import MCPManager, MCPOAuthTokenStorage, MCPServerConfig
+from src.tools.registry import ToolRegistry
+
+
+def _client_info(client_id: str = "cid-1") -> OAuthClientInformationFull:
+    return OAuthClientInformationFull.model_validate(
+        {
+            "client_id": client_id,
+            "redirect_uris": ["http://localhost:8989/callback"],
+            "token_endpoint_auth_method": "none",
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_oauth_storage_round_trips_client_info(tmp_path):
+    store = Store(path=tmp_path / "store.db")
+    await store.initialize()
+
+    s = MCPOAuthTokenStorage(store, "fastmail")
+    assert await s.get_client_info() is None  # nothing persisted yet
+
+    await s.set_client_info(_client_info("cid-1"))
+    got = await s.get_client_info()
+    assert got is not None and got.client_id == "cid-1"
+
+    # The update path (document already exists) also works.
+    await s.set_client_info(_client_info("cid-2"))
+    assert (await s.get_client_info()).client_id == "cid-2"
+
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_clear_oauth_tokens_removes_tokens_and_client_info(tmp_path):
+    store = Store(path=tmp_path / "store.db")
+    await store.initialize()
+    manager = MCPManager(store=store, secret_manager=None, registry=ToolRegistry())
+    await manager.create_server(
+        MCPServerConfig(
+            name="fastmail",
+            transport="streamable_http",
+            url="https://api.fastmail.com/mcp",
+            auth_type="oauth",
+        )
+    )
+
+    s = MCPOAuthTokenStorage(store, "fastmail")
+    await s.set_tokens(
+        OAuthToken.model_validate(
+            {"access_token": "a", "token_type": "Bearer", "refresh_token": "r"}
+        )
+    )
+    await s.set_client_info(_client_info("cid-1"))
+    assert await s.get_tokens() is not None
+    assert await s.get_client_info() is not None
+
+    msg = await manager.clear_oauth_tokens("fastmail")
+    assert "cleared" in msg.lower()
+    assert await s.get_tokens() is None
+    assert await s.get_client_info() is None
+
+    await store.close()

--- a/tests/test_schedule_timezone.py
+++ b/tests/test_schedule_timezone.py
@@ -1,0 +1,65 @@
+"""Absolute schedules (daily@/weekly@/cron) are interpreted in the operator's
+local timezone and converted to UTC for firing — including across DST."""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.config import CONFIG
+from src.scheduler.schedule import parse_schedule
+
+LA = ZoneInfo("America/Los_Angeles")
+
+
+def test_daily_default_utc_unchanged():
+    cfg = parse_schedule("daily@9:00")
+    with patch.object(CONFIG, "operator_timezone", "UTC"):
+        nxt = cfg.next_run(datetime(2026, 1, 10, 0, 0, tzinfo=timezone.utc))
+    assert (nxt.day, nxt.hour, nxt.minute) == (10, 9, 0)
+
+
+def test_daily_interpreted_in_operator_tz_winter():
+    """9:00 PST == 17:00 UTC."""
+    cfg = parse_schedule("daily@9:00")
+    with patch.object(CONFIG, "operator_timezone", "America/Los_Angeles"):
+        # 2026-01-10 00:00 UTC == 2026-01-09 16:00 PST -> next 9:00 is 01-10.
+        nxt = cfg.next_run(datetime(2026, 1, 10, 0, 0, tzinfo=timezone.utc))
+    assert nxt.tzinfo is not None
+    assert (nxt.day, nxt.hour) == (10, 17)
+    assert nxt.astimezone(LA).hour == 9
+
+
+def test_daily_interpreted_in_operator_tz_summer_dst():
+    """9:00 PDT == 16:00 UTC (one hour different from winter -> DST handled)."""
+    cfg = parse_schedule("daily@9:00")
+    with patch.object(CONFIG, "operator_timezone", "America/Los_Angeles"):
+        nxt = cfg.next_run(datetime(2026, 7, 10, 0, 0, tzinfo=timezone.utc))
+    assert (nxt.day, nxt.hour) == (10, 16)
+    assert nxt.astimezone(LA).hour == 9
+
+
+def test_weekly_interpreted_in_operator_tz():
+    cfg = parse_schedule("weekly@monday@9:00")
+    with patch.object(CONFIG, "operator_timezone", "America/Los_Angeles"):
+        nxt = cfg.next_run(datetime(2026, 1, 10, 0, 0, tzinfo=timezone.utc))
+    local = nxt.astimezone(LA)
+    assert local.weekday() == 0  # Monday
+    assert (local.hour, local.minute) == (9, 0)
+
+
+def test_interval_is_timezone_independent():
+    cfg = parse_schedule("2h")
+    from_time = datetime(2026, 1, 10, 0, 0, tzinfo=timezone.utc)
+    with patch.object(CONFIG, "operator_timezone", "America/Los_Angeles"):
+        nxt = cfg.next_run(from_time)
+    assert nxt == from_time.replace(hour=2)
+
+
+def test_cron_interpreted_in_operator_tz():
+    pytest.importorskip("croniter")
+    with patch.object(CONFIG, "operator_timezone", "America/Los_Angeles"):
+        cfg = parse_schedule("cron:0 9 * * *")
+        nxt = cfg.next_run(datetime(2026, 1, 10, 0, 0, tzinfo=timezone.utc))
+    assert nxt.astimezone(LA).hour == 9

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,49 @@
+"""Tests for operator-timezone-aware user-message timestamps."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+from src.agent.agent import _resolve_operator_tz, _timestamp_prefix
+from src.config import CONFIG
+
+
+def test_resolve_operator_tz_valid():
+    with patch.object(CONFIG, "operator_timezone", "America/Los_Angeles"):
+        assert _resolve_operator_tz() == ZoneInfo("America/Los_Angeles")
+
+
+def test_resolve_operator_tz_invalid_falls_back_to_utc():
+    with patch.object(CONFIG, "operator_timezone", "Not/AZone"):
+        assert _resolve_operator_tz() == timezone.utc
+
+
+def test_resolve_operator_tz_empty_resolves_to_utc():
+    with patch.object(CONFIG, "operator_timezone", ""):
+        tz = _resolve_operator_tz()
+    # Empty -> "UTC" (a valid zone), so it resolves rather than hitting the
+    # exception fallback; either way the offset must be zero.
+    assert datetime(2026, 1, 1, tzinfo=tz).utcoffset() == timedelta(0)
+
+
+def test_pacific_tz_handles_dst():
+    tz = ZoneInfo("America/Los_Angeles")
+    # January: PST (UTC-8). 08:00 UTC -> 00:00 local.
+    assert datetime(2026, 1, 1, 8, 0, tzinfo=timezone.utc).astimezone(tz).hour == 0
+    # July: PDT (UTC-7). 07:00 UTC -> 00:00 local.
+    assert datetime(2026, 7, 1, 7, 0, tzinfo=timezone.utc).astimezone(tz).hour == 0
+
+
+def test_timestamp_prefix_uses_operator_tz():
+    with patch.object(CONFIG, "operator_timezone", "America/Los_Angeles"):
+        out = _timestamp_prefix("hello")
+    assert out.startswith("[") and out.endswith("] hello")
+    # Stamped in Pacific time, not UTC.
+    assert ("PST" in out) or ("PDT" in out)
+    assert "UTC" not in out
+
+
+def test_timestamp_prefix_defaults_to_utc():
+    with patch.object(CONFIG, "operator_timezone", "UTC"):
+        out = _timestamp_prefix("hi")
+    assert "UTC" in out and out.endswith("] hi")

--- a/uv.lock
+++ b/uv.lock
@@ -1627,6 +1627,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1708,6 +1717,7 @@ dependencies = [
     { name = "playwright" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -1733,6 +1743,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
+    { name = "tzdata", specifier = ">=2024.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Fixes three related/unrelated bugs in one PR.

## 1. Agent thinks the operator is in UTC

**Symptom:** the agent kept insisting it was ~1 AM and telling an SF-based operator to "go to sleep," ignoring the timezone noted in operator memory.

**Cause:** `_timestamp_prefix` stamped every user message in UTC. The model trusts that explicit literal stamp over prose in the system prompt.

**Fix:**
- New `OPERATOR_TIMEZONE` config/env var (IANA name, default `UTC`).
- Messages are stamped in the operator's local time via `zoneinfo` (DST-correct), falling back to UTC + a logged warning on an invalid value.
- Added `tzdata` so `ZoneInfo` resolves regardless of the host's system tz database.

Set `OPERATOR_TIMEZONE=America/Los_Angeles` to use it.

## 2. Scheduler now speaks the operator's local time

**Why:** once the agent reasons in local time, UTC-anchored schedules force it to convert local→UTC when creating `daily@`/`weekly@`/`cron` tasks — the same arithmetic that produced bug #1.

**Fix:**
- Absolute schedule times (`daily@`, `weekly@day@`, `cron`) are interpreted in `OPERATOR_TIMEZONE` and converted to UTC internally for firing. DST-correct: the next occurrence is computed in naive wall-clock then localized.
- Interval schedules (`30m`, `2h`) are unchanged — they're relative.
- The tz resolver is shared via `config.resolve_operator_tz` (used by both the message prefix and the scheduler).
- Tool docs (`SCHEDULE_SYNTAX_HELP`) and next-run displays now reflect local time, so the agent just passes through the wall-clock time the operator asked for.

## 3. Fastmail (OAuth) MCP keeps requiring re-auth

**Symptom:** the OAuth-based Fastmail MCP server repeatedly demands re-authorization.

**Cause:** `MCPOAuthTokenStorage` persisted tokens but **not** the dynamically-registered OAuth client — `get_client_info`/`set_client_info` were no-ops. On every refresh/reconnect/restart the SDK re-ran Dynamic Client Registration, producing a *new* `client_id`; the saved refresh token was issued to the *old* client, so the server rejected it and forced a full interactive re-auth. The background health-monitor reconnect is silent-refresh-only, so it could never recover.

**Fix:**
- Persist the registered client under `mcpclient:<server>` (mirrors token storage) so refresh/reconnect reuse the same `client_id`.
- `clear_oauth_tokens` now also clears the stored client info, so a manual re-authorize starts clean.

**Heads-up:** existing OAuth servers have a token but no stored client info, so you'll re-auth Fastmail **one more time** after deploy — then it sticks.

## Testing

- Full suite: `418 passed, 1 skipped` (cron tz test skips when `croniter` isn't installed).
- New tests: `tests/test_timezone.py` (tz resolution, DST, fallback, prefix), `tests/test_schedule_timezone.py` (daily/weekly/cron interpreted in operator tz + DST + interval unaffected), `tests/test_mcp_oauth_storage.py` (client-info round-trip + clear removes both token and client info).
