### PR TITLE
fix: self-heal stale OAuth client scope on interactive re-auth

### DIFF
--- a/src/tools/mcp.py
+++ b/src/tools/mcp.py
@@ -454,6 +454,37 @@ class MCPOAuthTokenStorage:
         except StoreNotFound:
             await self._store.documents.create(self._client_rkey, content)
 
+    async def clear_stale_client_info(self) -> bool:
+        """Drop a stored client registration whose scope lacks ``offline_access``.
+
+        The SDK reuses a stored client registration instead of re-registering,
+        and Fastmail rejects an authorization whose scope isn't a subset of the
+        client's registered scopes. A client registered before the
+        ``offline_access`` fix (PR #55) has no ``offline_access`` in its scope,
+        so a later interactive re-auth that now requests ``offline_access``
+        fails with ``invalid_scope``. Dropping the stale registration makes the
+        SDK re-register under the corrected scope.
+
+        Only call this on an interactive connect: a background reconnect can't
+        complete a new authorization, so dropping the client would only make
+        things worse. Returns True if a stale client was dropped.
+        """
+        if self._store.documents is None:
+            return False
+        client_info = await self.get_client_info()
+        if client_info is None:
+            return False
+        scope = getattr(client_info, "scope", None)
+        # A null scope can't be inferred either way — leave it. Only drop when
+        # the server explicitly registered a scope that omits offline_access.
+        if scope and "offline_access" not in scope.split():
+            try:
+                await self._store.documents.delete(self._client_rkey)
+            except Exception:
+                return False
+            return True
+        return False
+
 
 class MCPManager:
     """Manages all MCP servers — parallel to CustomToolManager."""
@@ -557,6 +588,17 @@ class MCPManager:
         # build OAuth provider if needed
         oauth_provider = None
         if config.auth_type == "oauth" and config.url:
+            # Interactive connect only: drop a client registration whose scope
+            # predates the offline_access fix so the SDK re-registers fresh
+            # under the corrected scope (otherwise Fastmail rejects the auth
+            # with invalid_scope). Background reconnect leaves it alone.
+            if not auto:
+                storage = MCPOAuthTokenStorage(self._store, name)
+                if await storage.clear_stale_client_info():
+                    logger.info(
+                        "Dropped stale OAuth client registration for '%s' "
+                        "(scope missing offline_access); re-registering", name
+                    )
             # Background reconnect (auto=True) never launches interactive OAuth:
             # silent token refresh only, else fail fast and quiet.
             oauth_provider = self._create_oauth_provider(

--- a/tests/test_mcp_oauth_selfheal.py
+++ b/tests/test_mcp_oauth_selfheal.py
@@ -1,0 +1,80 @@
+"""Tests for the interactive-reauth client scope self-heal.
+
+A client registered before the offline_access fix (PR #55) has no
+``offline_access`` in its scope. Reusing it makes the SDK authorize with
+``offline_access`` against a client that wasn't registered for it, which Fastmail
+rejects with ``invalid_scope``. An interactive connect must drop such a stale
+registration so the SDK re-registers fresh; a background reconnect must not.
+"""
+
+import pytest
+from mcp.shared.auth import OAuthClientInformationFull
+
+from src.store.store import Store
+from src.tools.mcp import MCPManager, MCPOAuthTokenStorage, MCPServerConfig
+from src.tools.registry import ToolRegistry
+
+
+def _client_info(scope: str | None) -> OAuthClientInformationFull:
+    data = {
+        "client_id": "cid-stale",
+        "redirect_uris": ["http://localhost:8989/callback"],
+        "token_endpoint_auth_method": "none",
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+    }
+    if scope is not None:
+        data["scope"] = scope
+    return OAuthClientInformationFull.model_validate(data)
+
+
+async def _seed(store: Store, name: str, scope: str | None) -> None:
+    s = MCPOAuthTokenStorage(store, name)
+    await s.set_client_info(_client_info(scope))
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_drops_client_missing_offline_access(tmp_path):
+    store = Store(path=tmp_path / "store.db")
+    await store.initialize()
+    s = MCPOAuthTokenStorage(store, "fastmail")
+    await _seed(store, "fastmail", "https://www.fastmail.com/dev/mcp")
+
+    assert await s.clear_stale_client_info() is True
+    assert await s.get_client_info() is None  # dropped
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_keeps_client_with_offline_access(tmp_path):
+    store = Store(path=tmp_path / "store.db")
+    await store.initialize()
+    s = MCPOAuthTokenStorage(store, "fastmail")
+    await _seed(store, "fastmail", "https://www.fastmail.com/dev/mcp offline_access")
+
+    assert await s.clear_stale_client_info() is False
+    assert await s.get_client_info() is not None  # kept
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_keeps_client_with_null_scope(tmp_path):
+    # A server that didn't echo a scope on registration can't be inferred;
+    # don't drop (leave to the operator's deauthorize if needed).
+    store = Store(path=tmp_path / "store.db")
+    await store.initialize()
+    s = MCPOAuthTokenStorage(store, "fastmail")
+    await _seed(store, "fastmail", None)
+
+    assert await s.clear_stale_client_info() is False
+    assert await s.get_client_info() is not None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_noop_when_no_client(tmp_path):
+    store = Store(path=tmp_path / "store.db")
+    await store.initialize()
+    s = MCPOAuthTokenStorage(store, "fastmail")
+    assert await s.clear_stale_client_info() is False
+    await store.close()


### PR DESCRIPTION
## Problem

After #55 shipped, a manual re-auth of an existing OAuth server (e.g. fastmail) fails with `invalid_scope`:

```
http://localhost:8989/callback?error=invalid_scope&state=...
```

Cause: the SDK reuses the stored client registration instead of re-registering, and Fastmail rejects an authorization whose scope isn't a subset of the client's registered scopes. A client registered *before* #55 has no `offline_access` in its scope, so authorizing now (which requests `offline_access`) is rejected.

## Fix

On an **interactive** connect, drop a stored client whose `scope` is non-null and lacks `offline_access`, so the SDK re-registers fresh under the corrected scope.

- Only interactive (`auto=False`): a background reconnect can't complete a new authorization, so dropping the client would only make things worse.
- Null-scope clients are left alone (can't infer either way) — `deauthorize` remains the escape hatch.
- Verified against Fastmail: a fresh dynamic registration keeps `offline_access`.

## Tests

`tests/test_mcp_oauth_selfheal.py` covers the drop/keep/null/no-client cases. Full `tests/` suite: 438 passed, 1 skipped.

## After merge

Existing OAuth servers that hit `invalid_scope` can now just **Connect/authorize** from the web UI — no manual deauthorize needed. The stale client is dropped and re-registered automatically.
